### PR TITLE
feat(calendar): 默认后端切至 celestial + golden 重基线 (#93 A/B/C)

### DIFF
--- a/run_demo.py
+++ b/run_demo.py
@@ -11,7 +11,7 @@ from src.BaziChart import BaziChart
 from src.Defines import Tiangan, Dizhi, Wuxing, Ganzhi, ShierZhangsheng
 from src.Common import HiddenTianganDict
 from src.Utils.BaziUtils import traits, shishen, hidden_tiangans, nayin_str, shier_zhangsheng
-from src.Calendar.HkoDataCalendarUtils import prev_jie, next_jie
+from src.Calendar.CalendarBackend import calendar_utils_of
 
 
 T = TypeVar('T')
@@ -85,8 +85,9 @@ def get_transit_info(chart: BaziChart) -> str:
   day_master: Tiangan = chart.bazi.day_master
   s: str = '\n' # The output string.
 
-  jie_before = prev_jie(chart.bazi.solar_datetime)
-  jie_after = next_jie(chart.bazi.solar_datetime)
+  utils = calendar_utils_of(chart.bazi.backend)
+  jie_before = utils.prev_jie(chart.bazi.solar_datetime)
+  jie_after = utils.next_jie(chart.bazi.solar_datetime)
 
   s += f'出生时刻前一节：{jie_before.jieqi} - {jie_before.moment.isoformat()}\n'
   s += f'出生时刻后一节：{jie_after.jieqi} - {jie_after.moment.isoformat()}\n'

--- a/src/Bazi.py
+++ b/src/Bazi.py
@@ -113,12 +113,14 @@ class Bazi:
   Note:
   - We don't care about the timezone. `Bazi` knows nothing about timezone.
   - We don't care about the true solar time / daylight saving time - it should be well-processed outside of this class.
+  - The year pillar turns at 立春, not at 正月初一 (this library follows the 立春 school).
   - `Bazi` 不考虑时差。时差需要在外部处理。
   - `Bazi` 不考虑真太阳时和夏令时。这些时间需要在外部处理。
+  - 本库从立春派：年柱以立春换年，不以正月初一（春节）换年。
   '''
 
   def __init__(self, birth_time: datetime, gender: BaziGender, precision: BaziPrecision,
-               backend: CalendarBackend = CalendarBackend.HKO) -> None:
+               backend: CalendarBackend = CalendarBackend.CELESTIAL) -> None:
     '''
     `Bazi` (i.e. 八字, which means eight characters in Chinese) takes the birth time and gender as input, 
     and figures out the pillars of year, month, day, and hour.
@@ -242,7 +244,7 @@ class Bazi:
     birth_time: Union[datetime, str],
     gender: Union[BaziGender, str], 
     precision: Union[BaziPrecision, str],
-    backend: Union[CalendarBackend, str] = CalendarBackend.HKO
+    backend: Union[CalendarBackend, str] = CalendarBackend.CELESTIAL
   ) -> 'Bazi':
     '''
     Staticmethod that creates a `Bazi` object from the inputs.

--- a/src/Calendar/CelestialData/SCHEMA.md
+++ b/src/Calendar/CelestialData/SCHEMA.md
@@ -23,7 +23,7 @@ The loader is path-parameterised so the same code reads either.
 
 ## File format
 
-UTF-8 text, LF endings, trailing newline. Every line starting with `#` is header;
+UTF-8 text, trailing newline. LF is the on-disk convention; readers normalise line endings (`splitlines()`), so a CRLF file loads — and hashes — identically. Every line starting with `#` is header;
 data lines follow, one record per line, fields separated by single spaces.
 No blank lines. Rows are emitted in ascending `(year, jq_idx)` / `(lunar_year)` order.
 

--- a/tests/calendar/test_calendar_backend.py
+++ b/tests/calendar/test_calendar_backend.py
@@ -60,18 +60,11 @@ class TestCalendarBackend(unittest.TestCase):
 
 
 class TestBaziBackend(unittest.TestCase):
-  def test_default_backend(self) -> None:
-    bazi: Bazi = Bazi(datetime(1984, 4, 2, 4, 2), BaziGender.MALE, BaziPrecision.DAY)
-    self.assertIs(bazi.backend, CalendarBackend.HKO)
-
   def test_create_with_backend(self) -> None:
-    bazi_default: Bazi = Bazi.create('1984-04-02 04:02', 'male', 'day')
     bazi_enum: Bazi = Bazi.create('1984-04-02 04:02', 'male', 'day', backend=CalendarBackend.HKO)
     bazi_str: Bazi = Bazi.create('1984-04-02 04:02', 'male', 'day', backend='hko')
 
-    self.assertIs(bazi_default.backend, CalendarBackend.HKO)
-    self.assertEqual(bazi_default, bazi_enum)
-    self.assertEqual(bazi_default, bazi_str)
+    self.assertEqual(bazi_enum, bazi_str) # enum and string spellings resolve the same way
 
     with self.assertRaises(ValueError):
       Bazi.create('1984-04-02 04:02', 'male', 'day', backend='lunar')
@@ -93,12 +86,22 @@ class TestBaziBackend(unittest.TestCase):
       Bazi(datetime(1984, 4, 2, 4, 2), BaziGender.MALE, BaziPrecision.DAY,
            backend='hko') # type: ignore[arg-type]
 
-  def test_random_uses_default_backend(self) -> None:
-    self.assertIs(Bazi.random().backend, CalendarBackend.HKO)
+  def test_default_backend_is_celestial(self) -> None:
+    '''
+    #93 flipped the default from HKO to CELESTIAL.  The switch is two quiet keyword
+    defaults, so pin every construction path that can pick it up implicitly.
+    '''
+    self.assertIs(Bazi(datetime(2000, 2, 4, 22, 1), BaziGender.MALE, BaziPrecision.DAY).backend,
+                  CalendarBackend.CELESTIAL)
+    self.assertIs(Bazi.create('2000-02-04 22:01', 'male', 'day').backend, CalendarBackend.CELESTIAL)
+    self.assertIs(Bazi.random().backend, CalendarBackend.CELESTIAL)
 
   def test_json_contains_backend(self) -> None:
     chart: BaziChart = BaziChart(Bazi(datetime(1984, 4, 2, 4, 2), BaziGender.MALE, BaziPrecision.DAY))
-    self.assertEqual(chart.json['backend'], 'hko')
+    self.assertEqual(chart.json['backend'], 'celestial') # the default
+    hko_chart: BaziChart = BaziChart(Bazi(datetime(1984, 4, 2, 4, 2), BaziGender.MALE, BaziPrecision.DAY,
+                                          backend=CalendarBackend.HKO))
+    self.assertEqual(hko_chart.json['backend'], 'hko')
 
   def test_celestial_backend_end_to_end(self) -> None:
     '''

