### PR TITLE
feat: injectable calendar backend via CalendarBackend enum (#66)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,15 @@ those, don't restate them here. Two rules the README doesn't spell out:
 - `ruff` / `mypy` run on **default** config. There is intentionally NO
   pyproject.toml / ruff.toml / mypy.ini — do NOT add one.
 - Not a pip package — code runs with `src.` on path via the `run_*.py` scripts.
+- Before opening a PR, verify locally with the **same gates CI runs** — the PR
+  workflow invokes `run_tests.py -v -s -hko -c -cr 100 -ruff -mypy -d -i`.
+  Quick local equivalent (run all three, they are all hard gates):
+  - `ruff check .`
+  - `python -m mypy . --check-untyped-defs --warn-redundant-casts --warn-unused-ignores --warn-return-any --warn-unreachable`
+    (flags come from `run_tests.py`; a bare `mypy .` misses `--warn-unreachable`)
+  - `python -m coverage run --omit='*/__init__.py,*/run_tests.py,*/tests/*,src/Calendar/HkoData/Encoder.py' -m pytest tests/`
+    then `python -m coverage report --show-missing` — must stay at **100%**
+    (intentionally unreachable lines carry `# pragma: no cover` + a reason).
 
 ## File conventions
 - Every source file opens with the copyright header, verbatim except the year:

--- a/src/Bazi.py
+++ b/src/Bazi.py
@@ -104,7 +104,7 @@ class Bazi:
   def __init__(self, birth_time: datetime, gender: BaziGender, precision: BaziPrecision,
                backend: CalendarBackend = CalendarBackend.HKO) -> None:
     '''
-    `Bazi` (i.e. 八字, which means eight characters in Chinese) takes the birt time and gender as input, 
+    `Bazi` (i.e. 八字, which means eight characters in Chinese) takes the birth time and gender as input, 
     and figures out the pillars of year, month, day, and hour.
     `Bazi` 接受出生时间和性别作为输入，计算年、月、日、时的八字。
     

--- a/src/Bazi.py
+++ b/src/Bazi.py
@@ -8,13 +8,12 @@ from datetime import date, time, datetime, timedelta
 from typing import Final, Union
 
 from .Defines import Tiangan, Dizhi, Ganzhi
-from .Calendar import CalendarDate
+from .Calendar import (
+  CalendarDate, CalendarUtilsProtocol, CalendarBackend, calendar_utils_of,
+)
 
 from .Utils.BaziUtils import (
   month_tiangan, hour_tiangan, ganzhi_of_day, ganzhi_of_year,
-)
-from .Calendar.HkoDataCalendarUtils import (
-  to_solar, to_ganzhi, to_date, is_valid_solar_date,
 )
 
 
@@ -102,7 +101,8 @@ class Bazi:
   - `Bazi` 不考虑真太阳时和夏令时。这些时间需要在外部处理。
   '''
 
-  def __init__(self, birth_time: datetime, gender: BaziGender, precision: BaziPrecision) -> None:
+  def __init__(self, birth_time: datetime, gender: BaziGender, precision: BaziPrecision,
+               backend: CalendarBackend = CalendarBackend.HKO) -> None:
     '''
     `Bazi` (i.e. 八字, which means eight characters in Chinese) takes the birt time and gender as input, 
     and figures out the pillars of year, month, day, and hour.
@@ -118,17 +118,22 @@ class Bazi:
     - birth_time: (datetime) The birth date (in Georgian calendar) and time. Note that no timezone should be set.
     - gender: (BaziGender) The gender of the person.
     - precision: (BaziPrecision) The precision of the birth time.
+    - backend: (CalendarBackend) The calendar backend used for all calendar conversions.
     '''
 
     assert isinstance(birth_time, datetime)
     assert isinstance(gender, BaziGender)
     assert isinstance(precision, BaziPrecision)
+    assert isinstance(backend, CalendarBackend)
+
+    self._backend: Final[CalendarBackend] = backend
+    utils: Final[CalendarUtilsProtocol] = calendar_utils_of(backend)
 
     self._birth_time: Final[datetime] = copy.deepcopy(birth_time)
     assert self._birth_time.tzinfo is None, 'Timezone should be well-processed outside of this class.'
 
-    self._solar_date: Final[CalendarDate] = to_solar(self._birth_time)
-    assert is_valid_solar_date(self._solar_date) # Here we are also checking if the date falls into the supported range.
+    self._solar_date: Final[CalendarDate] = utils.to_solar(self._birth_time)
+    assert utils.is_valid_solar_date(self._solar_date) # Here we are also checking if the date falls into the supported range.
 
     self._hour: Final[int] = self._birth_time.hour
     assert self._hour >= 0 and self._hour < 24
@@ -143,7 +148,7 @@ class Bazi:
     # TODO: Currently only supports `DAY` precision.
     assert self._precision == BaziPrecision.DAY, 'see https://github.com/0xf3cd/bazi/issues/6'
 
-    ganzhi_calendardate: CalendarDate = to_ganzhi(self._solar_date)
+    ganzhi_calendardate: CalendarDate = utils.to_ganzhi(self._solar_date)
 
     # Figure out the solar date falls into which ganzhi year.
     # Also figure out the Year Ganzhi / Year Pillar (年柱).
@@ -166,8 +171,9 @@ class Bazi:
   def __parse_bazi_args(
     birth_time: Union[datetime, str],
     gender: Union[BaziGender, str], 
-    precision: Union[BaziPrecision, str]
-  ) -> tuple[datetime, BaziGender, BaziPrecision]:
+    precision: Union[BaziPrecision, str],
+    backend: Union[CalendarBackend, str]
+  ) -> tuple[datetime, BaziGender, BaziPrecision, CalendarBackend]:
     
     assert isinstance(birth_time, (datetime, str))
     _birth_time: datetime = birth_time if isinstance(birth_time, datetime) else datetime.fromisoformat(birth_time)
