### PR TITLE
refactor: TransitMoment key abstraction & TransitChart facade unification (#67)

### DIFF
--- a/src/Analyzer/Relationship.py
+++ b/src/Analyzer/Relationship.py
@@ -12,7 +12,8 @@ from ..Common import GanzhiData, frozendict
 from ..Defines import Tiangan, Dizhi, Shishen, DizhiRelation
 from ..Bazi import Bazi
 from ..BaziChart import BaziChart
-from ..Transits import TransitOptions, TransitDatabase
+from ..Transits import TransitMoment, TransitOptions
+from ..TransitChart import TransitChart
 from ..Utils import BaziUtils, ShenshaUtils, TianganUtils, DizhiUtils
 
 
@@ -167,13 +168,13 @@ class TransitAnalysis:
   '''Analysis of Relationship at Transits / 流年大运等的亲密关系分析'''
   def __init__(self, chart: BaziChart) -> None:
     self._chart: Final[BaziChart] = copy.deepcopy(chart)
-    self._transit_db: Final[TransitDatabase] = TransitDatabase(chart)
+    self._transit_chart: Final[TransitChart] = TransitChart(self._chart)
 
   def support(self, gz_year: int, options: TransitOptions) -> bool:
     '''
     Returns `True` if the given `gz_year` and `options` are both supported.
     '''
-    return self._transit_db.support(gz_year, options)
+    return self._transit_chart.support(TransitMoment(gz_year), options)
 
   def shensha(self, gz_year: int, options: TransitOptions) -> ShenshaAnalysis:
     '''
@@ -190,7 +191,7 @@ class TransitAnalysis:
     '''
 
     assert self.support(gz_year, options)
-    transit_ganzhis = self._transit_db.ganzhis(gz_year, options)
+    transit_ganzhis = self._transit_chart.ganzhis(TransitMoment(gz_year), options)
     transit_dizhis = tuple(gz.dizhi for gz in transit_ganzhis)
 
     bazi = self._chart.bazi
@@ -216,7 +217,7 @@ class TransitAnalysis:
     '''
 
     assert self.support(gz_year, options)
-    transit_ganzhis = self._transit_db.ganzhis(gz_year, options)
+    transit_ganzhis = self._transit_chart.ganzhis(TransitMoment(gz_year), options)
     transit_tiangans = tuple(gz.tiangan for gz in transit_ganzhis)
 
     return TianganUtils.discover_mutual([self._chart.bazi.day_master], transit_tiangans)
@@ -235,7 +236,7 @@ class TransitAnalysis:
     '''
 
     assert self.support(gz_year, options)
-    transit_ganzhis = self._transit_db.ganzhis(gz_year, options)
+    transit_ganzhis = self._transit_chart.ganzhis(TransitMoment(gz_year), options)
     transit_dizhis = [gz.dizhi for gz in transit_ganzhis]
 
     house = self._chart.house_of_relationship
@@ -300,7 +301,7 @@ class TransitAnalysis:
     assert level in TransitAnalysis.Level
     assert self.support(gz_year, options)
 
-    transit_ganzhis = self._transit_db.ganzhis(gz_year, options)
+    transit_ganzhis = self._transit_chart.ganzhis(TransitMoment(gz_year), options)
     transit_tg = tuple(gz.tiangan for gz in transit_ganzhis)
     transit_dz = tuple(gz.dizhi for gz in transit_ganzhis)
 
@@ -338,7 +339,7 @@ class TransitAnalysis:
     assert self.support(gz_year, options)
   
     f = functools.partial(BaziUtils.shishen, self._chart.bazi.day_master)
-    transit_ganzhis = self._transit_db.ganzhis(gz_year, options)
+    transit_ganzhis = self._transit_chart.ganzhis(TransitMoment(gz_year), options)
 
     return GanzhiData(
       any(f(gz.tiangan) is Shishen.正印 for gz in transit_ganzhis),
@@ -361,7 +362,7 @@ class TransitAnalysis:
     assert self.support(gz_year, options)
 
     stars = self._chart.relationship_stars
-    transit_ganzhis = self._transit_db.ganzhis(gz_year, options)
+    transit_ganzhis = self._transit_chart.ganzhis(TransitMoment(gz_year), options)
 
     return GanzhiData(
       any(gz.tiangan is stars.tiangan for gz in transit_ganzhis),

--- a/src/TransitChart.py
+++ b/src/TransitChart.py
@@ -6,7 +6,7 @@ from typing import Final
 
 from .Defines import Ganzhi
 from .BaziChart import BaziChart
-from .Transits import TransitOptions, TransitDatabase
+from .Transits import TransitMoment, TransitOptions, TransitDatabase
 
 
 class TransitChart:
@@ -37,37 +37,41 @@ class TransitChart:
     '''The underlying `BaziChart` (原盘). A defensive copy is returned. 返回防御性拷贝。'''
     return copy.deepcopy(self._bazi_chart)
 
-  def support(self, gz_year: int, options: TransitOptions) -> bool:
+  def support(self, moment: TransitMoment, options: TransitOptions) -> bool:
     '''
-    Return whether the given `gz_year` and `options` are supported by this `TransitChart`.
-    返回当前 `TransitChart` 是否支持给定的干支年和选项。
+    Return whether the given `moment` and `options` are supported by this `TransitChart`.
+    返回当前 `TransitChart` 是否支持给定的时刻和选项。
 
     Args:
-    - `gz_year`: (int) The year in Ganzhi calendar. 干支纪年法中的年。
+    - `moment`: (TransitMoment) The moment in Ganzhi calendar. 干支历法中的时刻。Only the year granularity is supported for now (目前仅支持年粒度)。
     - `options`: (TransitOptions) Specifies the transits to be picked. 用于指定是否考虑流年、小运、大运等。
 
-    Return: (bool) Whether the given `gz_year` and `options` are supported by this `TransitChart`.
+    Return: (bool) Whether the given `moment` and `options` are supported by this `TransitChart`.
+
+    Note: raises `NotImplementedError` for month/day-granularity moments until #48. / 注意：#48 落地前，月/日粒度的 moment 会抛 `NotImplementedError`。
     '''
 
-    assert isinstance(gz_year, int)
+    assert isinstance(moment, TransitMoment)
     assert isinstance(options, TransitOptions) and options in TransitOptions
-    return self._transit_db.support(gz_year, options)
+    return self._transit_db.support(moment, options)
 
-  def ganzhis(self, gz_year: int, options: TransitOptions) -> tuple[Ganzhi, ...]:
+  def ganzhis(self, moment: TransitMoment, options: TransitOptions) -> tuple[Ganzhi, ...]:
     '''
-    Return the Ganzhis of the selected transits for the given `gz_year` and `options`.
+    Return the Ganzhis of the selected transits for the given `moment` and `options`.
     返回所选中的小运、大运或流年等对应的干支。
 
     Args:
-    - `gz_year`: (int) The year in Ganzhi calendar, mainly used to compute the transit pillars. 干支纪年法中的年，主要用于计算运（小运/大运/流年）的天干地支。
+    - `moment`: (TransitMoment) The moment in Ganzhi calendar, mainly used to compute the transit pillars. 干支历法中的时刻，主要用于计算运（小运/大运/流年）的天干地支。Only the year granularity is supported for now (目前仅支持年粒度)。
     - `options`: (TransitOptions) Specifies the pillars to be picked from transits. 用于指定是否考虑流年、小运、大运等。
 
-    Return: (tuple[Ganzhi, ...]) The Ganzhis of the selected transits for the given `gz_year` and `options`.
+    Return: (tuple[Ganzhi, ...]) The Ganzhis of the selected transits for the given `moment` and `options`.
+
+    Note: raises `NotImplementedError` for month/day-granularity moments until #48 (via `TransitDatabase`). / 注意：#48 落地前，月/日粒度的 moment 会抛 `NotImplementedError`（经 `TransitDatabase` 冒出）。
     '''
 
-    assert isinstance(gz_year, int)
+    assert isinstance(moment, TransitMoment)
     assert isinstance(options, TransitOptions) and options in TransitOptions
-    return self._transit_db.ganzhis(gz_year, options)
+    return self._transit_db.ganzhis(moment, options)
 
 
 流年大运 = TransitChart

--- a/src/TransitChart.py
+++ b/src/TransitChart.py
@@ -6,7 +6,7 @@ from typing import Final
 
 from .Defines import Ganzhi
 from .BaziChart import BaziChart
-from .Transits import TransitMoment, TransitOptions, TransitDatabase
+from .Transits import TransitMoment, TransitOptions, TransitDatabase, _ALL_OPTIONS
 
 
 class TransitChart:
@@ -52,7 +52,9 @@ class TransitChart:
     '''
 
     assert isinstance(moment, TransitMoment)
-    assert isinstance(options, TransitOptions) and options in TransitOptions
+    assert isinstance(options, TransitOptions)
+    # `options in TransitOptions` rejects unnamed composites on Python 3.11; check the enumerated space instead.
+    assert options in _ALL_OPTIONS
     return self._transit_db.support(moment, options)
 
   def ganzhis(self, moment: TransitMoment, options: TransitOptions) -> tuple[Ganzhi, ...]:
@@ -70,7 +72,9 @@ class TransitChart:
     '''
 
     assert isinstance(moment, TransitMoment)
-    assert isinstance(options, TransitOptions) and options in TransitOptions
+    assert isinstance(options, TransitOptions)
+    # `options in TransitOptions` rejects unnamed composites on Python 3.11; check the enumerated space instead.
+    assert options in _ALL_OPTIONS
     return self._transit_db.ganzhis(moment, options)
 
 

--- a/src/Transits.py
+++ b/src/Transits.py
@@ -143,7 +143,9 @@ class TransitDatabase:
 
     assert isinstance(moment, TransitMoment)
     assert isinstance(options, TransitOptions)
-    assert options in TransitOptions
+    # `options in TransitOptions` rejects unnamed composites (e.g. XIAOYUN|DAYUN) on
+    # Python 3.11 (EnumType.__contains__ semantics), so check the enumerated space instead.
+    assert options in _ALL_OPTIONS
     _ensure_year_moment(moment)
 
     gz_year: Final[int] = moment.gz_year
@@ -175,7 +177,9 @@ class TransitDatabase:
     '''
 
     assert isinstance(moment, TransitMoment)
-    assert isinstance(options, TransitOptions) and options in TransitOptions
+    assert isinstance(options, TransitOptions)
+    # See `support` for why `_ALL_OPTIONS` instead of `options in TransitOptions` (3.11 semantics).
+    assert options in _ALL_OPTIONS
 
     if not self.support(moment, options):
       raise ValueError(f'Inputs not supported. Moment: {moment}, options: {options}')

--- a/src/Transits.py
+++ b/src/Transits.py
@@ -2,11 +2,14 @@
 
 import random
 
+from dataclasses import dataclass
+from datetime import date
 from enum import unique, IntFlag
+from itertools import combinations
 from typing import Final, Generator
 
 from .Common import DayunTuple, frozendict
-from .Defines import Ganzhi
+from .Defines import Ganzhi, Dizhi
 from .Calendar import CalendarDate
 from .Utils.BaziUtils import ganzhi_of_year
 from .BaziChart import BaziChart
@@ -35,6 +38,46 @@ class DayunDatabase:
     return DayunTuple(expected_gz_year, self._cache[expected_gz_year])
 
 
+@dataclass(frozen=True)
+class TransitMoment:
+  '''
+  The moment that a transit refers to (运作用的时刻).
+
+  Only the year granularity is supported for now -- pass `gz_year` only.
+  `gz_month` (for 流月) and `solar_date` (for 流日) are reserved for #48.
+  目前仅支持年粒度——只传 `gz_year` 即可。`gz_month`（流月用）和 `solar_date`（流日用）为 #48 预留。
+
+  Invariant (unchecked here): `gz_year` is always the Ganzhi year (立春分界), and when
+  `solar_date` is set, `gz_year` must be the Ganzhi year that `solar_date` falls in.
+  The caller is responsible for now; `TransitDatabase` will enforce this when #48 lands
+  (it has calendar access; this value type must not).
+  不变量（此处不校验）：`gz_year` 始终是干支年（立春分界）；传入 `solar_date` 时，`gz_year`
+  必须是 `solar_date` 所属的干支年。暂时由调用方负责；#48 落地时由 `TransitDatabase` 强制
+  （它能访问历法，而本值类型不应绑定历法后端）。
+  '''
+  gz_year:    int
+  gz_month:   Dizhi | None = None # The month's Dizhi (月支; 节气月, 正月建寅), for 流月.
+  solar_date: date | None = None  # The solar date (公历日期), for 流日.
+
+  def __post_init__(self) -> None:
+    # Type check at runtime. Note `datetime` is a subclass of `date` but breaks the value
+    # semantics (a `datetime` never equals a `date`, and their hashes differ), so require
+    # the exact type here. 运行时类型检查。datetime 是 date 的子类但破坏值语义（不相等、
+    # hash 不同），故此处要求精确类型。
+    assert isinstance(self.gz_year, int)
+    assert self.gz_month is None or isinstance(self.gz_month, Dizhi)
+    assert self.solar_date is None or type(self.solar_date) is date
+    # The month and day granularities are mutually exclusive: a day's Ganzhi is fully
+    # determined by `solar_date`, no `gz_month` needed. 月粒度与日粒度互斥（日柱由 solar_date 唯一确定）。
+    assert not (self.gz_month is not None and self.solar_date is not None)
+
+
+def _ensure_year_moment(moment: TransitMoment) -> None:
+  '''Only the year granularity is supported before #48 lands; reject the other granularities explicitly. / #48 落地前仅支持年粒度，其余粒度显式拒绝。'''
+  if moment.gz_month is not None or moment.solar_date is not None:
+    raise NotImplementedError(f'Only year-granularity transits are supported for now (目前仅支持年粒度的运): {moment}')
+
+
 @unique
 class TransitOptions(IntFlag):
   '''Specifies whether Dayun / Xiaoyun / Liunian transits should be considered. 用于指定是否考虑大运流年、小运、流年等。'''
@@ -47,15 +90,28 @@ class TransitOptions(IntFlag):
   @staticmethod
   def random() -> 'TransitOptions':
     '''Mainly for testing purpose.'''
-    # `list(TransitOptions)` only yields single-bit members on Python 3.11+,
-    # silently dropping the composite options. So explicitly list all options here.
-    return random.choice([
-      TransitOptions.XIAOYUN,
-      TransitOptions.DAYUN,
-      TransitOptions.LIUNIAN,
-      TransitOptions.XIAOYUN_LIUNIAN,
-      TransitOptions.DAYUN_LIUNIAN,
-    ])
+    return random.choice(_ALL_OPTIONS)
+
+
+def _all_options() -> list[TransitOptions]:
+  '''
+  All non-empty combinations of the single-bit `TransitOptions` members.
+  The enumeration follows new transit kinds (e.g. 流月/流日 in #48) automatically --
+  but wiring up their semantics in `support`/`ganzhis` is still required separately.
+  单 bit 成员的全部非空组合——枚举随新增运种类（如 #48 的流月/流日）自动跟随，但语义接线仍需同步修改 `support`/`ganzhis`。
+  '''
+  # `list(TransitOptions)` only yields single-bit members on Python 3.11+,
+  # silently dropping the composite options. Filter defensively anyway.
+  singles: list[TransitOptions] = [opt for opt in TransitOptions if opt.value > 0 and opt.value & (opt.value - 1) == 0]
+  return [
+    TransitOptions(sum(opt.value for opt in combo))
+    for r in range(1, len(singles) + 1)
+    for combo in combinations(singles, r)
+  ]
+
+
+'''The constant option space for `TransitOptions.random()` / `random()` 的常量选项空间。'''
+_ALL_OPTIONS: Final[tuple[TransitOptions, ...]] = tuple(_all_options())
 
 
 class TransitDatabase:
@@ -72,21 +128,25 @@ class TransitDatabase:
     self._first_dayun_start_gz_year: Final[int] = next(chart.dayun).ganzhi_year
     self._dayun_db: Final[DayunDatabase] = DayunDatabase(chart)
 
-  def support(self, gz_year: int, options: TransitOptions) -> bool:
+  def support(self, moment: TransitMoment, options: TransitOptions) -> bool:
     '''
-    Return whether the given `gz_year` and `option` are supported by this `TransitDatabase`.
+    Return whether the given `moment` and `option` are supported by this `TransitDatabase`.
 
     Args:
-    - `gz_year`: The year in Ganzhi calendar, mainly used to compute the transit pillars. 干支纪年法中的年，主要用于计算运（小运/大运/流年）的天干地支。
+    - `moment`: The moment in Ganzhi calendar, mainly used to compute the transit pillars. 干支历法中的时刻，主要用于计算运（小运/大运/流年）的天干地支。Only the year granularity is supported for now (目前仅支持年粒度)。
     - `options`: Specifies the pillars to be picked from transits. 用于指定是否考虑流年、小运、大运等。
 
-    Return: (bool) Whether the given `gz_year` and `options` are supported by this `TransitDatabase`.
+    Return: (bool) Whether the given `moment` and `options` are supported by this `TransitDatabase`.
+
+    Note: raises `NotImplementedError` for month/day-granularity moments until #48. / 注意：#48 落地前，月/日粒度的 moment 会抛 `NotImplementedError`。
     '''
 
-    assert isinstance(gz_year, int)
+    assert isinstance(moment, TransitMoment)
     assert isinstance(options, TransitOptions)
     assert options in TransitOptions
+    _ensure_year_moment(moment)
 
+    gz_year: Final[int] = moment.gz_year
     if options.value & TransitOptions.XIAOYUN.value:
       if gz_year not in self._xiaoyun_ganzhis:
         return False
@@ -99,25 +159,28 @@ class TransitDatabase:
 
     return True
 
-  def ganzhis(self, gz_year: int, options: TransitOptions) -> tuple[Ganzhi, ...]:
+  def ganzhis(self, moment: TransitMoment, options: TransitOptions) -> tuple[Ganzhi, ...]:
     '''
-    Return the Ganzhis of the selected transits for the given `gz_year` and `option`.
+    Return the Ganzhis of the selected transits for the given `moment` and `option`.
 
     返回所选中的小运、大运或流年等对应的干支。
 
     Args:
-    - `gz_year`: The year in Ganzhi calendar, mainly used to compute the transit pillars. 干支纪年法中的年，主要用于计算运（小运/大运/流年）的天干地支。
+    - `moment`: The moment in Ganzhi calendar, mainly used to compute the transit pillars. 干支历法中的时刻，主要用于计算运（小运/大运/流年）的天干地支。Only the year granularity is supported for now (目前仅支持年粒度)。
     - `options`: Specifies the pillars to be picked from transits. 用于指定是否考虑流年、小运、大运等。
 
-    Return: (tuple[Ganzhi, ...]) The Ganzhis of the selected transits for the given `gz_year` and `options`.
+    Return: (tuple[Ganzhi, ...]) The Ganzhis of the selected transits for the given `moment` and `options`.
+
+    Note: raises `NotImplementedError` for month/day-granularity moments until #48 (via `support`). / 注意：#48 落地前，月/日粒度的 moment 会抛 `NotImplementedError`（经 `support` 冒出）。
     '''
 
-    assert isinstance(gz_year, int)
+    assert isinstance(moment, TransitMoment)
     assert isinstance(options, TransitOptions) and options in TransitOptions
 
-    if not self.support(gz_year, options):
-      raise ValueError(f'Inputs not supported. Year: {gz_year}, options: {options}')
+    if not self.support(moment, options):
+      raise ValueError(f'Inputs not supported. Moment: {moment}, options: {options}')
 
+    gz_year: Final[int] = moment.gz_year
     transit_ganzhis: list[Ganzhi] = []
     if options.value & TransitOptions.XIAOYUN.value:
       assert gz_year in self._xiaoyun_ganzhis

--- a/tests/analyzer/test_relationship_analyzer.py
+++ b/tests/analyzer/test_relationship_analyzer.py
@@ -10,7 +10,7 @@ import itertools
 from src.Defines import Tiangan, Dizhi, Shishen, DizhiRelation
 from src.Utils import ShenshaUtils, TianganUtils, DizhiUtils, BaziUtils
 from src.BaziChart import BaziChart
-from src.Transits import TransitOptions, TransitDatabase
+from src.Transits import TransitMoment, TransitOptions, TransitDatabase
 from src.Analyzer.Relationship import RelationshipAnalyzer, TransitAnalysis, ShenshaAnalysis, _REGISTRY
 
 
@@ -182,7 +182,7 @@ class TestTransitAnalysis(unittest.TestCase):
         if not transits_analysis.support(randon_year, random_options):
           continue
 
-        transit_dz = tuple(gz.dizhi for gz in db.ganzhis(randon_year, random_options))
+        transit_dz = tuple(gz.dizhi for gz in db.ganzhis(TransitMoment(randon_year), random_options))
         actual = transits_analysis.shensha(randon_year, random_options)
 
         with self.subTest('Taohua / 桃花'):
@@ -238,7 +238,7 @@ class TestTransitAnalysis(unittest.TestCase):
         if not transits_analysis.support(randon_year, random_options):
           continue
         
-        transit_tg = tuple(gz.tiangan for gz in db.ganzhis(randon_year, random_options))
+        transit_tg = tuple(gz.tiangan for gz in db.ganzhis(TransitMoment(randon_year), random_options))
         expected = TianganUtils.discover_mutual([chart.bazi.day_master], transit_tg)
         actual = transits_analysis.day_master_relations(randon_year, random_options)
 
@@ -260,7 +260,7 @@ class TestTransitAnalysis(unittest.TestCase):
         if not transits_analysis.support(randon_year, random_options):
           continue
 
-        transit_dz = list(gz.dizhi for gz in db.ganzhis(randon_year, random_options))
+        transit_dz = list(gz.dizhi for gz in db.ganzhis(TransitMoment(randon_year), random_options))
 
         actual = transits_analysis.house_relations(randon_year, random_options)
         for _, combos in actual.items():
@@ -305,8 +305,8 @@ class TestTransitAnalysis(unittest.TestCase):
         if not transits_analysis.support(randon_year, random_options):
           continue
         
-        transit_tg = tuple(gz.tiangan for gz in db.ganzhis(randon_year, random_options))
-        transit_dz = tuple(gz.dizhi for gz in db.ganzhis(randon_year, random_options))
+        transit_tg = tuple(gz.tiangan for gz in db.ganzhis(TransitMoment(randon_year), random_options))
+        transit_dz = tuple(gz.dizhi for gz in db.ganzhis(TransitMoment(randon_year), random_options))
 
         tg_discovery = TianganUtils.TianganRelationDiscovery({})
         dz_discovery = DizhiUtils.DizhiRelationDiscovery({})
@@ -365,7 +365,7 @@ class TestTransitAnalysis(unittest.TestCase):
 
         expected_tg: bool = False
         expected_dz: bool = False
-        for gz in db.ganzhis(randon_year, random_options):
+        for gz in db.ganzhis(TransitMoment(randon_year), random_options):
           if BaziUtils.shishen(chart.bazi.day_master, gz.tiangan) == Shishen.正印:
             expected_tg = True
           if BaziUtils.shishen(chart.bazi.day_master, gz.dizhi) == Shishen.正印:
@@ -391,7 +391,7 @@ class TestTransitAnalysis(unittest.TestCase):
 
         expected_tg: bool = False
         expected_dz: bool = False
-        for gz in db.ganzhis(randon_year, random_options):
+        for gz in db.ganzhis(TransitMoment(randon_year), random_options):
           if gz.tiangan == chart.relationship_stars.tiangan:
             expected_tg = True
           if gz.dizhi in chart.relationship_stars.dizhi:

--- a/tests/integration/test_ganzhi_relations.py
+++ b/tests/integration/test_ganzhi_relations.py
@@ -8,7 +8,7 @@ from datetime import datetime
 
 from src.Bazi import Bazi, BaziGender, BaziPrecision
 from src.BaziChart import BaziChart
-from src.Transits import TransitOptions, TransitDatabase
+from src.Transits import TransitMoment, TransitOptions, TransitDatabase
 from src.Defines import Tiangan, Dizhi, Ganzhi, TianganRelation, DizhiRelation
 from src.Utils import TianganUtils, DizhiUtils
 
@@ -82,7 +82,7 @@ class TestTianganDizhiRelations(unittest.TestCase):
       }, DizhiUtils.discover(chart.bazi.four_dizhis)))
 
     with self.subTest('1993 dayun and liunian - transits only'):