--- a/tests/calendar/test_celestial_parity_derived.py
+++ b/tests/calendar/test_celestial_parity_derived.py
@@ -23,7 +23,7 @@ HKO x DE441 dual-axis golden tests (0.525 min agreement over 2022-2028).
 
 import unittest
 
-from datetime import date, timedelta
+from datetime import date, datetime, time, timedelta
 
 from src.Calendar import HkoDataCalendarUtils as HKO
 from src.Calendar.CalendarDefines import CalendarType, CalendarDate
@@ -94,9 +94,10 @@ class TestJieqiDateWhitelist(unittest.TestCase):
         cel, hko = CEL.jieqi_date(year, jq), HKO.jieqi_date(year, jq)
         if cel != hko:
           measured.append((year, jq_idx, cel))
+    # Sorted: the signal is the key set, not the scan order (layer (b) compares as a set too).
     self.assertEqual(
-      measured,
-      [(row.year, row.jq_idx, row.celestial_moment.date()) for row in JIEQI_DATE_DIVERGENCES],
+      sorted(measured),
+      sorted((row.year, row.jq_idx, row.celestial_moment.date()) for row in JIEQI_DATE_DIVERGENCES),
     )
 
   def test_moments_match_the_whitelist(self) -> None:
@@ -110,6 +111,47 @@ class TestJieqiDateWhitelist(unittest.TestCase):
     # Only 节 start ganzhi months, so only these two can propagate into ganzhi methods.
     self.assertEqual([(row.year, row.name) for row in flipped_jies()],
                      [(1917, '大雪'), (1927, '白露')])