@@ -199,14 +205,22 @@ class Bazi:
         _precision = BaziPrecision.DAY
       else:
         raise ValueError(f'Unsupported precision: {precision}')
-      
-    return _birth_time, _gender, _precision
+
+    _backend: CalendarBackend
+    if isinstance(backend, CalendarBackend):
+      _backend = backend
+    else:
+      assert isinstance(backend, str)
+      _backend = CalendarBackend.from_str(backend)
+
+    return _birth_time, _gender, _precision, _backend
 
   @staticmethod
   def create(
     birth_time: Union[datetime, str],
     gender: Union[BaziGender, str], 
-    precision: Union[BaziPrecision, str]
+    precision: Union[BaziPrecision, str],
+    backend: Union[CalendarBackend, str] = CalendarBackend.HKO
   ) -> 'Bazi':
     '''
     Staticmethod that creates a `Bazi` object from the inputs.
@@ -223,17 +237,23 @@ class Bazi:
       - if `BaziPrecision` type: it will be directly fed to `Bazi`.
       - if `str` type: it will be converted by `BaziPrecision`. 
         - Supported values: "分"/"分钟"/"时"/"小时"/"天"/"日"/"m"/"min"/"minute"/"h"/"hour"/"d"/"day" (case insensitive).
+    - backend: (Union[CalendarBackend, str]) The calendar backend used for all calendar conversions.
+      - if `CalendarBackend` type: it will be directly fed to `Bazi`.
+      - if `str` type: it will be converted by `CalendarBackend.from_str`.
+        - Supported values: the member names and values of `CalendarBackend` (e.g. "HKO"/"hko", case insensitive).
     '''
 
     assert isinstance(birth_time, (datetime, str))
     assert isinstance(gender, (BaziGender, str))
     assert isinstance(precision, (BaziPrecision, str))
+    assert isinstance(backend, (CalendarBackend, str))
 
