### PR TITLE
docs: AGENTS.md 对齐 celestial 工作流(review-rounds + 多行调用排版)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,18 @@ those, don't restate them here. Two rules the README doesn't spell out:
     then `python -m coverage report --show-missing` — must stay at **100%**
     (intentionally unreachable lines carry `# pragma: no cover` + a reason).
 
+## PR workflow
+- Branch from `main`; PR body in Chinese, four sections (内容 / 测试 / 验证 / 范围说明);
+  squash-merge is the author's call.
+- Before the PR: run the double review round per the shared `review-rounds` skill
+  (`~/ai_memory/skills/review-rounds/SKILL.md`, driver-agnostic — same process as
+  celestial-calendar): a correctness adversarial round × a style/design round,
+  R1 → batched fixes → R2 re-verify; don't touch the worktree while reviewers read.
+  Cross-model calls are plain CLI (`claude -p … --model <model>` / `kimi -p` /
+  `grok -p`); task briefs go on disk for the callee to read.
+- Commits are SK-signed and agents can't sign: commit via GraphQL
+  `createCommitOnBranch` (GitHub signs it), or write a script for the author to run.
+
 ## File conventions
 - Every source file opens with the copyright header, verbatim except the year:
   `# Copyright (C) <year> Ningqi Wang (0xf3cd) <https://github.com/0xf3cd>`
@@ -52,6 +64,16 @@ those, don't restate them here. Two rules the README doesn't spell out:
 - Module filenames are **PascalCase** (`BaziChart.py`). NOT snake_case.
 - Imports: stdlib → third-party → local (relative `from ..Defines import ...`),
   blank line between groups; long typing imports use the grouped `from typing import (…)` form.
+- Multi-line call layout: when an argument is itself a call, or the call grows long,
+  put each argument on its own line and the closing `)` on its own line at the call's
+  indentation (same rule as celestial-calendar). Trivial short calls stay on one line.
+  ```python
+  bazi = Bazi.create(
+    birth_time,
+    gender,
+    precision,
+  )
+  ```
 
 ## Ubiquitous language = Pinyin
 Domain terms keep Pinyin names, never translated (`Tiangan`, `Shensha`, `he`, `chong`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,14 +47,17 @@ those, don't restate them here. Two rules the README doesn't spell out:
 ## PR workflow
 - Branch from `main`; PR body in Chinese, four sections (内容 / 测试 / 验证 / 范围说明);
   squash-merge is the author's call.
-- Before the PR: run the double review round per the shared `review-rounds` skill
-  (`~/ai_memory/skills/review-rounds/SKILL.md`, driver-agnostic — same process as
-  celestial-calendar): a correctness adversarial round × a style/design round,
-  R1 → batched fixes → R2 re-verify; don't touch the worktree while reviewers read.
-  Cross-model calls are plain CLI (`claude -p … --model <model>` / `kimi -p` /
-  `grok -p`); task briefs go on disk for the callee to read.
-- Commits are SK-signed and agents can't sign: commit via GraphQL
-  `createCommitOnBranch` (GitHub signs it), or write a script for the author to run.
+- Before the PR: run a double review round (same process as celestial-calendar) —
+  a correctness adversarial round × a style/design round; R1 findings → batched
+  fixes → R2 re-verify; don't touch the worktree while reviewers read. Reviewers
+  are independent AI models invoked as plain CLI (`claude -p …` / `kimi -p` /
+  `grok -p`), with task briefs written to disk for the callee to read. The detailed
+  playbook is the author's `review-rounds` skill
+  (`~/ai_memory/skills/review-rounds/SKILL.md` — author-machine tooling, not
+  tracked in this repo); contributors without it follow the summary in this bullet.
+- Commits must be signed; the author signs with a hardware security key, which
+  agents can't operate. Agents commit via GraphQL `createCommitOnBranch` (GitHub
+  signs the commit), or write a commit script for the author to run.
 
 ## File conventions
 - Every source file opens with the copyright header, verbatim except the year:


### PR DESCRIPTION
## 内容

Phase F(celestial 历法后端接入)开工前的工作流对齐,docs-only:

1. 新增 **PR workflow** 节:双轮审阅流程(正确性对抗轮 × 风格设计轮,SSOT = 共享 `review-rounds` skill,驾驶者无关的 CLI 调用形式)、中文四段 PR body、SK 签名下的 GraphQL 代签提交方式
2. **File conventions** 补多行调用排版规则:实参各占一行 + 尾逗号 + `)` 独立行(与 celestial-calendar AGENTS.md 同规,例证 = 仓内 `Relationship.py:323/346` 现状)

## 测试

无代码变更;CI 照常全绿即可。

## 验证

多行调用 + 尾逗号写法先 grep 仓内现有代码确认为既成风格,规则是**成文化**而非新发明。

## 范围说明

不动任何代码与配置;review-rounds 流程本体在 `~/ai_memory/skills`(跨仓共享),本 PR 只落指针。Phase F 正式 PR 将在此规则下受审。

🤖 Generated with [Claude Code](https://claude.com/claude-code)