+
+  def test_prev_next_jie_diverge_only_inside_the_moment_window(self) -> None:
+    '''
+    `prev_jie`/`next_jie` escape layer (c) by design (see the protocol's carve-out): inside
+    the window between the two backends' ideas of when a jie starts, they legitimately name
+    different jie -- and `dayun_start_moment` rides on it.  Both backends answer over the 12
+    节 only, so this pins the shape of that escape for every 节: the window is
+    [min(hko_date, true date) midnight, true moment); inside it the backends are exactly one
+    节 apart, outside it they agree.  A day-level regression that *narrows* a window turns
+    red here; a widening one moves the probes along with it and is caught by the whitelist
+    tests above instead.
+    '''
+    cel_first, cel_last = CEL.supported_jie_boundaries()
+    hko_first, hko_last = HKO.supported_jie_boundaries()
+    cycle: list[Jieqi] = JIES
+    for year in range(1901, 2101):
+      for jq_idx, jq in enumerate(cycle):
+        moment: datetime = CEL.jieqi_moment(year, jq)
+        window_start: datetime = datetime.combine(
+          min(HKO.jieqi_date(year, jq), moment.date()),
+          time.min,
+        )
+        prev_jq: Jieqi = cycle[(jq_idx - 1) % len(cycle)]
+        next_jq: Jieqi = cycle[(jq_idx + 1) % len(cycle)]
+
+        inside: datetime = window_start + (moment - window_start) / 2
+        if inside >= cel_first: # else both queries fall off the table edge (小寒 1901)
+          self.assertEqual(CEL.prev_jie(inside).jieqi, prev_jq, (year, jq))
+          self.assertEqual(CEL.next_jie(inside).jieqi, jq, (year, jq))
+        if inside < hko_last: # else both queries fall off the table edge (大雪 2100)
+          self.assertEqual(HKO.prev_jie(inside).jieqi, jq, (year, jq))
+          self.assertEqual(HKO.next_jie(inside).jieqi, next_jq, (year, jq))
+
+        before: datetime = window_start - timedelta(seconds=1)
+        if before >= cel_first and before >= hko_first:
+          self.assertEqual(CEL.prev_jie(before).jieqi, HKO.prev_jie(before).jieqi, (year, jq))
+          self.assertEqual(CEL.next_jie(before).jieqi, HKO.next_jie(before).jieqi, (year, jq))
+        after: datetime = moment + timedelta(seconds=1)
+        if after < cel_last and after < hko_last:
+          self.assertEqual(CEL.prev_jie(after).jieqi, HKO.prev_jie(after).jieqi, (year, jq))
+          self.assertEqual(CEL.next_jie(after).jieqi, HKO.next_jie(after).jieqi, (year, jq))
 
   def test_the_derivations_preconditions_hold(self) -> None:
     '''

--- a/tests/test_bazichart.py
+++ b/tests/test_bazichart.py
@@ -274,29 +274,30 @@ class TestBaziChart(unittest.TestCase):
       self.assertEqual(chart.dayun_order, expected_order)
 
   def test_dayun_start_moment(self) -> None:
-    # TODO: currently `HkoDataCalendarUtils` only supports day-level precision,
-    # which makes the `delta` a lot bigger.
-    # After supporting finer precision, this test should be updated.
-    delta: timedelta = timedelta(days=120)
+    # Golden values from 测测, kept as provenance: 2009-12-30 / 1985-03-05 / 1993-05-25.
+    # The expectations are the celestial backend's answers, pinned to the shipped tables:
+    # the 3-days-to-1-year rule amplifies jieqi-moment drift ~122x (1s -> ~2min), so any
+    # re-bake that moves a jieqi goes red here -- and trips the frozen table hash first.
+    delta: timedelta = timedelta(seconds=1)
 
     bazi1: Bazi = Bazi.create(datetime(2000, 2, 4, 22, 1), BaziGender.MALE, BaziPrecision.DAY)
     self.assertAlmostEqual(
       BaziChart(bazi1).dayun_start_moment,
-      datetime(2009, 12, 30),
+      datetime(2009, 12, 26, 21, 8, 25),
       delta=delta,
     )
 
     bazi2: Bazi = Bazi.create(datetime(1984, 4, 2, 4, 2), BaziGender.MALE, BaziPrecision.DAY)
     self.assertAlmostEqual(
-      BaziChart(bazi2).dayun_start_moment, 
-      datetime(1985, 3, 5),
+      BaziChart(bazi2).dayun_start_moment,
+      datetime(1985, 3, 4, 11, 17, 55),
       delta=delta,
     )
 
     bazi3: Bazi = Bazi.create(datetime(1984, 4, 2, 4, 2), BaziGender.FEMALE, BaziPrecision.DAY)
     self.assertAlmostEqual(
-      BaziChart(bazi3).dayun_start_moment, 
-      datetime(1993, 5, 25),
+      BaziChart(bazi3).dayun_start_moment,
+      datetime(1993, 5, 24, 0, 24, 13, 333333),
       delta=delta,
     )
 
@@ -326,7 +327,8 @@ class TestBaziChart(unittest.TestCase):
 
     bazi2: Bazi = Bazi.create(datetime(1984, 4, 2, 4, 2), BaziGender.MALE, BaziPrecision.DAY)
     first_dayun2: DayunTuple = next(BaziChart(bazi2).dayun)
-    self.assertEqual(first_dayun2.ganzhi_year, 1984) # TODO: 测测 Says Dayun starts in 1985. Revisit here later...
+    # celestial start 1985-03-04 is past 立春 1985; lunar_python / china95 / 测测 all agree.
+    self.assertEqual(first_dayun2.ganzhi_year, 1985)
 
     bazi3: Bazi = Bazi.create(datetime(1984, 4, 2, 4, 2), BaziGender.FEMALE, BaziPrecision.DAY)
     first_dayun3: DayunTuple = next(BaziChart(bazi3).dayun)
@@ -356,6 +358,11 @@ class TestBaziChart(unittest.TestCase):
               '丙子 乙亥 甲戌 癸酉')
     __subtest(Bazi.create(datetime(2017, 4, 16, 2, 23), BaziGender.FEMALE, BaziPrecision.DAY),
               '甲寅 乙卯 丙辰 丁巳 戊午 己未 庚申')
+
+    # Directed: celestial moves this man's dayun start past 立春 1985, so xiaoyun gains a year
+    # (HKO gives '辛卯' alone); china95 lists exactly '辛卯 壬辰' for the same birth.
+    __subtest(Bazi.create(datetime(1984, 4, 2, 4, 2), BaziGender.MALE, BaziPrecision.DAY),
+              '辛卯 壬辰')
 
   def test_liunian(self) -> None:
     cycle: list[Ganzhi] = Ganzhi.list_sexagenary_cycle()
@@ -427,7 +434,8 @@ class TestBaziChart(unittest.TestCase):
       self.assertEqual(j_gender, chart.bazi.gender)
 
       __chart: BaziChart = BaziChart(
-        Bazi.create(datetime.fromisoformat(j['birth_time']), j_gender, BaziPrecision.DAY)
+        Bazi.create(datetime.fromisoformat(j['birth_time']), j_gender, BaziPrecision.DAY,
+                    backend=j['backend'])
       )
 
       self.assertEqual(j, __chart.json)


### PR DESCRIPTION
## 内容

Closes #93。F2 = 默认后端切至 celestial + 据此重基线 golden 期望（A/B/C 三节；D 测测取证由作者后续人工采集，不阻塞本 PR）。

- **A 切换**：`Bazi.__init__`/`create` 两处默认值 HKO → CELESTIAL；HKO 保留显式 opt-in，旧 json 档显式解析不受影响。
- **B 重基线**：`dayun_start_moment` 三例换 celestial 精确值（2009-12-26 21:08:25 / 1985-03-04 11:17:55 / 1993-05-24 00:24:13.333333），`delta` 120 天 → **1 秒**；首运干支年 1984 → 1985（删 TODO）；xiaoyun 新增 1984 男定向 `辛卯 壬辰`；站点 1 与站点 4 既有期望不动。
- **C 顺手**：Bazi docstring 显化立春派；SCHEMA 行尾措辞归一化；parity 锚点改 sorted；`test_json` 还原路径补 `backend=j['backend']`；run_demo 前后节改走 `calendar_utils_of(chart.bazi.backend)`。

## 测试

- 新增 `test_default_backend_is_celestial`：三条隐式构造路径（`__init__`/`create`/`random`）默认解析钉死——切换是安静动作，此锁使其变响（回退 HKO 实测 2 红）。
- 新增 `test_prev_next_jie_diverge_only_inside_the_moment_window`：2400 节逐节断言两后端分歧恰呈「窗口内差一节、窗外一致」形状，含表边界 range 守卫；docstring 如实标注变宽向突变由白名单测试兜住（fable 突变矩阵实证）。
- 本地全门禁 exit 0（coverage 100%、ruff/mypy 干净、demo/interpreter 过）；突变检出：默认回退 2 红、旧 golden 1 红、+1s 节气注入击穿（121.67s）实测。

## 验证

- 双轮三家审阅**零 P1**：grok × claude fable（正确性对抗）× kimi k3（风格），关注面零重叠（第四次复现）。
- 收敛发现：grok×fable 同抓 `delta` 容差与注释依据数学矛盾（121.67× 放大，1.5s→3min）→ delta 收紧至 1s、注释改为「钉死出厂表，节气动 1s 此处必红，表哈希先响」；kimi×fable 同抓 run_demo 第三处隐式默认。
- 重基线数值三例经 grok、fable 双独立复算（自写解析器直读表文件），偏差 0.000000s。

## 范围说明

- 行为变更面 = #93 A 节所冻结：61 个公历日干支索引（白名单推导，celestial 为对）+ 起运全体变准（HKO 实测中位偏 58 天 → celestial ≤3.9 分钟）+ 节气日真时刻前出生的数节方向（收益，`CalendarUtilsProtocol` docstring 有 carve-out）。此外排盘不变。
- D 节（测测取证）由作者后续人工采集，结果只影响 golden 残差解读，不影响本 PR 代码。
- 遗留（均有账）：#92（HKO 缓存泄漏，含 celestial 侧同形条目）、#86（协议实例形态）、#72（待关，由 #6 承接）。