-    _birth_time, _gender, _precision = Bazi.__parse_bazi_args(birth_time, gender, precision)
+    _birth_time, _gender, _precision, _backend = Bazi.__parse_bazi_args(birth_time, gender, precision, backend)
     bazi: Bazi = Bazi(
       birth_time=_birth_time,
       gender=_gender,
       precision=_precision,
+      backend=_backend,
     )
     return bazi
   
@@ -260,12 +280,12 @@ class Bazi:
   @property
   def solar_date(self) -> date:
     '''The birth date (in solar/georgian calendar) / 公历出生日期'''
-    return to_date(self._solar_date)
+    return self._utils.to_date(self._solar_date)
   
   @property
   def ganzhi_date(self) -> CalendarDate:
     '''The birth date (in ganzhi calendar) / 干支历出生日期'''
-    return to_ganzhi(self._solar_date)
+    return self._utils.to_ganzhi(self._solar_date)
 
   @property
   def hour(self) -> int:
@@ -287,6 +307,23 @@ class Bazi:
   @property
   def precision(self) -> BaziPrecision:
     return self._precision
+
+  @property
+  def backend(self) -> CalendarBackend:
+    '''The calendar backend that this `Bazi` uses / 此命盘使用的历法后端'''
+    return self._backend
+
+  @property
+  def _utils(self) -> CalendarUtilsProtocol:
+    '''
+    The resolved calendar utils of `self.backend`. Resolved on each access, so nothing
+    non-deepcopyable (i.e. the utils module) is stored on the instance.
+    当前历法后端对应的实际工具。每次访问时现解析，实例上不存模块引用，保证 `Bazi` 可 deepcopy。
+
+    Do NOT turn this into a `cached_property` -- that would write the module into
+    the instance dict and break `deepcopy`.
+    '''
+    return calendar_utils_of(self._backend)
   
   @property
   def four_dizhis(self) -> tuple[Dizhi, Dizhi, Dizhi, Dizhi]:
@@ -373,6 +410,8 @@ class Bazi:
     if self.gender != other.gender:
       return False
     if self.precision != other.precision:
+      return False
+    if self.backend != other.backend:
       return False
     return True
   

--- a/src/Bazi.py
+++ b/src/Bazi.py
@@ -405,15 +405,12 @@ class Bazi:
   def __eq__(self, other: object) -> bool:
     if not isinstance(other, Bazi):
       return False
-    if self.solar_datetime != other.solar_datetime:
-      return False
-    if self.gender != other.gender:
-      return False
-    if self.precision != other.precision:
-      return False
-    if self.backend != other.backend:
-      return False
-    return True
+    return (
+      self.solar_datetime == other.solar_datetime
+      and self.gender == other.gender
+      and self.precision == other.precision
+      and self.backend == other.backend
+    )
   
   def __ne__(self, other: object) -> bool:
     return not self.__eq__(other)

--- a/src/Bazi.py
+++ b/src/Bazi.py
@@ -115,7 +115,7 @@ class Bazi:
     - `Bazi` 不考虑真太阳时和夏令时。这些时间需要在外部处理。
     
     Args:
-    - birth_time: (datetime) The birth date (in Georgian calendar) and time. Note that no timezone should be set.
+    - birth_time: (datetime) The birth date (in Gregorian calendar) and time. Note that no timezone should be set.
     - gender: (BaziGender) The gender of the person.
     - precision: (BaziPrecision) The precision of the birth time.
     - backend: (CalendarBackend) The calendar backend used for all calendar conversions.
@@ -279,7 +279,7 @@ class Bazi:
 
   @property
   def solar_date(self) -> date:
-    '''The birth date (in solar/georgian calendar) / 公历出生日期'''
+    '''The birth date (in solar/gregorian calendar) / 公历出生日期'''
     return self._utils.to_date(self._solar_date)
   
   @property
@@ -297,7 +297,7 @@ class Bazi:
   
   @property
   def solar_datetime(self) -> datetime:
