### PR TITLE
refactor: decouple HkoData offline tooling (#65)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 ## Instructions
 * Python version should be >= 3.11
 * Install requirements by `python -m pip install -r Requirements.txt`
+* The encoded HKO data under `src/Calendar/HkoData/data/` is committed to the repo; the library only reads it at runtime. To regenerate the data, `pip install requests` manually (deliberately not in Requirements.txt) and run `python -m src.Calendar.HkoData.Encoder` from the repo root.
 * Run linter: `ruff check .`
 * Run static type checker: `mypy .`
 * Run tests: `./run_tests.py`

--- a/Requirements.txt
+++ b/Requirements.txt
@@ -1,4 +1,3 @@
-requests==2.34.2
 colorama==0.4.6
 psutil==7.2.2
 tzdata==2026.3

--- a/run_tests.py
+++ b/run_tests.py
@@ -261,7 +261,7 @@ def run_coverage(test_f: Callable[[], int]) -> int:
       '*/__init__.py',
       '*/run_tests.py',
       '*/tests/*',
-      'src/Calendar/HkoData/encoder.py', # The raw data already downloaded. No much need to fully test the encoder.
+      'src/Calendar/HkoData/Encoder.py', # The raw data already downloaded. No much need to fully test the encoder.
     ]
   )
   cov.start()

--- a/src/Calendar/HkoData/Common.py
+++ b/src/Calendar/HkoData/Common.py
@@ -1,7 +1,5 @@
-#!/usr/bin/env python3
-#
-# bazi/src/Calendar/HkoData/common.py
 # Copyright (C) 2024 Ningqi Wang (0xf3cd) <https://github.com/0xf3cd>
+# bazi/src/Calendar/HkoData/Common.py
 #
 # Define variables and functions used in other .py files in hkodata directory.
 

--- a/src/Calendar/HkoData/Decoder.py
+++ b/src/Calendar/HkoData/Decoder.py
@@ -1,9 +1,9 @@
-#!/usr/bin/env python3
-#
-# bazi/src/Calendar/HkoData/encoder.py
 # Copyright (C) 2024 Ningqi Wang (0xf3cd) <https://github.com/0xf3cd>
+# bazi/src/Calendar/HkoData/Decoder.py
 #
-# Decode the encoded data produced by encoder.py.
+# Decode the encoded data produced by Encoder.py.
+# The decoder only reads the committed binary data files under `HkoData/data/`;
+# it never downloads or re-encodes anything (use Encoder.py as an offline tool for that).
 
 import functools
 
@@ -13,11 +13,10 @@ from typing import TypedDict, Optional, Final
 
 from ...Defines import Jieqi, Ganzhi
 
