### PR TITLE
refactor: freeze description corpus & clean up Interpreter shell (#70)

### DIFF
--- a/src/Descriptions.py
+++ b/src/Descriptions.py
@@ -1,11 +1,16 @@
 # Copyright (C) 2024 Ningqi Wang (0xf3cd) <https://github.com/0xf3cd>
 
-from .Common import ShishenDescription, TianganDescription
+from typing import Final
+
+from .Common import ShishenDescription, TianganDescription, frozendict
 from .Defines import Shishen, Tiangan
 
 
 # This table stores the descriptions of each Shishen.
-SHISHEN_DESCRIPTIONS: dict[Shishen, ShishenDescription] = {
+# The corpus tables are frozen: access via `frozendict` returns a deep copy,
+# so the corpus can never be mutated from outside.
+# 语料表是冻结的：通过 `frozendict` 访问返回深拷贝，外部无法篡改语料。
+SHISHEN_DESCRIPTIONS: Final[frozendict[Shishen, ShishenDescription]] = frozendict({
   Shishen.比肩 : {
     'general': [
       '代表同辈、竞争、合作。',
@@ -316,11 +321,11 @@ SHISHEN_DESCRIPTIONS: dict[Shishen, ShishenDescription] = {
       '和他们恋爱，需要敞开心扉，探索生活的多种可能性，也需要欣赏、支持他在生活中的探索和创造。',
     ],
   },
-}
+})
 
 
-# The dictionary for descriptions of the Tiangan.
-TIANGAN_DESCRIPTIONS: dict[Tiangan, TianganDescription] = {
+# The dictionary for descriptions of the Tiangan. Frozen as above. / 天干语料表，同上冻结。
+TIANGAN_DESCRIPTIONS: Final[frozendict[Tiangan, TianganDescription]] = frozendict({
   Tiangan.甲: {
     'general': [
       '甲为阳木，比做参天大树，栋梁之才。',
@@ -439,4 +444,4 @@ TIANGAN_DESCRIPTIONS: dict[Tiangan, TianganDescription] = {
       '若癸水日主身旺癸为忌神，为人表面心如止水，内心想入非非，好幻想，不切实际，喜钻牛角尖。',
     ],
   },
-}
+})

--- a/src/Interpreter.py
+++ b/src/Interpreter.py
@@ -1,9 +1,5 @@
 # Copyright (C) 2024 Ningqi Wang (0xf3cd) <https://github.com/0xf3cd>
 
-import copy
-from typing import Final
-
-from .BaziChart import BaziChart
 from .Defines import Shishen, Tiangan
 from .Common import ShishenDescription, TianganDescription
 from .Descriptions import SHISHEN_DESCRIPTIONS, TIANGAN_DESCRIPTIONS
@@ -11,37 +7,46 @@ from .Descriptions import SHISHEN_DESCRIPTIONS, TIANGAN_DESCRIPTIONS
 
 class Interpreter:
   '''
-  This class takes a BaziChart and interprets it.
+  `Interpreter` statically looks up the curated description corpus (语料库) of
+  Shishen and Tiangan. The corpus tables are frozen, and the returned descriptions
+  are deep copies (see `frozendict` in `Common`), so callers may freely modify them
+  without corrupting the corpus.
+
+  `Interpreter` 以静态方法查询十神和天干的语料库。语料表是冻结的，且返回的描述是
+  深拷贝（见 `Common` 中的 `frozendict`），调用方可随意修改，不会污染语料库。
+
+  Note:
+  - Combining the descriptions against a specific chart (i.e. producing a whole-chart
+    reading) is currently done in the `run_interpreter` entry script, not in this class.
+  - 针对具体命盘组合这些描述（即整盘解读）目前在 `run_interpreter` 入口脚本中完成，不在本类中。
   '''
 
   @staticmethod
   def interpret_shishen(shishen: Shishen) -> ShishenDescription:
-    '''Interpret the given Shishen and return the corresponding description.'''
-    assert isinstance(shishen, Shishen)
-    return copy.deepcopy(SHISHEN_DESCRIPTIONS[shishen])
-  
-  @staticmethod
-  def interpret_tiangan(tg: Tiangan) -> TianganDescription:
-    '''Interpret the given Tiangan and return the description.'''
-    assert isinstance(tg, Tiangan)
-    return copy.deepcopy(TIANGAN_DESCRIPTIONS[tg])
-
-  def __init__(self, chart: BaziChart) -> None:
     '''
-    This method initializes a new instance of the Interpretation class by
-    creating a deep copy of the provided BaziChart object.
+    Look up the description of the given Shishen.
+    查询给定十神的描述。
 
     Args:
-    - chart: (BaziChart) The BaziChart object to be interpreted.
+    - shishen: (Shishen) The Shishen to look up. / 要查询的十神。
 
-    Raises:
-      AssertionError: If the provided chart is not an instance of BaziChart.
+    Returns:
+    - (ShishenDescription) A deep copy of the corpus entry. / 语料库对应条目的深拷贝。
     '''
-    assert isinstance(chart, BaziChart)
-    self._chart: Final[BaziChart] = copy.deepcopy(chart)
+    assert isinstance(shishen, Shishen)
+    return SHISHEN_DESCRIPTIONS[shishen]
 
-    # TODO: To be implemented.
+  @staticmethod
+  def interpret_tiangan(tg: Tiangan) -> TianganDescription:
+    '''
+    Look up the description of the given Tiangan.
+    查询给定天干的描述。
 
-  @property
-  def chart(self) -> BaziChart:
-    return copy.deepcopy(self._chart)
+    Args:
+    - tg: (Tiangan) The Tiangan to look up. / 要查询的天干。
+
+    Returns:
+    - (TianganDescription) A deep copy of the corpus entry. / 语料库对应条目的深拷贝。
+    '''
+    assert isinstance(tg, Tiangan)
+    return TIANGAN_DESCRIPTIONS[tg]

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -5,8 +5,7 @@ import unittest
 
 from src.Common import ShishenDescription, TianganDescription
 from src.Defines import Tiangan, Shishen
-from src.Bazi import Bazi
-from src.BaziChart import BaziChart
+from src.Descriptions import SHISHEN_DESCRIPTIONS, TIANGAN_DESCRIPTIONS
 from src.Interpreter import Interpreter
 
 class TestInterpreter(unittest.TestCase):
@@ -46,7 +45,19 @@ class TestInterpreter(unittest.TestCase):
 
       self.assertEqual(result, Interpreter.interpret_tiangan(tg))
 
-  def test_chart(self) -> None:
-    chart: BaziChart = BaziChart(Bazi.random())
-    interpretation: Interpreter = Interpreter(chart)
-    self.assertEqual(chart.json, interpretation.chart.json)
+  def test_corpus_is_frozen(self) -> None:
+    # The corpus tables are frozen: reassigning an entry must fail, and mutating a
+    # returned description must not corrupt the corpus.
+    # 语料表是冻结的：覆盖条目必须报错；修改返回的描述不能污染语料库。
+    with self.assertRaises(TypeError):
+      SHISHEN_DESCRIPTIONS[Shishen.比肩] = SHISHEN_DESCRIPTIONS[Shishen.比肩] # type: ignore # mypy complains.
+    with self.assertRaises(TypeError):
+      TIANGAN_DESCRIPTIONS[Tiangan.甲] = TIANGAN_DESCRIPTIONS[Tiangan.甲] # type: ignore # mypy complains.
+
+    mutated_shishen: ShishenDescription = Interpreter.interpret_shishen(Shishen.比肩)
+    mutated_shishen['general'].append('污染内容')
+    self.assertNotIn('污染内容', Interpreter.interpret_shishen(Shishen.比肩)['general'])
+
+    mutated_tg: TianganDescription = Interpreter.interpret_tiangan(Tiangan.甲)
+    mutated_tg['general'].append('污染内容')
+    self.assertNotIn('污染内容', Interpreter.interpret_tiangan(Tiangan.甲)['general'])


### PR DESCRIPTION
## 背景

#70 原拟废弃解释层，经讨论方向反转关闭：语料层确认为 repo 的产品功能（自包含排盘 + 基础分析，第三方 fork 在用），不迁 vault。本 PR 只处理原 issue 中仍然成立的卫生项。

## 变更

- **`src/Descriptions.py`**：两张语料表从可变 module-level `dict` 改为 `Final[frozendict[...]]`（与 `Rules.py` 同一不可变惯例）。`frozendict.__getitem__` 返回深拷贝，外部无法再篡改语料。
- **`src/Interpreter.py`**：删除从未实现的 TODO 空壳（`Interpreter(chart)` 构造器 / `.chart` 属性），只保留两个静态查表方法；docstring 双语化（AGENTS.md 知识层规范）。显式 `copy.deepcopy` 移除——防护下沉到表类型。
- **`tests/test_interpreter.py`**：`test_chart`（测空壳）→ `test_corpus_is_frozen`（冻结回归：覆盖条目抛 `TypeError`；改返回副本不污染语料）。

## ⚠️ Breaking（给 fork 用户的披露）

- `Interpreter(chart)` 构造器与 `.chart` 属性已删除（系从未实现的 TODO 空壳）。替代路径：`Interpreter.interpret_shishen` / `Interpreter.interpret_tiangan` 静态方法。失败模式为调用点响亮抛 `TypeError`，非静默漂移。
- 语料表类型 `dict` → `frozendict`：item 赋值抛 `TypeError`；`isinstance(SHISHEN_DESCRIPTIONS, dict)` 不再成立；直接访问现在返回深拷贝（原先是可变共享引用）。

## 门禁

- `ruff check .` ✅
- `mypy`（--check-untyped-defs --warn-redundant-casts --warn-unused-ignores --warn-return-any --warn-unreachable）✅
- `pytest` 243 passed + coverage 100% ✅

## 本地交叉审阅

- **Claude (Fable 5)**：LGTM，无 P0/P1。逐条核验：深拷贝语义不变；mypy 双向推断了了；breaking 披露义务 → 已落实于本节；双语规范符合。P2/NIT 已修（Note 措辞松绑、中文表达、assertNotIn）。
- **Grok**：LGTM，无 P0/P1。P2 为 breaking 披露义务 → 已落实。
- **Codex**：额度用尽（8/25 重置），本轮缺席。

Ref #70（已按方向反转关闭，关闭评论有完整决策记录）。