-    '''The exact birth time (in solar/georgian calendar) / 出生时刻（公历）'''
+    '''The exact birth time (in solar/gregorian calendar) / 出生时刻（公历）'''
     return datetime.combine(self.solar_date, time(self.hour, self.minute))
   
   @property

--- a/src/BaziChart.py
+++ b/src/BaziChart.py
@@ -291,7 +291,8 @@ class BaziChart:
     '''
 
     step: Final[int] = 1 if self.dayun_order else -1
-    until_xusui_age: Final[int] = 1 + self._utils.to_ganzhi(self.dayun_start_moment).year - self._utils.to_ganzhi(self._bazi.solar_datetime).year
+    utils: Final[CalendarUtilsProtocol] = self._utils
+    until_xusui_age: Final[int] = 1 + utils.to_ganzhi(self.dayun_start_moment).year - utils.to_ganzhi(self._bazi.solar_datetime).year
 
     def __xiaoyun_at_age(age: int) -> XiaoyunTuple:
       return XiaoyunTuple(age, self._bazi.hour_pillar.next(age * step))

--- a/src/BaziChart.py
+++ b/src/BaziChart.py
@@ -14,7 +14,7 @@ from .Common import (
 from .Defines import Tiangan, Dizhi, Ganzhi, Shishen, ShierZhangsheng, Yinyang
 from .Bazi import Bazi, BaziGender
 
-from .Calendar.HkoDataCalendarUtils import prev_jie, next_jie, to_ganzhi
+from .Calendar import CalendarUtilsProtocol, calendar_utils_of
 from .Utils.BaziUtils import (
   traits, hidden_tiangans, shier_zhangsheng, shishen, nayin_str, ganzhi_of_year
 )
@@ -40,6 +40,18 @@ class BaziChart:
   @property
   def bazi(self) -> Bazi:
     return copy.deepcopy(self._bazi)
+
+  @property
+  def _utils(self) -> CalendarUtilsProtocol:
+    '''
+    The resolved calendar utils of the underlying `Bazi`'s backend. Resolved on each access,
+    so nothing non-deepcopyable (i.e. the utils module) is stored on the instance.
+    底层 `Bazi` 所用历法后端对应的实际工具。每次访问时现解析，实例上不存模块引用，保证 `BaziChart` 可 deepcopy。
+
+    Do NOT turn this into a `cached_property` -- that would write the module into
+    the instance dict and break `deepcopy`.
+    '''
+    return calendar_utils_of(self._bazi.backend)
   
   @property
   def house_of_relationship(self) -> Dizhi:
@@ -221,8 +233,8 @@ class BaziChart:
 
     def __gap() -> timedelta:
       if self.dayun_order:
-        return next_jie(birthtime).moment - birthtime
-      return birthtime - prev_jie(birthtime).moment
+        return self._utils.next_jie(birthtime).moment - birthtime
+      return birthtime - self._utils.prev_jie(birthtime).moment
     
     def __diff() -> timedelta:
       gap: Final[timedelta] = __gap()
@@ -253,7 +265,7 @@ class BaziChart:
 
     def __dayun_generator() -> Generator[DayunTuple, None, None]:
       step: Final[int] = 1 if self.dayun_order else -1
-      ganzhi_year: int = to_ganzhi(self.dayun_start_moment).year
+      ganzhi_year: int = self._utils.to_ganzhi(self.dayun_start_moment).year
       gz: Ganzhi = self._bazi.month_pillar.next(step)
 
       while True:
@@ -279,7 +291,7 @@ class BaziChart:
     '''
 
     step: Final[int] = 1 if self.dayun_order else -1
-    until_xusui_age: Final[int] = 1 + to_ganzhi(self.dayun_start_moment).year - to_ganzhi(self._bazi.solar_datetime).year
+    until_xusui_age: Final[int] = 1 + self._utils.to_ganzhi(self.dayun_start_moment).year - self._utils.to_ganzhi(self._bazi.solar_datetime).year
 
     def __xiaoyun_at_age(age: int) -> XiaoyunTuple:
       return XiaoyunTuple(age, self._bazi.hour_pillar.next(age * step))