-      ganzhis = db.ganzhis(1993, TransitOptions.DAYUN_LIUNIAN)
+      ganzhis = db.ganzhis(TransitMoment(1993), TransitOptions.DAYUN_LIUNIAN)
 
       self.assertTrue(self.__check_tiangan({
         TianganRelation.合 : [frozenset({Tiangan.戊, Tiangan.癸})],
@@ -93,7 +93,7 @@ class TestTianganDizhiRelations(unittest.TestCase):
       }, DizhiUtils.discover(tuple(gz.dizhi for gz in ganzhis))))
 
     with self.subTest('2024 dayun and liunian - between transits and at-birth'):
-      ganzhis = db.ganzhis(2024, TransitOptions.DAYUN_LIUNIAN)
+      ganzhis = db.ganzhis(TransitMoment(2024), TransitOptions.DAYUN_LIUNIAN)
 
       self.assertTrue(self.__check_tiangan({
         TianganRelation.克 : [frozenset({Tiangan.丁, Tiangan.辛}), frozenset({Tiangan.辛, Tiangan.乙})],
@@ -109,7 +109,7 @@ class TestTianganDizhiRelations(unittest.TestCase):
       }, DizhiUtils.discover_mutual(bazi.four_dizhis, tuple(gz.dizhi for gz in ganzhis))))
 
     with self.subTest('2051 dayun and liunian - transits only'):