-from .common import (
+from .Common import (
   HkoYearLimits, date_to_bytes, bytes_to_date, bytes_to_int,
-  get_jieqi_encoded_data_path, get_lunardate_encoded_data_path,
+  get_jieqi_encoded_data_path, get_lunardate_encoded_data_path, encoded_data_ready,
 )
-from .encoder import do_encode, encoded_data_ready
 
 
 JieqiDates = dict[Jieqi, date] # Jieqi -> Solar-calendar Date
@@ -30,8 +29,7 @@ class DecodedJieqiDates:
   date_bytes_len: int = len(date_to_bytes(date(2000, 1, 1)))
 
   def __init__(self) -> None:
-    if not encoded_data_ready():
-      do_encode()
+    assert encoded_data_ready(), 'Encoded HKO data files are missing. Run `python -m src.Calendar.HkoData.Encoder` from the repo root to regenerate them.'
 
     self._start_year: Final[int] = HkoYearLimits.START_YEAR
     self._end_year: Final[int] = HkoYearLimits.END_YEAR
@@ -54,8 +52,6 @@ class DecodedJieqiDates:
     self._jieqi_offset_mapping: Final[dict[Jieqi, int]] = { k : v for k, v in zip(self._actual_jieqi_order, range(0, 24 * DecodedJieqiDates.date_bytes_len, DecodedJieqiDates.date_bytes_len)) }
     assert len(self._jieqi_offset_mapping) == 24
 
-    self._cached_datetimes: Final[dict[int, JieqiDates]] = {}
-
   @property
   def start_year(self) -> int:
     '''Note: Gregorian/Solar year / 公历年'''
@@ -66,7 +62,6 @@ class DecodedJieqiDates:
     '''Note: Gregorian/Solar year / 公历年'''
     return self._end_year
 
-  @functools.cache
   def __read_bytes_for_jieqi(self, year: int, jieqi: Jieqi) -> bytes:
     assert year in self.supported_year_range()
     offset: int = self._jieqi_offset_mapping[jieqi]
@@ -91,9 +86,7 @@ class DecodedJieqiDates:
     Note: `year` means Gregorian/Solar year / 公历年
     '''
     assert year in self.supported_year_range()
-    if year not in self._cached_datetimes:
-      self._cached_datetimes[year] = self.__getitem__(year)
-    return self._cached_datetimes[year][jieqi]
+    return self[year][jieqi]
   
   def supported_year_range(self) -> range:
     '''Note: Gregorian/Solar year / 公历年'''
@@ -118,8 +111,7 @@ class DecodedLunarYears:
   sexagenary_cycle: list[Ganzhi] = Ganzhi.list_sexagenary_cycle()
 
   def __init__(self) -> None:
-    if not encoded_data_ready():
-      do_encode()
+    assert encoded_data_ready(), 'Encoded HKO data files are missing. Run `python -m src.Calendar.HkoData.Encoder` from the repo root to regenerate them.'
 
     self._start_year: Final[int] = HkoYearLimits.START_YEAR
     self._end_year: Final[int] = HkoYearLimits.END_YEAR - 1 # hkodata.END_YEAR not included, since the data for it is incomplete.

--- a/src/Calendar/HkoData/Decoder.py
+++ b/src/Calendar/HkoData/Decoder.py
@@ -29,7 +29,10 @@ class DecodedJieqiDates:
   date_bytes_len: int = len(date_to_bytes(date(2000, 1, 1)))
 
   def __init__(self) -> None:
-    assert encoded_data_ready(), 'Encoded HKO data files are missing. Run `python -m src.Calendar.HkoData.Encoder` from the repo root to regenerate them.'
+    # Explicit raise (not assert): this is the public fail-fast contract for library
+    # consumers, and it must survive `python -O`.
+    if not encoded_data_ready():
+      raise RuntimeError('Encoded HKO data files are missing. Run `python -m src.Calendar.HkoData.Encoder` from the repo root to regenerate them.')
 
     self._start_year: Final[int] = HkoYearLimits.START_YEAR
     self._end_year: Final[int] = HkoYearLimits.END_YEAR
@@ -111,7 +114,10 @@ class DecodedLunarYears:
   sexagenary_cycle: list[Ganzhi] = Ganzhi.list_sexagenary_cycle()
 
   def __init__(self) -> None:
-    assert encoded_data_ready(), 'Encoded HKO data files are missing. Run `python -m src.Calendar.HkoData.Encoder` from the repo root to regenerate them.'
+    # Explicit raise (not assert): this is the public fail-fast contract for library
+    # consumers, and it must survive `python -O`.
+    if not encoded_data_ready():
+      raise RuntimeError('Encoded HKO data files are missing. Run `python -m src.Calendar.HkoData.Encoder` from the repo root to regenerate them.')
 
     self._start_year: Final[int] = HkoYearLimits.START_YEAR
     self._end_year: Final[int] = HkoYearLimits.END_YEAR - 1 # hkodata.END_YEAR not included, since the data for it is incomplete.

--- a/src/Calendar/HkoData/Encoder.py
+++ b/src/Calendar/HkoData/Encoder.py
@@ -37,10 +37,10 @@ def download_one_year_data(txt_path: Path, year: int) -> bool:
   except ModuleNotFoundError as e:
     if e.name != 'requests':
       raise # A transitive dependency of `requests` is missing; don't misreport it.
-    raise ModuleNotFoundError('`requests` is not installed. Run `pip install requests` to regenerate the HKO data.') from None
+    raise ModuleNotFoundError('`requests` is not installed. Run `pip install requests` to regenerate the HKO data.', name='requests') from None
 
   url = f'https://www.hko.gov.hk/tc/gts/time/calendar/text/files/T{year}c.txt'
-  response = requests.get(url)
+  response = requests.get(url, timeout=30)
   if response.status_code == 200:
     response.encoding = 'big5'
     with txt_path.open('w', encoding='utf-8') as f:

--- a/src/Calendar/HkoData/Encoder.py
+++ b/src/Calendar/HkoData/Encoder.py
@@ -1,41 +1,44 @@
-#!/usr/bin/env python3
-#
-# bazi/src/Calendar/HkoData/encoder.py
 # Copyright (C) 2024 Ningqi Wang (0xf3cd) <https://github.com/0xf3cd>
+# bazi/src/Calendar/HkoData/Encoder.py
 #
 # Download the raw data from Hong Kong Observatory (hko) and encode the downloaded hko data.
+#
+# This module is an offline tool, only used when the data under `HkoData/data/`
+# needs to be regenerated. It is not needed at runtime: the decoder only reads
+# the committed data files. `requests` is deliberately not in Requirements.txt --
+# install it manually (`pip install requests`) and run this tool from the repo root:
+#   python -m src.Calendar.HkoData.Encoder
 
-import requests
 import re
-from pathlib import Path
+
 from datetime import datetime
+from importlib import import_module
+from pathlib import Path
+from typing import Any
 
-if __name__ == '__main__':
-  from common import ( # type: ignore # somehow mypy can't find it.
-    HkoYearLimits,
-    get_data_base_path, get_raw_txt_file_paths, raw_data_ready,
-    get_jieqi_encoded_data_path, get_lunardate_encoded_data_path, encoded_data_ready,
-    jieqi_list_in_traditional_chinese, twelve_months_in_traditional_chinese,
-    date_to_bytes, int_to_bytes,
-  )
+from ...Defines import Ganzhi
 
-  import sys
-  sys.path.append(Path(__file__).parent.parent.parent.as_posix())
-  from Defines import Ganzhi # type: ignore # somehow mypy can't find it.
-else:
-  from ...Defines import Ganzhi
-  from .common import (
-    HkoYearLimits,
-    get_data_base_path, get_raw_txt_file_paths, raw_data_ready,
-    get_jieqi_encoded_data_path, get_lunardate_encoded_data_path, encoded_data_ready,
-    jieqi_list_in_traditional_chinese, twelve_months_in_traditional_chinese,
-    date_to_bytes, int_to_bytes,
-  )
+from .Common import (
+  HkoYearLimits,
+  get_data_base_path, get_raw_txt_file_paths, raw_data_ready,
+  get_jieqi_encoded_data_path, get_lunardate_encoded_data_path, encoded_data_ready,
+  jieqi_list_in_traditional_chinese, twelve_months_in_traditional_chinese,
+  date_to_bytes, int_to_bytes,
+)
 
 
 __sexagenary_cycle__: list[Ganzhi] = Ganzhi.list_sexagenary_cycle()
 
 def download_one_year_data(txt_path: Path, year: int) -> bool:
+  # Lazy-load `requests`: it is only needed when regenerating the data, so importing
+  # this module (and certainly the decoder) never requires `requests` to be installed.
+  try:
+    requests: Any = import_module('requests')
+  except ModuleNotFoundError as e:
+    if e.name != 'requests':
+      raise # A transitive dependency of `requests` is missing; don't misreport it.
+    raise ModuleNotFoundError('`requests` is not installed. Run `pip install requests` to regenerate the HKO data.') from None
+
   url = f'https://www.hko.gov.hk/tc/gts/time/calendar/text/files/T{year}c.txt'
   response = requests.get(url)
   if response.status_code == 200:

--- a/src/Calendar/HkoData/HkoDataExplorer.ipynb
+++ b/src/Calendar/HkoData/HkoDataExplorer.ipynb
@@ -7,7 +7,7 @@
    "outputs": [],
    "source": [
     "from pathlib import Path\n",
-    "from encoder import raw_data_ready, get_raw_txt_file_paths\n",
+    "from Common import raw_data_ready, get_raw_txt_file_paths\n",
     "\n",
     "assert raw_data_ready()\n",
     "raw_txt_paths: dict[int, Path] = get_raw_txt_file_paths()"

--- a/src/Calendar/HkoData/__init__.py
+++ b/src/Calendar/HkoData/__init__.py
@@ -1,4 +1,4 @@
-from .common import (
+from .Common import (
   HkoYearLimits,
   get_data_base_path, get_raw_txt_file_paths, raw_data_ready,
   get_jieqi_encoded_data_path, get_lunardate_encoded_data_path, encoded_data_ready,
@@ -6,9 +6,7 @@ from .common import (
   int_to_bytes, bytes_to_int, date_to_bytes, bytes_to_date,
 )
 
-from .encoder import do_download, do_encode
-
-from .decoder import (
+from .Decoder import (
   JieqiDates, DecodedJieqiDates, LunarYearInfo, DecodedLunarYears
 )
 
@@ -18,5 +16,5 @@ __all__ = [
   'get_jieqi_encoded_data_path', 'get_lunardate_encoded_data_path', 'encoded_data_ready',
   'jieqi_list_in_traditional_chinese', 'twelve_months_in_traditional_chinese', 
   'int_to_bytes', 'bytes_to_int', 'date_to_bytes', 'bytes_to_date',
-  'do_download', 'do_encode', 'JieqiDates', 'DecodedJieqiDates', 'LunarYearInfo', 'DecodedLunarYears'
+  'JieqiDates', 'DecodedJieqiDates', 'LunarYearInfo', 'DecodedLunarYears'
 ]

--- a/src/Calendar/__init__.py
+++ b/src/Calendar/__init__.py
@@ -1,9 +1,20 @@
+from importlib import import_module
+from typing import Any
+
 from . import HkoData
 from .CalendarDefines import CalendarType, CalendarDate
 from .CalendarUtilsProtocol import CalendarUtilsProtocol
-from . import HkoDataCalendarUtils
 
 __all__ = [
   'HkoData',
   'CalendarType', 'CalendarDate', 'CalendarUtilsProtocol', 'HkoDataCalendarUtils',
 ]
+
+def __getattr__(name: str) -> Any:
+  # `HkoDataCalendarUtils` instantiates the decoder databases at import time, which
+  # requires the encoded data files to be present. Import it lazily (PEP 562) so the
+  # offline encoder (`python -m src.Calendar.HkoData.Encoder`) can still run to
+  # regenerate the data when it is missing.
+  if name == 'HkoDataCalendarUtils':
+    return import_module('.HkoDataCalendarUtils', __name__)
+  raise AttributeError(f'module {__name__!r} has no attribute {name!r}')

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,17 +1,28 @@
+from importlib import import_module
+from typing import Any, Final
+
 from . import Calendar
 
 from . import Common
 from . import Defines
-from . import Bazi
-from . import BaziChart
 from . import Rules
 from . import Utils
-from . import Analyzer
 from . import Descriptions
-from . import Interpreter
-from . import TransitChart
 
 __all__ = [
   'Common', 'Defines', 'Calendar', 'Bazi', 'BaziChart', 'Rules', 'Utils', 
   'Analyzer', 'Descriptions', 'Interpreter', 'TransitChart',
 ]
+
+# `Bazi` / `BaziChart` (and everything built on top of them) instantiate the HKO
+# decoder databases at import time, which requires the encoded data files to be
+# present. Import them lazily (PEP 562) so the offline encoder
+# (`python -m src.Calendar.HkoData.Encoder`) can still run when the data is missing.
+_LAZY_SUBMODULES: Final[frozenset[str]] = frozenset({
+  'Bazi', 'BaziChart', 'Analyzer', 'Interpreter', 'TransitChart',
+})
+
+def __getattr__(name: str) -> Any:
+  if name in _LAZY_SUBMODULES:
+    return import_module(f'.{name}', __name__)
+  raise AttributeError(f'module {__name__!r} has no attribute {name!r}')

--- a/tests/calendar/test_hkodata.py
+++ b/tests/calendar/test_hkodata.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from datetime import date, timedelta
 
 from src.Calendar import HkoData
+from src.Calendar.HkoData import Encoder
 from src.Defines import Jieqi, Ganzhi
 
 
@@ -255,21 +256,21 @@ class TestHkoData(unittest.TestCase):
     data_path: Path = HkoData.get_data_base_path()
     self.assertTrue(data_path.exists() and data_path.is_dir())
 
-    txt_paths: dict[int, Path] = HkoData.common.get_raw_txt_file_paths()
+    txt_paths: dict[int, Path] = HkoData.Common.get_raw_txt_file_paths()
     for path in txt_paths.values():
       self.assertTrue(path.exists() and path.is_file())
       with open(path, 'r', encoding='utf-8') as f:
         self.assertTrue(f.read() != '')
 
-    self.assertTrue(HkoData.common.raw_data_ready())
+    self.assertTrue(HkoData.Common.raw_data_ready())
 
   def test_raw_data_ready(self) -> None:
-    self.assertTrue(HkoData.common.raw_data_ready())
+    self.assertTrue(HkoData.Common.raw_data_ready())
 
     # Do something bad in between.
 
     temp_dir: Path = Path(tempfile.mkdtemp())
-    data_path: Path = HkoData.common.get_data_base_path()
+    data_path: Path = HkoData.Common.get_data_base_path()
     self.assertTrue(temp_dir.exists() and temp_dir.is_dir())
     self.assertTrue(data_path.exists() and data_path.is_dir())
 
@@ -278,12 +279,12 @@ class TestHkoData(unittest.TestCase):
 
     try:
       shutil.move(data_path, temp_dir / 'data2')
-      self.assertFalse(HkoData.common.raw_data_ready())
+      self.assertFalse(HkoData.Common.raw_data_ready())
 
       # Create a file called "data" (not a folder).
       with open(data_path, 'w') as f:
         f.write('I am not a folder!!!')
-      self.assertFalse(HkoData.common.raw_data_ready())
+      self.assertFalse(HkoData.Common.raw_data_ready())
 
       # Remove the fake "data" file.
       data_path.unlink()
@@ -291,58 +292,66 @@ class TestHkoData(unittest.TestCase):
 
       # Copy the original data folder back.
       shutil.copytree(temp_dir / 'data', data_path)
-      self.assertTrue(HkoData.common.raw_data_ready())
+      self.assertTrue(HkoData.Common.raw_data_ready())
 
-      all_txt_paths: dict[int, Path] = HkoData.common.get_raw_txt_file_paths()
+      all_txt_paths: dict[int, Path] = HkoData.Common.get_raw_txt_file_paths()
       random.choice(list(all_txt_paths.values())).unlink()
-      self.assertFalse(HkoData.common.raw_data_ready())
+      self.assertFalse(HkoData.Common.raw_data_ready())
 
     finally:
       # Finally restore the original data folder.
       # Also ensure the data is ready again after the above malicious operations.
       shutil.copytree(temp_dir / 'data', data_path, dirs_exist_ok=True)
-      self.assertTrue(HkoData.common.raw_data_ready())
+      self.assertTrue(HkoData.Common.raw_data_ready())
 
       shutil.rmtree(temp_dir)
 
   @pytest.mark.slow
   def test_do_encode(self) -> None:
-    self.assertTrue(HkoData.common.encoded_data_ready())
+    self.assertTrue(HkoData.Common.encoded_data_ready())
 
     # Do something bad in between.
 
     temp_dir: Path = Path(tempfile.mkdtemp())
-    jieqi_path: Path = HkoData.common.get_jieqi_encoded_data_path()
-    lunardate_path: Path = HkoData.common.get_lunardate_encoded_data_path()
+    jieqi_path: Path = HkoData.Common.get_jieqi_encoded_data_path()
+    lunardate_path: Path = HkoData.Common.get_lunardate_encoded_data_path()
     self.assertTrue(temp_dir.exists() and temp_dir.is_dir())
     self.assertTrue(jieqi_path.exists() and jieqi_path.is_file())
     self.assertTrue(lunardate_path.exists() and lunardate_path.is_file())
 
     # Copy the data folder to the temporary folder.
-    data_path: Path = HkoData.common.get_data_base_path()
+    data_path: Path = HkoData.Common.get_data_base_path()
     shutil.copytree(data_path, temp_dir / 'data')
 
     try:
       # Copy the encoded binary files to the temporary folder.
       shutil.move(jieqi_path, temp_dir / 'jieqi.bin')
-      self.assertFalse(HkoData.common.encoded_data_ready())
+      self.assertFalse(HkoData.Common.encoded_data_ready())
       shutil.move(lunardate_path, temp_dir / 'lunardate.bin')
-      self.assertFalse(HkoData.common.encoded_data_ready())
+      self.assertFalse(HkoData.Common.encoded_data_ready())
 
       # Ensure the encoded binary files are gone.
       self.assertFalse(jieqi_path.exists())
       self.assertFalse(lunardate_path.exists())
 
-      # Encode them again.
+      # The decoder only reads the committed data files; it never re-encodes them.
+      with self.assertRaises(AssertionError):
+        HkoData.DecodedJieqiDates()
+      with self.assertRaises(AssertionError):
+        HkoData.DecodedLunarYears()
+
+      # Encode them again, with the offline encoder tool.
+      Encoder.do_encode()
       self.assertIsNotNone(HkoData.DecodedJieqiDates())
-      self.assertTrue(HkoData.common.encoded_data_ready())
+      self.assertTrue(HkoData.Common.encoded_data_ready())
 
       lunardate_path.unlink()
-      self.assertFalse(HkoData.common.encoded_data_ready())
+      self.assertFalse(HkoData.Common.encoded_data_ready())
 
-      # Encode them again.
+      # Encode them again, with the offline encoder tool.
+      Encoder.do_encode()
       self.assertIsNotNone(HkoData.DecodedLunarYears())
-      self.assertTrue(HkoData.common.encoded_data_ready())
+      self.assertTrue(HkoData.Common.encoded_data_ready())
 
       # Ensure the new encoded binary files are the same as the old ones.
       prev_jieqi_md5: str = hashlib.md5((temp_dir / 'jieqi.bin').read_bytes()).hexdigest()
@@ -358,6 +367,6 @@ class TestHkoData(unittest.TestCase):
       # Finally restore the original data folder.
       # Also ensure the data is ready again after the above malicious operations.
       shutil.copytree(temp_dir / 'data', data_path, dirs_exist_ok=True)
-      self.assertTrue(HkoData.common.raw_data_ready())
+      self.assertTrue(HkoData.Common.raw_data_ready())
 
       shutil.rmtree(temp_dir)

--- a/tests/calendar/test_hkodata.py
+++ b/tests/calendar/test_hkodata.py
@@ -335,9 +335,9 @@ class TestHkoData(unittest.TestCase):
       self.assertFalse(lunardate_path.exists())
 
       # The decoder only reads the committed data files; it never re-encodes them.
-      with self.assertRaises(AssertionError):
+      with self.assertRaises(RuntimeError):
         HkoData.DecodedJieqiDates()
-      with self.assertRaises(AssertionError):
+      with self.assertRaises(RuntimeError):
         HkoData.DecodedLunarYears()
 
       # Encode them again, with the offline encoder tool.


### PR DESCRIPTION
## 背景

实现 #65：斩断 `decoder → encoder → 网络下载` 的 import 副作用链，把 HKO 数据工具链与运行时解耦。二进制数据格式保留（作者裁决）。

## 改动

- **Decoder** 只读 repo 内已提交数据；缺数据 fail-fast（assert 指向再生成命令），不再隐式联网下载+编码
- **Encoder** 降级为离线工具：`requests` 懒加载（importlib，区分传递依赖缺失），移出 `Requirements.txt`；再生成入口 `python -m src.Calendar.HkoData.Encoder`
- 三件套 `common/decoder/encoder.py` → PascalCase `Common/Decoder/Encoder.py`，全仓引用同步（含 coverage omit、notebook）
- `DecodedJieqiDates` 三层缓存精简为一层 `functools.cache`（语义不变，测试 pin 住：`get` 同对象、`__getitem__` 新 dict）
- `HkoData/__init__.py` 不再 re-export `do_download`/`do_encode`（API 收窄，repo 内无消费方）
- **PEP 562 惰性化**（`src/__init__.py` + `src/Calendar/__init__.py`）：`python -m` 会先 import 父包，而父包 eager import 链会在 import 期实例化解码库——数据缺失时再生成入口会崩在自己的 assert 上（本地三家 review 中 Claude 发现，已实证）。惰性化后入口在数据缺失时可用

## 验证

- 全量测试 + `ruff` + `mypy`（47 文件）全绿
- 1901–2099 全量解码对照（节气 200 年 + 阴历 199 年 + 4772 条月度转换 + 14184 条节气日 ±1 天转换）重构前后逐字节一致
- 数据缺失场景实证：`python -m src.Calendar.HkoData.Encoder` 离线重编码出两个 .bin，随后正常 import 工作

Closes #65