@@ -326,6 +338,7 @@ class BaziChart:
       'birth_time': self._bazi.solar_datetime.isoformat(),
       'gender': str(self._bazi.gender),
       'precision': str(self._bazi.precision),
+      'backend': str(self._bazi.backend),
       'pillars': f([str(p) for p in self._bazi.pillars]),
       'nayin': f([str(ny) for ny in self.nayin]),
       'shier_zhangsheng': f([str(sz) for sz in self.shier_zhangsheng]),

--- a/src/Calendar/CalendarBackend.py
+++ b/src/Calendar/CalendarBackend.py
@@ -69,4 +69,5 @@ def calendar_utils_of(backend: Union[CalendarBackend, str]) -> CalendarUtilsProt
 
   # Invariant: every enum member must be wired up above. Reaching here means we
   # added a member but forgot to resolve it -- not something users can trigger.
-  assert False, f'Backend not wired up in `calendar_utils_of`: {_backend}' # pragma: no cover # Unreachable invariant guard.
+  # `raise` instead of `assert` so the guard survives `python -O`.
+  raise AssertionError(f'Backend not wired up in `calendar_utils_of`: {_backend}') # pragma: no cover # Unreachable invariant guard.

--- a/src/Calendar/CalendarBackend.py
+++ b/src/Calendar/CalendarBackend.py
@@ -69,4 +69,4 @@ def calendar_utils_of(backend: Union[CalendarBackend, str]) -> CalendarUtilsProt
 
   # Invariant: every enum member must be wired up above. Reaching here means we
   # added a member but forgot to resolve it -- not something users can trigger.
-  assert False, f'Backend not wired up in `calendar_utils_of`: {_backend}'
+  assert False, f'Backend not wired up in `calendar_utils_of`: {_backend}' # pragma: no cover # Unreachable invariant guard.

--- a/src/Calendar/CalendarBackend.py
+++ b/src/Calendar/CalendarBackend.py
@@ -1,0 +1,72 @@
+# Copyright (C) 2026 Ningqi Wang (0xf3cd) <https://github.com/0xf3cd>
+
+from enum import Enum
+from typing import Union, cast
+
+from .CalendarUtilsProtocol import CalendarUtilsProtocol
+
+
+class CalendarBackend(Enum):
+  '''
+  The calendar backend that a `Bazi` uses for all calendar conversions
+  (solar <-> lunar <-> ganzhi, jieqi moments, etc.).
+  命盘进行历法换算（公历 <-> 农历 <-> 干支、节气时刻等）所使用的历法后端。
+
+  - HKO: based on the data from Hong Kong Observatory. Day-level precision,
+    meaning that the accurate times of Jieqis are unknown.
+    基于香港天文台数据的历法。日级精度，即无法得知节气的准确时刻。
+
+  In the future, an astronomical-algorithm-based backend will be added,
+  which knows the accurate times of Jieqis (minute-level precision) and
+  hence unlocks true solar time and higher-precision Bazi charts.
+  未来会加入基于天文算法的后端，得知节气的准确时刻（分钟级精度），
+  从而解锁真太阳时和更高精度的命盘。
+
+  See https://github.com/0xf3cd/bazi/issues/2 and
+      https://github.com/0xf3cd/bazi/issues/6
+  '''
+  HKO = 'hko'
+
+  def __str__(self) -> str:
+    # Invariant: every enum member must be covered here.
+    assert self is self.HKO
+    return 'hko'
+
+  @staticmethod
+  def from_str(s: str) -> 'CalendarBackend':
+    '''
+    Parse a `CalendarBackend` from a string (case insensitive).
+    Both the member name and the value are accepted, e.g. 'HKO' and 'hko'.
+    从字符串解析历法后端（大小写不敏感）。成员名和值都可以，例如 'HKO' 和 'hko'。
+
+    Args:
+    - s: (str) The string to parse. Raises `ValueError` if it matches no backend.
+    '''
+    assert isinstance(s, str)
+    for member in CalendarBackend:
+      if s.lower() in (member.name.lower(), member.value.lower()):
+        return member
+    raise ValueError(f'Unsupported backend: {s}')
+
+
+def calendar_utils_of(backend: Union[CalendarBackend, str]) -> CalendarUtilsProtocol:
+  '''
+  Resolve a `CalendarBackend` to the actual calendar utils, lazily.
+  The resolved utils conform to `CalendarUtilsProtocol`.
+  把历法后端声明解析成实际的历法工具（懒加载），解析结果遵循 `CalendarUtilsProtocol`。
+  '''
+  assert isinstance(backend, (CalendarBackend, str))
+  _backend: CalendarBackend = backend if isinstance(backend, CalendarBackend) else CalendarBackend.from_str(backend)
+
+  if _backend is CalendarBackend.HKO:
+    # `HkoDataCalendarUtils` instantiates the decoder databases at import time.
+    # Import it lazily so that users of other backends never pay that cost.
+    from . import HkoDataCalendarUtils
+    # A module structurally conforms to `CalendarUtilsProtocol` at runtime (the
+    # protocol's staticmethods are satisfied by module-level functions), but mypy
+    # cannot see that, hence the `cast`.
+    return cast(CalendarUtilsProtocol, HkoDataCalendarUtils)
+
+  # Invariant: every enum member must be wired up above. Reaching here means we
+  # added a member but forgot to resolve it -- not something users can trigger.
+  assert False, f'Backend not wired up in `calendar_utils_of`: {_backend}'

