### PR TITLE
refactor: unified shensha registry & wire up Yima (#68)

### DIFF
--- a/run_relationship_analyzer.py
+++ b/run_relationship_analyzer.py
@@ -17,6 +17,8 @@ def shensha_strs(shensha: ShenshaAnalysis) -> list[str]:
     str_list.append(f'红艳：{", ".join(str(x) for x in dz_fs)}')
   if len(dz_fs := shensha['tianxi']) > 0:
     str_list.append(f'天喜：{", ".join(str(x) for x in dz_fs)}')
+  if len(dz_fs := shensha['yima']) > 0:
+    str_list.append(f'驿马：{", ".join(str(x) for x in dz_fs)}')
   return str_list
 
 
@@ -30,7 +32,7 @@ if __name__ == '__main__':
 
   shensha_str_list = shensha_strs(analyzer.at_birth.shensha)
   if len(shensha_str_list) == 0:
-    print('原局无桃花、红艳、红鸾、天喜星')
+    print('原局无桃花、红艳、红鸾、天喜、驿马星')
   else:
     print('原局神煞：')
     print('\n'.join(shensha_str_list))
@@ -40,7 +42,7 @@ if __name__ == '__main__':
   gz_year = chart.bazi.ganzhi_date.year + 20
   liunian_shensha_str_list = shensha_strs(analyzer.transits.shensha(gz_year, TransitOptions.LIUNIAN))
   if len(liunian_shensha_str_list) == 0:
-    print(f'{gz_year} 流年无桃花、红艳、红鸾、天喜星')
+    print(f'{gz_year} 流年无桃花、红艳、红鸾、天喜、驿马星')
   else:
     print(f'{gz_year} 流年神煞：')
     print('\n'.join(liunian_shensha_str_list))

--- a/src/Analyzer/Relationship.py
+++ b/src/Analyzer/Relationship.py
@@ -3,12 +3,14 @@
 import copy
 import functools
 
-from enum import IntFlag, unique
+from dataclasses import dataclass
+from enum import Enum, IntFlag, auto, unique
 from itertools import starmap, product, compress, chain
 from typing import Final, TypedDict, Callable, Union, Iterable
 
-from ..Common import GanzhiData
+from ..Common import GanzhiData, frozendict
 from ..Defines import Tiangan, Dizhi, Shishen, DizhiRelation
+from ..Bazi import Bazi
 from ..BaziChart import BaziChart
 from ..Transits import TransitOptions, TransitDatabase
 from ..Utils import BaziUtils, ShenshaUtils, TianganUtils, DizhiUtils
@@ -33,6 +35,76 @@ def find_shensha(
   return map(lambda x : x[1], compress(producted_args, results))
 
 
+@unique
+class _KeySource(Enum):
+  '''The key(s) that a Shensha is looked up by (查询神煞时所用的 key).'''
+  YEAR_DIZHI        = auto() # By the year pillar's Dizhi only (只看年支).
+  YEAR_OR_DAY_DIZHI = auto() # By the year or day pillar's Dizhi (看年支或日支).
+  DAY_MASTER        = auto() # By the day master (看日主).
+
+
+@dataclass(frozen=True)
+class _ShenshaSpec:
+  '''
+  The spec of a Shensha: the predicate and the key source (神煞的规格：判断函数和查询 key).
+
+  Note: the predicate's first-parameter type must match `key` (e.g. a `Tiangan`-keyed predicate
+  pairs with `DAY_MASTER`). This contract is guarded by the runtime asserts in `ShenshaUtils`
+  and the registry tests, not by the type system.
+  '''
+  predicate: Callable[..., bool]
+  key:       _KeySource
+
+
+'''The registry of the Shenshas that relationship analysis currently supports (亲密关系分析目前支持的神煞注册表).'''
+_REGISTRY: Final[frozendict[str, _ShenshaSpec]] = frozendict({
+  'taohua'  : _ShenshaSpec(ShenshaUtils.taohua,   _KeySource.YEAR_OR_DAY_DIZHI),
+  'hongyan' : _ShenshaSpec(ShenshaUtils.hongyan,  _KeySource.DAY_MASTER),
+  'hongluan': _ShenshaSpec(ShenshaUtils.hongluan, _KeySource.YEAR_DIZHI),
+  'tianxi'  : _ShenshaSpec(ShenshaUtils.tianxi,   _KeySource.YEAR_DIZHI),
+  'yima'    : _ShenshaSpec(ShenshaUtils.yima,     _KeySource.YEAR_OR_DAY_DIZHI),
+})
+
+
+def _eval_at_birth(spec: _ShenshaSpec, bazi: Bazi) -> frozenset[Dizhi]:
+  '''Evaluate a Shensha against the at-birth Bazi / 在原局上评估某个神煞。'''
+  dm = bazi.day_master
+  y_dz, m_dz, d_dz, h_dz = bazi.four_dizhis
+
+  args: tuple[_ArgsType, ...]
+  if spec.key is _KeySource.YEAR_DIZHI:
+    args = (([y_dz], [m_dz, d_dz, h_dz]),)
+  elif spec.key is _KeySource.YEAR_OR_DAY_DIZHI:
+    args = (([y_dz], [m_dz, d_dz, h_dz]), ([d_dz], [y_dz, m_dz, h_dz]))
+  elif spec.key is _KeySource.DAY_MASTER:
+    args = (([dm], [y_dz, m_dz, d_dz, h_dz]),)
+  else:
+    # Invariant: every `_KeySource` member must be wired up above. Reaching here means we
+    # added a member but forgot to update this evaluator -- not something users can trigger.
+    # `raise` instead of `assert` so the guard survives `python -O`.
+    raise AssertionError(f'`_KeySource` not wired up in `_eval_at_birth`: {spec.key}') # pragma: no cover # Unreachable invariant guard.
+
+  return frozenset(find_shensha(spec.predicate, *args))
+
+
+def _eval_transits(spec: _ShenshaSpec, bazi: Bazi, transit_dizhis: Iterable[Dizhi]) -> frozenset[Dizhi]:
+  '''Evaluate a Shensha against the transit Dizhis / 在流运地支上评估某个神煞。'''
+  first_args: _FirstArgType
+  if spec.key is _KeySource.YEAR_DIZHI:
+    first_args = [bazi.year_pillar.dizhi]
+  elif spec.key is _KeySource.YEAR_OR_DAY_DIZHI:
+    first_args = [bazi.year_pillar.dizhi, bazi.day_pillar.dizhi]
+  elif spec.key is _KeySource.DAY_MASTER:
+    first_args = [bazi.day_master]
+  else:
+    # Invariant: every `_KeySource` member must be wired up above. Reaching here means we
+    # added a member but forgot to update this evaluator -- not something users can trigger.
+    # `raise` instead of `assert` so the guard survives `python -O`.
+    raise AssertionError(f'`_KeySource` not wired up in `_eval_transits`: {spec.key}') # pragma: no cover # Unreachable invariant guard.
+
+  return frozenset(find_shensha(spec.predicate, (first_args, transit_dizhis)))
+
+
 
 class ShenshaAnalysis(TypedDict):
   # The Taohua Dizhis   (桃花星所在地支)
@@ -43,6 +115,8 @@ class ShenshaAnalysis(TypedDict):
   hongluan: frozenset[Dizhi]
   # The Tianxi Dizhis   (天喜星所在地支)
   tianxi:   frozenset[Dizhi]
+  # The Yima Dizhis     (驿马星所在地支)
+  yima:     frozenset[Dizhi]
 
 
 class AtBirthAnalysis:
@@ -52,14 +126,13 @@ class AtBirthAnalysis:
 
   @property
   def shensha(self) -> ShenshaAnalysis:
-    dm = self._chart.bazi.day_master
-    y_dz, m_dz, d_dz, h_dz = self._chart.bazi.four_dizhis
+    bazi = self._chart.bazi
     return {
-      'taohua' :  frozenset(find_shensha(ShenshaUtils.taohua,   ([y_dz],  [m_dz, d_dz, h_dz]), 
-                                                                ([d_dz],  [y_dz, m_dz, h_dz]))),
-      'hongyan':  frozenset(find_shensha(ShenshaUtils.hongyan,  ([dm],    [y_dz, m_dz, d_dz, h_dz]))),
-      'hongluan': frozenset(find_shensha(ShenshaUtils.hongluan, ([y_dz],  [m_dz, d_dz, h_dz]))),
-      'tianxi':   frozenset(find_shensha(ShenshaUtils.tianxi,   ([y_dz],  [m_dz, d_dz, h_dz]))),
+      'taohua' :  _eval_at_birth(_REGISTRY['taohua'],   bazi),
+      'hongyan':  _eval_at_birth(_REGISTRY['hongyan'],  bazi),
+      'hongluan': _eval_at_birth(_REGISTRY['hongluan'], bazi),
+      'tianxi':   _eval_at_birth(_REGISTRY['tianxi'],   bazi),
+      'yima'   :  _eval_at_birth(_REGISTRY['yima'],     bazi),
     }
 
   @property
@@ -106,7 +179,7 @@ class TransitAnalysis:
     '''
     Return the relationship-related Shenshas of the given transits.
 
-    返回给定流年大运等的亲密关系相关的神煞（桃花、红艳、红鸾、天喜）。
+    返回给定流年大运等的亲密关系相关的神煞（桃花、红艳、红鸾、天喜、驿马）。
 
     Args:
     - gz_year: (int) The year of the transits. 流年/小运/大运等的年份。
@@ -120,15 +193,13 @@ class TransitAnalysis:
     transit_ganzhis = self._transit_db.ganzhis(gz_year, options)
     transit_dizhis = tuple(gz.dizhi for gz in transit_ganzhis)
 
-    dm = self._chart.bazi.day_master
-    y_dz = self._chart.bazi.year_pillar.dizhi
-    d_dz = self._chart.bazi.day_pillar.dizhi
-
+    bazi = self._chart.bazi
     return {
-      'taohua' :  frozenset(find_shensha(ShenshaUtils.taohua,   ([y_dz, d_dz], transit_dizhis))),
-      'hongyan':  frozenset(find_shensha(ShenshaUtils.hongyan,  ([dm],         transit_dizhis))),
-      'hongluan': frozenset(find_shensha(ShenshaUtils.hongluan, ([y_dz],       transit_dizhis))),
-      'tianxi':   frozenset(find_shensha(ShenshaUtils.tianxi,   ([y_dz],       transit_dizhis))),
+      'taohua' :  _eval_transits(_REGISTRY['taohua'],   bazi, transit_dizhis),
+      'hongyan':  _eval_transits(_REGISTRY['hongyan'],  bazi, transit_dizhis),
+      'hongluan': _eval_transits(_REGISTRY['hongluan'], bazi, transit_dizhis),
+      'tianxi':   _eval_transits(_REGISTRY['tianxi'],   bazi, transit_dizhis),
+      'yima'   :  _eval_transits(_REGISTRY['yima'],     bazi, transit_dizhis),
     }
   
   def day_master_relations(self, gz_year: int, options: TransitOptions) -> TianganUtils.TianganRelationDiscovery:

--- a/tests/analyzer/test_relationship_analyzer.py
+++ b/tests/analyzer/test_relationship_analyzer.py
@@ -11,7 +11,7 @@ from src.Defines import Tiangan, Dizhi, Shishen, DizhiRelation
 from src.Utils import ShenshaUtils, TianganUtils, DizhiUtils, BaziUtils
 from src.BaziChart import BaziChart
 from src.Transits import TransitOptions, TransitDatabase
-from src.Analyzer.Relationship import RelationshipAnalyzer, TransitAnalysis
+from src.Analyzer.Relationship import RelationshipAnalyzer, TransitAnalysis, ShenshaAnalysis, _REGISTRY
 
 
 class TestAtBirthAnalysis(unittest.TestCase):
@@ -60,6 +60,17 @@ class TestAtBirthAnalysis(unittest.TestCase):
             expected_tianxi.append(dz2)
         self.assertSetEqual(at_birth.shensha['tianxi'], set(expected_tianxi))
         self.assertSetEqual(at_birth.shensha['tianxi'], at_birth.shensha['tianxi'], 'Constancy')
+
+      with self.subTest('Yima / 驿马'):
+        expected_yima: list[Dizhi] = []
+        for dz1, dz2 in itertools.product([y], [m, d, h]):
+          if ShenshaUtils.yima(dz1, dz2):
+            expected_yima.append(dz2)
+        for dz1, dz2 in itertools.product([d], [y, m, h]):
+          if ShenshaUtils.yima(dz1, dz2):
+            expected_yima.append(dz2)
+        self.assertSetEqual(at_birth.shensha['yima'], set(expected_yima))
+        self.assertSetEqual(at_birth.shensha['yima'], at_birth.shensha['yima'], 'Constancy')
 
   @pytest.mark.slow
   def test_day_master_relations(self) -> None:
@@ -203,6 +214,15 @@ class TestTransitAnalysis(unittest.TestCase):
             if ShenshaUtils.tianxi(y_dz, dz):
               expected.append(dz)
           self.assertSetEqual(actual['tianxi'], set(expected))
+
+        with self.subTest('Yima / 驿马'):
+          expected = []
+          for dz in transit_dz:
+            if ShenshaUtils.yima(y_dz, dz):
+              expected.append(dz)
+            if ShenshaUtils.yima(d_dz, dz):
+              expected.append(dz)
+          self.assertSetEqual(actual['yima'], set(expected))
 
   @pytest.mark.slow
   def test_day_master_relations(self) -> None:
@@ -380,3 +400,10 @@ class TestTransitAnalysis(unittest.TestCase):
         actual = transits_analysis.star(randon_year, random_options)
         self.assertEqual(expected_tg, actual.tiangan)
         self.assertEqual(expected_dz, actual.dizhi)
+
+
+class TestShenshaRegistry(unittest.TestCase):
+  def test_registry_matches_shensha_analysis_keys(self) -> None:
+    '''The Shensha registry and `ShenshaAnalysis` must stay in sync / 神煞注册表和 ShenshaAnalysis 的键必须保持同步。'''
+    self.assertSetEqual(set(_REGISTRY.keys()),
+                        set(ShenshaAnalysis.__required_keys__ | ShenshaAnalysis.__optional_keys__))

--- a/tests/integration/test_relationship_analysis.py
+++ b/tests/integration/test_relationship_analysis.py
@@ -83,6 +83,7 @@ class TestRelationshipAnalysis(unittest.TestCase):
       # 问真八字以乙日主见午为红艳，但 `Rules.HONGYAN` 中以乙日主见申为红艳，所以这里为空。
       self.assertSetEqual(at_birth.shensha['hongyan'],  set()) 
       self.assertSetEqual(at_birth.shensha['tianxi'],   set())
+      self.assertSetEqual(at_birth.shensha['yima'],     set())
 
       # 感情分析主要关心日主被合的情况，但原局日主没有被合。
       # 虽然我们不关心相生关系，但在这里还是检查一下。
@@ -112,6 +113,7 @@ class TestRelationshipAnalysis(unittest.TestCase):
       self.assertSetEqual(shensha['hongluan'], set())
       self.assertSetEqual(shensha['hongyan'],  set())
       self.assertSetEqual(shensha['tianxi'],   set())
+      self.assertSetEqual(shensha['yima'],     set())
 
       self.assertTrue(self.__check_tiangan({
         TianganRelation.合 : [frozenset({Tiangan.乙, Tiangan.庚})],
@@ -163,6 +165,7 @@ class TestRelationshipAnalysis(unittest.TestCase):
       self.assertSetEqual(shensha['hongluan'], set())
       self.assertSetEqual(shensha['hongyan'],  set())
       self.assertSetEqual(shensha['tianxi'],   set())
+      self.assertSetEqual(shensha['yima'],     set())
 
       self.assertTrue(self.__check_tiangan({
         TianganRelation.克 : [frozenset({Tiangan.乙, Tiangan.辛}),
@@ -211,6 +214,7 @@ class TestRelationshipAnalysis(unittest.TestCase):
       self.assertSetEqual(shensha['hongluan'], set())
       self.assertSetEqual(shensha['hongyan'],  {Dizhi.申})
       self.assertSetEqual(shensha['tianxi'],   set())
+      self.assertSetEqual(shensha['yima'],     {Dizhi.亥})
 
       self.assertTrue(self.__check_tiangan({
         TianganRelation.克 : [frozenset({Tiangan.乙, Tiangan.辛})],
@@ -262,6 +266,7 @@ class TestRelationshipAnalysis(unittest.TestCase):
       self.assertSetEqual(at_birth.shensha['hongluan'], set())
       self.assertSetEqual(at_birth.shensha['hongyan'],  set()) 
       self.assertSetEqual(at_birth.shensha['tianxi'],   set())
+      self.assertSetEqual(at_birth.shensha['yima'],     set())
 
       # 感情分析主要关心日主被合的情况，但原局日主没有被合。
       # 虽然我们不关心其他关系，但在这里还是检查一下。
@@ -293,6 +298,7 @@ class TestRelationshipAnalysis(unittest.TestCase):
         'hongyan'  : frozenset([Dizhi.寅]),
         'hongluan' : frozenset([Dizhi.卯]),
         'tianxi'   : frozenset([Dizhi.酉]),
+        'yima'     : frozenset([Dizhi.寅, Dizhi.申]),
       }
 
       db = TransitDatabase(chart)
@@ -502,16 +508,21 @@ def test_random_cases(bazi: Bazi) -> None:
       def __taohua(dz: Dizhi) -> bool:
         return ShenshaUtils.taohua(y_dz, dz) or ShenshaUtils.taohua(d_dz, dz)
       
+      def __yima(dz: Dizhi) -> bool:
+        return ShenshaUtils.yima(y_dz, dz) or ShenshaUtils.yima(d_dz, dz)
+
       expected_taohua:   set[Dizhi] = set(filter(__taohua, transits_dz_set))
       expected_hongyan:  set[Dizhi] = set(filter(lambda dz : ShenshaUtils.hongyan(dm, dz), transits_dz_set))
       expected_hongluan: set[Dizhi] = set(filter(lambda dz : ShenshaUtils.hongluan(y_dz, dz), transits_dz_set))
       expected_tianxi:   set[Dizhi] = set(filter(lambda dz : ShenshaUtils.tianxi(y_dz, dz), transits_dz_set))
+      expected_yima:     set[Dizhi] = set(filter(__yima, transits_dz_set))
 
       shensha = transits.shensha(year, option)
       assert expected_taohua == shensha['taohua']
       assert expected_hongyan == shensha['hongyan']
       assert expected_hongluan == shensha['hongluan']
       assert expected_tianxi == shensha['tianxi']
+      assert expected_yima == shensha['yima']
 
   # day master and house relations
   for year in range(bazi.ganzhi_date.year, bazi.ganzhi_date.year + 100):


### PR DESCRIPTION
## Summary

Implements #68: introduces a private Shensha registry in `src/Analyzer/Relationship.py` so that adding a Shensha to relationship analysis becomes a one-line registration, and wires up Yima (驿马) as the first newly-connected Shensha (`ShenshaUtils.yima` / `ShenshaRules.YIMA` already existed but were never connected to the analysis layer). Paves the way for #16 (贵人 / 华盖 / 羊刃 ...).

## Changes

- `src/Analyzer/Relationship.py`
  - `_KeySource` enum — which key a Shensha is looked up by (`YEAR_DIZHI` / `YEAR_OR_DAY_DIZHI` / `DAY_MASTER`).
  - `_ShenshaSpec` frozen dataclass + private `_REGISTRY` (frozendict): taohua, hongyan, hongluan, tianxi, **yima**.
  - Generic evaluators `_eval_at_birth` / `_eval_transits` replace the per-Shensha hardcoded `find_shensha` calls — point-wise equivalent to the previous logic.
  - `ShenshaAnalysis` gains the `yima` key. Both `shensha` constructors are now uniform one-line-per-Shensha **literal** dicts (kept literal rather than comprehension-derived, so mypy checks TypedDict completeness; the registry guard test checks the other direction).
  - Evaluators exhaustively `elif` over `_KeySource` and end with `raise AssertionError(...)  # pragma: no cover`, mirroring the `CalendarBackend.py:73` idiom — a future `_KeySource` member that forgets to update an evaluator fails loudly on first test run instead of silently evaluating as `DAY_MASTER`.
- Tests
  - Unit: Yima subtests in both `test_shensha` (recompute-oracle style, mirroring Taohua); new `TestShenshaRegistry` guard asserting `_REGISTRY.keys() == ShenshaAnalysis.__required_keys__ | __optional_keys__`.
  - Integration: Yima assertions at all fixed-chart spots (2031 = `{亥}`, others `∅` — values produced by running the code, then independently hand-verified by both reviewers); the whole-dict `assertDictEqual` spot gains `'yima': {寅, 申}`; `test_random_cases` gains the `__yima` oracle.
- `run_relationship_analyzer.py`: prints 驿马; fallback texts updated.

## Local gates (all green)

- `ruff check .` ✓
- `mypy --check-untyped-defs --warn-redundant-casts --warn-unused-ignores --warn-return-any --warn-unreachable` — 49 files ✓
- `coverage run -m pytest tests/` — 244 tests passed, **100%** coverage ✓

## Local cross-review (pre-push)

Reviewed by Claude (Fable 5) and Grok on the uncommitted diff. Both independently re-verified the pair-by-pair equivalence table, the Yima table semantics, and every new expected value. One P1 (bare `else` silently catching future `_KeySource` members) was fixed and re-reviewed → accepted. Remaining findings were P2/P3-level and either adopted (TypedDict introspection-based guard, spec docstring contract note, docstring wording) or declined with evidence (pre-existing 3-blank-line separators; fallback text ordering predates this PR).

Closes #68
