### PR TITLE
ci: pin claude-review to claude-sonnet-5

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -37,4 +37,6 @@ jobs:
             Only post GitHub comments - don't submit review text as messages.
 
           claude_args: |
+            --model claude-sonnet-5
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+


### PR DESCRIPTION
成本控制:review workflow 未锁定 model,跟随 Claude Code 默认(Opus 档),多轮 PR 一次烧 ~$4。锁定 `claude-sonnet-5`(约降 5x);触发条件不变(保留每 push 重审)——owner 拍板方案。

🤖 Generated with [Claude Code](https://claude.com/claude-code)