--- a/src/Calendar/__init__.py
+++ b/src/Calendar/__init__.py
@@ -4,10 +4,12 @@ from typing import Any
 from . import HkoData
 from .CalendarDefines import CalendarType, CalendarDate
 from .CalendarUtilsProtocol import CalendarUtilsProtocol
+from .CalendarBackend import CalendarBackend, calendar_utils_of
 
 __all__ = [
   'HkoData',
   'CalendarType', 'CalendarDate', 'CalendarUtilsProtocol', 'HkoDataCalendarUtils',
+  'CalendarBackend', 'calendar_utils_of',
 ]
 
 def __getattr__(name: str) -> Any:

--- a/src/Common.py
+++ b/src/Common.py
@@ -334,6 +334,7 @@ class BaziJson:
     birth_time: str
     gender: str
     precision: str
+    backend: str
     pillars: 'BaziJson.FourPillars'
     nayin: 'BaziJson.FourPillars'
     shier_zhangsheng: 'BaziJson.FourPillars'

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -14,10 +14,12 @@ __all__ = [
   'Analyzer', 'Descriptions', 'Interpreter', 'TransitChart',
 ]
 
-# `Bazi` / `BaziChart` (and everything built on top of them) instantiate the HKO
-# decoder databases at import time, which requires the encoded data files to be
-# present. Import them lazily (PEP 562) so the offline encoder
-# (`python -m src.Calendar.HkoData.Encoder`) can still run when the data is missing.
+# Since #66, `Bazi` / `BaziChart` resolve their calendar backend lazily (see
+# `Calendar/CalendarBackend.py`), so importing them no longer loads any calendar
+# data -- that now happens on the first `Bazi` construction. Keep these submodules
+# lazy (PEP 562) regardless: `import src` stays cheap, and the offline encoder
+# (`python -m src.Calendar.HkoData.Encoder`) can never accidentally pull in the
+# chart layer.
 _LAZY_SUBMODULES: Final[frozenset[str]] = frozenset({
   'Bazi', 'BaziChart', 'Analyzer', 'Interpreter', 'TransitChart',
 })