-      ganzhis = db.ganzhis(2051, TransitOptions.DAYUN_LIUNIAN)
+      ganzhis = db.ganzhis(TransitMoment(2051), TransitOptions.DAYUN_LIUNIAN)
 
       self.assertTrue(self.__check_dizhi({
         DizhiRelation.破 : [frozenset({Dizhi.戌, Dizhi.未})],
@@ -117,7 +117,7 @@ class TestTianganDizhiRelations(unittest.TestCase):
       }, DizhiUtils.discover(tuple(gz.dizhi for gz in ganzhis))))
 
     with self.subTest('2051 dayun and liunian - between transits and at-birth'):
-      ganzhis = db.ganzhis(2051, TransitOptions.DAYUN_LIUNIAN)
+      ganzhis = db.ganzhis(TransitMoment(2051), TransitOptions.DAYUN_LIUNIAN)
 
       self.assertTrue(self.__check_tiangan({
         TianganRelation.克 : [frozenset({Tiangan.丁, Tiangan.辛}), frozenset({Tiangan.辛, Tiangan.乙})],
@@ -165,7 +165,7 @@ class TestTianganDizhiRelations(unittest.TestCase):
 
     with self.subTest('2024 xiaoyun and liunian - between transits and at-birth'): 
       # 测测's Xiaoyun result is kinda buggy. So use 问真八字's Xiaoyun result here.
-      ganzhis = db.ganzhis(2024, TransitOptions.XIAOYUN_LIUNIAN)
+      ganzhis = db.ganzhis(TransitMoment(2024), TransitOptions.XIAOYUN_LIUNIAN)
 
       self.assertTrue(self.__check_tiangan({
         TianganRelation.合 : [frozenset({Tiangan.甲, Tiangan.己})],
@@ -179,7 +179,7 @@ class TestTianganDizhiRelations(unittest.TestCase):
       }, DizhiUtils.discover_mutual(bazi.four_dizhis, tuple(gz.dizhi for gz in ganzhis))))
 
     with self.subTest('2052 dayun and liunian - transits only'):
-      ganzhis = db.ganzhis(2052, TransitOptions.DAYUN_LIUNIAN)
+      ganzhis = db.ganzhis(TransitMoment(2052), TransitOptions.DAYUN_LIUNIAN)
 
       self.assertTrue(self.__check_tiangan({
         TianganRelation.冲 : [frozenset({Tiangan.丙, Tiangan.壬})],
@@ -191,7 +191,7 @@ class TestTianganDizhiRelations(unittest.TestCase):
       }, DizhiUtils.discover(tuple(gz.dizhi for gz in ganzhis))))
 
     with self.subTest('2052 dayun and liunian - between transits and at-birth'):
-      ganzhis = db.ganzhis(2052, TransitOptions.DAYUN_LIUNIAN)
+      ganzhis = db.ganzhis(TransitMoment(2052), TransitOptions.DAYUN_LIUNIAN)
 
       self.assertTrue(self.__check_tiangan({
         TianganRelation.合 : [frozenset({Tiangan.丙, Tiangan.辛})],
@@ -206,14 +206,14 @@ class TestTianganDizhiRelations(unittest.TestCase):
       }, DizhiUtils.discover_mutual(bazi.four_dizhis, tuple(gz.dizhi for gz in ganzhis))))
 
     with self.subTest('2062 dayun and liunian - transits only'):
-      ganzhis = db.ganzhis(2062, TransitOptions.DAYUN_LIUNIAN)
+      ganzhis = db.ganzhis(TransitMoment(2062), TransitOptions.DAYUN_LIUNIAN)
 
       self.assertTrue(self.__check_dizhi({
         DizhiRelation.害 : [frozenset({Dizhi.丑, Dizhi.午})],
       }, DizhiUtils.discover(tuple(gz.dizhi for gz in ganzhis))))
 
     with self.subTest('2062 dayun and liunian - between transits and at-birth'):
-      ganzhis = db.ganzhis(2062, TransitOptions.DAYUN_LIUNIAN)
+      ganzhis = db.ganzhis(TransitMoment(2062), TransitOptions.DAYUN_LIUNIAN)
 
       self.assertTrue(self.__check_tiangan({
         TianganRelation.冲 : [frozenset({Tiangan.乙, Tiangan.辛})],

--- a/tests/integration/test_relationship_analysis.py
+++ b/tests/integration/test_relationship_analysis.py
@@ -13,7 +13,7 @@ from src.Defines import Tiangan, Dizhi, Ganzhi, TianganRelation, DizhiRelation, 
 from src.Utils import TianganUtils, DizhiUtils, BaziUtils, ShenshaUtils
 from src.Bazi import Bazi, BaziGender, BaziPrecision
 from src.BaziChart import BaziChart
-from src.Transits import TransitOptions, TransitDatabase
+from src.Transits import TransitMoment, TransitOptions, TransitDatabase
 from src.Analyzer.Relationship import RelationshipAnalyzer, ShenshaAnalysis, TransitAnalysis, AtBirthAnalysis
 from src.Rules import DizhiRules
 
@@ -105,7 +105,7 @@ class TestRelationshipAnalysis(unittest.TestCase):
       self.assertEqual(len(at_birth.star_relations.dizhi), 0)
 
     with self.subTest('1990'):
-      self.assertSetEqual(set(db.ganzhis(1990, TransitOptions.DAYUN_LIUNIAN)),
+      self.assertSetEqual(set(db.ganzhis(TransitMoment(1990), TransitOptions.DAYUN_LIUNIAN)),
                           {Ganzhi.from_str('戊辰'), Ganzhi.from_str('庚午')})
 
       shensha = transits.shensha(1990, TransitOptions.DAYUN_LIUNIAN)
@@ -157,7 +157,7 @@ class TestRelationshipAnalysis(unittest.TestCase):
       self.assertFalse(transits.star(1990, TransitOptions.LIUNIAN).dizhi)
 
     with self.subTest('2018'):
-      self.assertSetEqual(set(db.ganzhis(2018, TransitOptions.DAYUN_LIUNIAN)),
+      self.assertSetEqual(set(db.ganzhis(TransitMoment(2018), TransitOptions.DAYUN_LIUNIAN)),
                           {Ganzhi.from_str('辛未'), Ganzhi.from_str('戊戌')})
       
       shensha = transits.shensha(2018, TransitOptions.DAYUN_LIUNIAN)
@@ -206,7 +206,7 @@ class TestRelationshipAnalysis(unittest.TestCase):
       self.assertFalse(transits.star(2018, TransitOptions.DAYUN).dizhi)
 
     with self.subTest('2031'):
-      self.assertSetEqual(set(db.ganzhis(2031, TransitOptions.DAYUN_LIUNIAN)),
+      self.assertSetEqual(set(db.ganzhis(TransitMoment(2031), TransitOptions.DAYUN_LIUNIAN)),
                           {Ganzhi.from_str('辛亥'), Ganzhi.from_str('壬申')})
 
       shensha = transits.shensha(2031, TransitOptions.DAYUN_LIUNIAN)
@@ -308,7 +308,7 @@ class TestRelationshipAnalysis(unittest.TestCase):
         if not transits.support(random_year, random_option):
           continue
 
-        transits_gz = db.ganzhis(random_year, random_option)
+        transits_gz = db.ganzhis(TransitMoment(random_year), random_option)
         transits_dz = set(gz.dizhi for gz in transits_gz)
 
         self.assertDictEqual(transits.shensha(random_year, random_option), {
@@ -330,7 +330,7 @@ class TestRelationshipAnalysis(unittest.TestCase):
           if not transits.support(year, option):
             continue
 
-          transits_gz = db.ganzhis(year, option)
+          transits_gz = db.ganzhis(TransitMoment(year), option)
           transits_tg = set(gz.tiangan for gz in transits_gz)
 
           for tg_rel, tg_combos in transits.day_master_relations(year, option).items():
@@ -363,7 +363,7 @@ class TestRelationshipAnalysis(unittest.TestCase):
           if not transits.support(year, option):
             continue
 
-          transits_gz = db.ganzhis(year, option)
+          transits_gz = db.ganzhis(TransitMoment(year), option)
           transits_dz = set(gz.dizhi for gz in transits_gz)
 
           house_dz = chart.house_of_relationship
@@ -403,7 +403,7 @@ class TestRelationshipAnalysis(unittest.TestCase):
           if not transits.support(year, option):
             continue
 
-          transits_gz = db.ganzhis(year, option)
+          transits_gz = db.ganzhis(TransitMoment(year), option)
           transits_tg = set(gz.tiangan for gz in transits_gz)
           transits_dz = set(gz.dizhi for gz in transits_gz)
 
@@ -464,7 +464,7 @@ class TestRelationshipAnalysis(unittest.TestCase):
           if not transits.support(year, option):
             continue
 
-          transits_gz = db.ganzhis(year, option)
+          transits_gz = db.ganzhis(TransitMoment(year), option)
           transits_tg = set(gz.tiangan for gz in transits_gz)
           transits_dz = set(gz.dizhi for gz in transits_gz)
 
@@ -502,7 +502,7 @@ def test_random_cases(bazi: Bazi) -> None:
       if not transits.support(year, option):
         continue
 
-      transits_gz = db.ganzhis(year, option)
+      transits_gz = db.ganzhis(TransitMoment(year), option)
       transits_dz_set = set(gz.dizhi for gz in transits_gz)
 
       def __taohua(dz: Dizhi) -> bool:
@@ -530,7 +530,7 @@ def test_random_cases(bazi: Bazi) -> None:
       if not transits.support(year, option):
         continue
 
-      transits_gz = db.ganzhis(year, option)
+      transits_gz = db.ganzhis(TransitMoment(year), option)
       transits_tg_set = set(gz.tiangan for gz in transits_gz)
       transits_dz_set = set(gz.dizhi for gz in transits_gz)
 
@@ -580,7 +580,7 @@ def test_random_cases(bazi: Bazi) -> None:
       if not transits.support(year, option):
         continue
 
-      transits_gz = db.ganzhis(year, option)
+      transits_gz = db.ganzhis(TransitMoment(year), option)
       transits_tg_list = list(gz.tiangan for gz in transits_gz)
       transits_dz_list = list(gz.dizhi for gz in transits_gz)
 
@@ -640,7 +640,7 @@ def test_random_cases(bazi: Bazi) -> None:
       if not transits.support(year, option):
         continue
 
-      transits_gz = db.ganzhis(year, option)
+      transits_gz = db.ganzhis(TransitMoment(year), option)
       transits_tg_set = set(gz.tiangan for gz in transits_gz)
       transits_dz_set = set(gz.dizhi for gz in transits_gz)
 

--- a/tests/test_transit_chart.py
+++ b/tests/test_transit_chart.py
@@ -7,7 +7,8 @@ from datetime import datetime
 
 from src.Bazi import Bazi, BaziGender, BaziPrecision
 from src.BaziChart import BaziChart
-from src.Transits import TransitOptions, TransitDatabase
+from src.Defines import Dizhi
+from src.Transits import TransitMoment, TransitOptions, TransitDatabase
 from src.TransitChart import TransitChart, 流年大运
 
 
@@ -36,17 +37,20 @@ class TestTransitChart(unittest.TestCase):
 
     for gz_year in (first_dayun_gz_year, first_dayun_gz_year + 7, first_dayun_gz_year + 25):
       for option in TransitOptions:
-        self.assertEqual(transits.support(gz_year, option), db.support(gz_year, option))
-        if transits.support(gz_year, option):
-          self.assertEqual(transits.ganzhis(gz_year, option), db.ganzhis(gz_year, option))
+        self.assertEqual(transits.support(TransitMoment(gz_year), option), db.support(TransitMoment(gz_year), option))
+        if transits.support(TransitMoment(gz_year), option):
+          self.assertEqual(transits.ganzhis(TransitMoment(gz_year), option), db.ganzhis(TransitMoment(gz_year), option))
 
   def test_delegation_negative(self) -> None:
     bazi: Bazi = Bazi.create(datetime(2000, 2, 4, 22, 1), BaziGender.MALE, BaziPrecision.DAY)
     transits: TransitChart = TransitChart(BaziChart(bazi))
 
     self.assertRaises(AssertionError, lambda: transits.support('1999', TransitOptions.XIAOYUN)) # type: ignore
-    self.assertRaises(AssertionError, lambda: transits.ganzhis(1999, 'XIAOYUN')) # type: ignore
+    self.assertRaises(AssertionError, lambda: transits.support(1999, TransitOptions.XIAOYUN)) # type: ignore # int no longer accepted; `TransitMoment` required.
+    self.assertRaises(AssertionError, lambda: transits.ganzhis(TransitMoment(1999), 'XIAOYUN')) # type: ignore
+    # Month/day-granularity moments are rejected until #48 / #48 落地前，月/日粒度的 moment 显式拒绝。
+    self.assertRaises(NotImplementedError, lambda: transits.support(TransitMoment(2000, gz_month=Dizhi.寅), TransitOptions.LIUNIAN))
 
     first_dayun_gz_year: int = next(transits.bazi_chart.dayun).ganzhi_year
-    self.assertFalse(transits.support(first_dayun_gz_year - 1, TransitOptions.DAYUN))
-    self.assertRaises(ValueError, lambda: transits.ganzhis(first_dayun_gz_year - 1, TransitOptions.DAYUN))
+    self.assertFalse(transits.support(TransitMoment(first_dayun_gz_year - 1), TransitOptions.DAYUN))
+    self.assertRaises(ValueError, lambda: transits.ganzhis(TransitMoment(first_dayun_gz_year - 1), TransitOptions.DAYUN))

--- a/tests/test_transits.py
+++ b/tests/test_transits.py
@@ -65,6 +65,9 @@ class TestTransitDatabase(unittest.TestCase):
       self.assertRaises(AssertionError, lambda: db.support(1999, TransitOptions.XIAOYUN)) # type: ignore # int no longer accepted; `TransitMoment` required.
       self.assertRaises(AssertionError, lambda: db.support(TransitMoment(1999), 'XIAOYUN')) # type: ignore
       self.assertRaises(AssertionError, lambda: db.support(TransitMoment(1999), 0x1 | 0x4)) # type: ignore
+      # Zero-value and unknown-bit flags are rejected on all Python versions (3.12+'s `in` used to let them through).
+      self.assertRaises(AssertionError, lambda: db.support(TransitMoment(1999), TransitOptions(0)))
+      self.assertRaises(AssertionError, lambda: db.support(TransitMoment(1999), TransitOptions(0x8)))
 
       with self.subTest('Test ganzhi years before the birth year. Expect not to support.'):
         for gz_year in range(chart.bazi.ganzhi_date.year - 10, chart.bazi.ganzhi_date.year):
@@ -188,5 +191,10 @@ class TestAllOptions(unittest.TestCase):
     self.assertEqual(len(_ALL_OPTIONS), 2 ** len(singles) - 1)
     # The unnamed combo that the old hand-listed `random()` never returned.
     self.assertIn(TransitOptions.XIAOYUN | TransitOptions.DAYUN, _ALL_OPTIONS)
+    # Every enumerated option is non-zero and composed of known bits only.
+    # (Do NOT assert `opt in TransitOptions` here -- on Python 3.11 the enum `in`
+    # rejects unnamed composites, which is exactly what this test enumerates.)
+    full_mask = sum(opt.value for opt in singles)
     for opt in _ALL_OPTIONS:
-      self.assertIn(opt, TransitOptions)
+      self.assertGreater(opt.value, 0)
+      self.assertEqual(full_mask, opt.value | full_mask)

--- a/tests/test_transits.py
+++ b/tests/test_transits.py
@@ -5,16 +5,16 @@ import unittest
 
 import random
 import itertools
-from datetime import datetime
+from datetime import date, datetime
 
 from src.Common import DayunTuple
-from src.Defines import Ganzhi
+from src.Defines import Ganzhi, Dizhi
 from src.Utils import BaziUtils
 
 from src.Calendar.HkoDataCalendarUtils import to_ganzhi
 from src.Bazi import Bazi, BaziGender, BaziPrecision
 from src.BaziChart import BaziChart
-from src.Transits import DayunDatabase, TransitOptions, TransitDatabase
+from src.Transits import DayunDatabase, TransitMoment, TransitOptions, TransitDatabase, _ALL_OPTIONS
 
 
 class TestDayunDatabase(unittest.TestCase):
@@ -62,23 +62,24 @@ class TestTransitDatabase(unittest.TestCase):
       db: TransitDatabase = TransitDatabase(chart)
 
       self.assertRaises(AssertionError, lambda: db.support('1999', TransitOptions.XIAOYUN)) # type: ignore
-      self.assertRaises(AssertionError, lambda: db.support(1999, 'XIAOYUN')) # type: ignore
-      self.assertRaises(AssertionError, lambda: db.support(1999, 0x1 | 0x4)) # type: ignore
+      self.assertRaises(AssertionError, lambda: db.support(1999, TransitOptions.XIAOYUN)) # type: ignore # int no longer accepted; `TransitMoment` required.
+      self.assertRaises(AssertionError, lambda: db.support(TransitMoment(1999), 'XIAOYUN')) # type: ignore
+      self.assertRaises(AssertionError, lambda: db.support(TransitMoment(1999), 0x1 | 0x4)) # type: ignore
 
       with self.subTest('Test ganzhi years before the birth year. Expect not to support.'):
         for gz_year in range(chart.bazi.ganzhi_date.year - 10, chart.bazi.ganzhi_date.year):
           for option in TransitOptions:
-            self.assertFalse(db.support(gz_year, option))
+            self.assertFalse(db.support(TransitMoment(gz_year), option))
 
       with self.subTest('Test Xiaoyun / 小运.'):
         first_dayun_gz_year: int = next(chart.dayun).ganzhi_year
         for gz_year in range(chart.bazi.ganzhi_date.year, chart.bazi.ganzhi_date.year + len(chart.xiaoyun)):
-          self.assertTrue(db.support(gz_year, TransitOptions.XIAOYUN))
-          self.assertTrue(db.support(gz_year, TransitOptions.LIUNIAN))
-          self.assertTrue(db.support(gz_year, TransitOptions.XIAOYUN_LIUNIAN))
+          self.assertTrue(db.support(TransitMoment(gz_year), TransitOptions.XIAOYUN))
+          self.assertTrue(db.support(TransitMoment(gz_year), TransitOptions.LIUNIAN))
+          self.assertTrue(db.support(TransitMoment(gz_year), TransitOptions.XIAOYUN_LIUNIAN))
 
           # The last Xiaoyun year may also be the first Dayun year - this is the only expected overlap.
-          if db.support(gz_year, TransitOptions.DAYUN):
+          if db.support(TransitMoment(gz_year), TransitOptions.DAYUN):
             self.assertEqual(gz_year, first_dayun_gz_year)
           else:
             self.assertLess(gz_year, first_dayun_gz_year)
@@ -86,9 +87,9 @@ class TestTransitDatabase(unittest.TestCase):
       with self.subTest('Test Dayun / 大运.'):
         for start_gz_year, _ in itertools.islice(chart.dayun, 10): # Expect the first 10 dayuns to be supported anyways...
           for gz_year in range(start_gz_year, start_gz_year + 10):
-            self.assertTrue(db.support(gz_year, TransitOptions.DAYUN))
-            self.assertTrue(db.support(gz_year, TransitOptions.LIUNIAN))
-            self.assertTrue(db.support(gz_year, TransitOptions.DAYUN_LIUNIAN))
+            self.assertTrue(db.support(TransitMoment(gz_year), TransitOptions.DAYUN))
+            self.assertTrue(db.support(TransitMoment(gz_year), TransitOptions.LIUNIAN))
+            self.assertTrue(db.support(TransitMoment(gz_year), TransitOptions.DAYUN_LIUNIAN))
 
   def test_ganzhis(self) -> None:
     for _ in range(4):
@@ -107,12 +108,12 @@ class TestTransitDatabase(unittest.TestCase):
       random_liunians = random.sample(list(itertools.islice(chart.liunian, 200)), 20)
       random.shuffle(random_liunians)
 
-      self.assertRaises(ValueError, lambda: db.ganzhis(dayun_start_gz_year - 1, TransitOptions.DAYUN))
+      self.assertRaises(ValueError, lambda: db.ganzhis(TransitMoment(dayun_start_gz_year - 1), TransitOptions.DAYUN))
 
       for gz_year, _ in random_liunians:
         for option in TransitOptions:
-          if not db.support(gz_year, option):
-            self.assertRaises(ValueError, lambda: db.ganzhis(gz_year, option))
+          if not db.support(TransitMoment(gz_year), option):
+            self.assertRaises(ValueError, lambda: db.ganzhis(TransitMoment(gz_year), option))
             continue
 
           transit_ganzhis: list[Ganzhi] = []
@@ -124,7 +125,68 @@ class TestTransitDatabase(unittest.TestCase):
           if option.value & TransitOptions.LIUNIAN.value:
             transit_ganzhis.append(BaziUtils.ganzhi_of_year(gz_year))
 
-          actual = db.ganzhis(gz_year, option)
+          actual = db.ganzhis(TransitMoment(gz_year), option)
           self.assertEqual(len(actual), len(transit_ganzhis))
           for gz in actual:
             self.assertIn(gz, transit_ganzhis)
+
+
+class TestTransitMoment(unittest.TestCase):
+  def test_valid_shapes(self) -> None:
+    '''The three granularities / 三种粒度：年、月、日。'''
+    year_moment = TransitMoment(1990)
+    self.assertEqual(year_moment.gz_year, 1990)
+    self.assertIsNone(year_moment.gz_month)
+    self.assertIsNone(year_moment.solar_date)
+
+    month_moment = TransitMoment(1990, gz_month=Dizhi.寅)
+    self.assertEqual(month_moment.gz_year, 1990)
+    self.assertEqual(month_moment.gz_month, Dizhi.寅)
+    self.assertIsNone(month_moment.solar_date)
+
+    day_moment = TransitMoment(1990, solar_date=date(1990, 5, 20))
+    self.assertEqual(day_moment.gz_year, 1990)
+    self.assertIsNone(day_moment.gz_month)
+    self.assertEqual(day_moment.solar_date, date(1990, 5, 20))
+
+  def test_value_semantics(self) -> None:
+    '''Equality and hash -- the contract that the exact-type check defends / 相等性与 hash——精确类型检查所捍卫的契约。'''
+    self.assertEqual(TransitMoment(1990), TransitMoment(1990))
+    self.assertEqual(hash(TransitMoment(1990)), hash(TransitMoment(1990)))
+    self.assertNotEqual(TransitMoment(1990), TransitMoment(1990, gz_month=Dizhi.寅))
+    self.assertEqual(1, len({TransitMoment(1990), TransitMoment(1990)}))
+
+  def test_invalid(self) -> None:
+    self.assertRaises(AssertionError, lambda: TransitMoment('1990')) # type: ignore
+    self.assertRaises(AssertionError, lambda: TransitMoment(1990, gz_month=3)) # type: ignore
+    self.assertRaises(AssertionError, lambda: TransitMoment(1990, solar_date='1990-05-20')) # type: ignore
+    # `datetime` is a `date` subclass but breaks the value semantics / datetime 是 date 子类，但破坏值语义（与 date 不相等、hash 不同）。
+    self.assertRaises(AssertionError, lambda: TransitMoment(1990, solar_date=datetime(1990, 5, 20, 12, 0)))
+    # The month and day granularities are mutually exclusive / 月粒度与日粒度互斥。
+    self.assertRaises(AssertionError, lambda: TransitMoment(1990, gz_month=Dizhi.寅, solar_date=date(1990, 5, 20)))
+
+  def test_granularity_rejection(self) -> None:
+    '''Month/day granularities are explicitly rejected before #48 lands / #48 落地前，月/日粒度显式拒绝。'''
+    chart: BaziChart = BaziChart.random()
+    db: TransitDatabase = TransitDatabase(chart)
+    gz_year: int = chart.bazi.ganzhi_date.year
+
+    moments = [
+      TransitMoment(gz_year, gz_month=Dizhi.寅),
+      TransitMoment(gz_year, solar_date=date(gz_year, 5, 20)),
+    ]
+    for moment in moments:
+      self.assertRaises(NotImplementedError, lambda: db.support(moment, TransitOptions.LIUNIAN))
+      self.assertRaises(NotImplementedError, lambda: db.ganzhis(moment, TransitOptions.LIUNIAN))
+
+
+class TestAllOptions(unittest.TestCase):
+  def test_enumeration(self) -> None:
+    '''`_ALL_OPTIONS` enumerates all non-empty combos of the single-bit members / 枚举单 bit 成员的全部非空组合（扩位自动跟随）。'''
+    singles = [opt for opt in TransitOptions if opt.value > 0 and opt.value & (opt.value - 1) == 0]
+
+    self.assertEqual(len(_ALL_OPTIONS), 2 ** len(singles) - 1)
+    # The unnamed combo that the old hand-listed `random()` never returned.
+    self.assertIn(TransitOptions.XIAOYUN | TransitOptions.DAYUN, _ALL_OPTIONS)
+    for opt in _ALL_OPTIONS:
+      self.assertIn(opt, TransitOptions)


### PR DESCRIPTION
## Summary

Implements #67 (prerequisite for #48 流月/流日):

1. **`TransitMoment` key abstraction** (`src/Transits.py`) — a frozen value type replacing the raw `gz_year: int` key: `gz_year` required; `gz_month: Dizhi | None` and `solar_date: date | None` reserved for #48. Construction-time validation: month/day granularities are mutually exclusive, and an exact-`type(...) is date` check rejects `datetime` (a `date` subclass whose `==`/`hash` semantics would silently break this value type). The `gz_year` ↔ `solar_date` consistency invariant (立春 boundary) is documented as an unchecked caller responsibility — `TransitDatabase` will enforce it in #48, since the value type must not bind a calendar backend.
2. **Clean signature break** — `TransitDatabase.support/ganzhis` and the `TransitChart` facade now take `moment: TransitMoment`. Year-granularity logic is line-for-line identical to the old `int` version. Month/day granularity raises `NotImplementedError` explicitly (documented in all four docstrings) — no silent paths before #48.
3. **Facade unification** — `TransitAnalysis` no longer builds its own `TransitDatabase`; it goes through the `TransitChart` facade with a single copy source. Analyzer public signatures `(gz_year: int, options)` are unchanged; `TransitMoment(gz_year)` conversion happens at the boundary.
4. **`TransitOptions.random()` never goes stale** — now draws from `_ALL_OPTIONS`, the auto-enumerated space of all non-empty single-bit combinations (the old hand-listed 5 silently missed `XIAOYUN|DAYUN`). Enumeration follows new bits automatically; the docstring is explicit that semantic wiring in `support`/`ganzhis` remains a separate, manual step.

Explicitly out of scope (for #48): LIUYUE/LIURI option bits, month/day evaluation logic, and `BaziJson.Transits` extension (its JSON generation in `BaziChart` is independent of `TransitDatabase`).

## #48 handoff checklist

- Enforce the documented invariant in `TransitDatabase`: `solar_date`'s Ganzhi year must equal `gz_year` (requires calendar access — do **not** put this in the value type).
- Add `options` ↔ moment-granularity cross-validation (e.g. LIURI requires `solar_date`).
- Extend `TransitOptions` bits and wire `support`/`ganzhis` semantics; extend `BaziJson.Transits` in sync.

## Local gates (all green)

- `ruff check .` ✓
- `mypy --check-untyped-defs --warn-redundant-casts --warn-unused-ignores --warn-return-any --warn-unreachable` — 49 files ✓
- `coverage run -m pytest tests/` — 249 tests, **100%** coverage ✓

## Local cross-review (pre-push)

Reviewed by Claude (Fable 5) and Grok, two rounds. R1: no P0 from either side; three P1s (consistency-invariant documentation, `datetime` leaking through `isinstance`, `support()` raise behavior undocumented) plus shared P2s — all adopted or declined with reasons recorded. R2 (fix verification): both approved with no new P0/P1. Both reviewers independently verified the year-granularity path line-by-line against `HEAD` and confirmed the #48 field shape (`gz_month: Dizhi` + `solar_date: date`) is sufficient for `month_tiangan` / `ganzhi_of_day` without rework.

Closes #67