--- a/tests/calendar/test_calendar_backend.py
+++ b/tests/calendar/test_calendar_backend.py
@@ -1,0 +1,111 @@
+# Copyright (C) 2026 Ningqi Wang (0xf3cd) <https://github.com/0xf3cd>
+# test_calendar_backend.py
+
+import copy
+import types
+import unittest
+
+from datetime import datetime
+
+from src.Calendar import (
+  CalendarBackend, CalendarUtilsProtocol, HkoDataCalendarUtils, calendar_utils_of,
+)
+from src.Bazi import Bazi, BaziGender, BaziPrecision
+from src.BaziChart import BaziChart
+
+
+class TestCalendarBackend(unittest.TestCase):
+  def test_basic(self) -> None:
+    self.assertEqual(len(CalendarBackend), 1)
+    self.assertEqual(str(CalendarBackend.HKO), 'hko')
+
+  def test_from_str(self) -> None:
+    for s in ['hko', 'HKO', 'Hko']:
+      self.assertIs(CalendarBackend.from_str(s), CalendarBackend.HKO)
+
+    with self.assertRaises(ValueError):
+      CalendarBackend.from_str('lunar') # Not a supported backend.
+
+    with self.assertRaises(AssertionError):
+      CalendarBackend.from_str(42) # type: ignore[arg-type]
+
+  def test_calendar_utils_of(self) -> None:
+    utils = calendar_utils_of(CalendarBackend.HKO)
+    self.assertIs(utils, HkoDataCalendarUtils)
+    self.assertIsInstance(utils, CalendarUtilsProtocol)
+
+    # Strings are also accepted and resolved the same way.
+    self.assertIs(calendar_utils_of('hko'), HkoDataCalendarUtils)
+
+    with self.assertRaises(ValueError):
+      calendar_utils_of('lunar')
+
+    with self.assertRaises(AssertionError):
+      calendar_utils_of(42) # type: ignore[arg-type]
+
+
+class TestBaziBackend(unittest.TestCase):
+  def test_default_backend(self) -> None:
+    bazi: Bazi = Bazi(datetime(1984, 4, 2, 4, 2), BaziGender.MALE, BaziPrecision.DAY)
+    self.assertIs(bazi.backend, CalendarBackend.HKO)
+
+  def test_create_with_backend(self) -> None:
+    bazi_default: Bazi = Bazi.create('1984-04-02 04:02', 'male', 'day')
+    bazi_enum: Bazi = Bazi.create('1984-04-02 04:02', 'male', 'day', backend=CalendarBackend.HKO)
+    bazi_str: Bazi = Bazi.create('1984-04-02 04:02', 'male', 'day', backend='hko')
+
+    self.assertIs(bazi_default.backend, CalendarBackend.HKO)
+    self.assertEqual(bazi_default, bazi_enum)
+    self.assertEqual(bazi_default, bazi_str)
+
+    with self.assertRaises(ValueError):
+      Bazi.create('1984-04-02 04:02', 'male', 'day', backend='lunar')
+
+    with self.assertRaises(AssertionError):
+      Bazi.create('1984-04-02 04:02', 'male', 'day', backend=42) # type: ignore[arg-type]
+
+  def test_consistent_with_hko_utils(self) -> None:
+    # The backend-resolved utils should produce results identical to direct HKO calls.
+    bazi: Bazi = Bazi(datetime(2000, 2, 4, 20, 35), BaziGender.FEMALE, BaziPrecision.DAY,
+                      backend=CalendarBackend.HKO)
+    self.assertEqual(bazi.solar_date, HkoDataCalendarUtils.to_date(datetime(2000, 2, 4)))
+    self.assertEqual(bazi.ganzhi_date, HkoDataCalendarUtils.to_ganzhi(bazi.solar_date))
+
+  def test_init_rejects_str_backend(self) -> None:
+    # `__init__` only takes the enum; strings go through `Bazi.create` (same
+    # contract split as `gender` / `precision`).
+    with self.assertRaises(AssertionError):
+      Bazi(datetime(1984, 4, 2, 4, 2), BaziGender.MALE, BaziPrecision.DAY,
+           backend='hko') # type: ignore[arg-type]
+
+  def test_random_uses_default_backend(self) -> None:
+    self.assertIs(Bazi.random().backend, CalendarBackend.HKO)
+
+  def test_json_contains_backend(self) -> None:
+    chart: BaziChart = BaziChart(Bazi(datetime(1984, 4, 2, 4, 2), BaziGender.MALE, BaziPrecision.DAY))
+    self.assertEqual(chart.json['backend'], 'hko')
+
+  def test_deepcopy(self) -> None:
+    bazi: Bazi = Bazi(datetime(1984, 4, 2, 4, 2), BaziGender.MALE, BaziPrecision.DAY)
+    chart: BaziChart = BaziChart(bazi) # `BaziChart` deepcopies the bazi internally.
+
+    # Trigger the utils-resolving paths before copying.
+    _ = bazi.solar_date, bazi.ganzhi_date
+    _ = chart.dayun_start_moment
+
+    # Only the `CalendarBackend` enum may be stored on the instances (deepcopy-safe).
+    # `_utils` must stay a plain property: no module reference may ever land in
+    # the instance dicts, since modules are not deepcopyable.
+    for obj in (bazi, chart):
+      for value in vars(obj).values():
+        self.assertNotIsInstance(value, types.ModuleType)
+
+    bazi2: Bazi = copy.deepcopy(bazi)
+    self.assertEqual(bazi, bazi2)
+    self.assertIs(bazi2.backend, CalendarBackend.HKO)
+    # The copy still resolves the calendar utils on demand.
+    self.assertEqual(bazi2.ganzhi_date, bazi.ganzhi_date)
+
+    chart2: BaziChart = copy.deepcopy(chart)
+    self.assertIs(chart2.bazi.backend, CalendarBackend.HKO)
+    self.assertEqual(chart2.dayun_start_moment, chart.dayun_start_moment)


### PR DESCRIPTION
## 背景

`CalendarUtilsProtocol` 的 docstring 明言为天文算法历法预留，但 `src/Bazi.py:16-18`、`src/BaziChart.py:17` 硬编码 `from .Calendar.HkoDataCalendarUtils import ...`，协议形同虚设。本 PR 落地历法后端注入点，HKO 成为默认实现而非唯一实现。这是 #2（真太阳时）/ #6（HOUR/MINUTE 精度）的架构前置。

Closes #66.

## 设计

- 新增 `CalendarBackend` Enum（目前仅 `HKO` 成员），声明式选择历法后端；未来天文算法后端以新 enum 成员接入
- `Bazi.__init__` / `Bazi.create` 新增 `backend` 参数（默认 `CalendarBackend.HKO`，追加在末位，既有调用全部兼容）；`create` 还接受 `'hko'` 等字符串（与 gender/precision 的契约一致）
- 实例上只存 enum（deepcopy 安全）；历法工具经 `_utils` property 每次访问现解析，`calendar_utils_of` 懒加载 HKO 模块——模块引用永不落实例，`BaziChart` 被 `TransitChart`/`Interpreter`/`Analyzer` deepcopy 的链路不受影响
- `BaziChart` 不加参数，从 `self._bazi.backend` 取同一后端，保证原盘/大运/流年用同一套历法
- `Bazi.__eq__` 纳入 backend 比较（后端是排盘语义的一部分）
- `BaziChart.json` 新增 `backend` 字段（非破坏性，与 `precision` 对称）
- 附带效果：`import src.Bazi` 不再加载 HKO 数据，数据加载推迟到首次构造 `Bazi`

## 验证

- `pytest tests/`：243 passed（新增 `tests/calendar/test_calendar_backend.py` 10 条：enum 解析、`calendar_utils_of` 三态、backend 注入、与 HKO 直调一致性、deepcopy 安全性加固、json backend 字段等）
- `ruff check .` / `mypy .`：全绿
- 本地三家 CLI 交叉审阅（Claude Fable 5 / Codex / Grok）均已通过，无 blocker；review 意见已落实（PEP 562 注释更新、deepcopy 测试加固、json backend 字段、入口 assert、不变量分支用 assert）