### PR TITLE
feat(bazi): BaziPrecision HOUR/MINUTE 粒度归属 + 出生侧全盘同源 (Phase G, #6/#72)

### DIFF
--- a/src/Bazi.py
+++ b/src/Bazi.py
@@ -5,9 +5,10 @@ import random
 
 from enum import Enum
 from datetime import date, time, datetime, timedelta
-from typing import Final, Union
+from typing import Final, Optional, Union
 
-from .Defines import Tiangan, Dizhi, Ganzhi
+from .Common import JieqiTime
+from .Defines import Tiangan, Dizhi, Ganzhi, Jieqi
 from .Calendar import (
   CalendarDate, CalendarUtilsProtocol, CalendarBackend, calendar_utils_of,
 )
@@ -85,7 +86,14 @@ class BaziPrecision(Enum):
   estimator would have to flip its answer based on a clock time the DAY caller is not claiming
   to know, which would also make ganzhi month lengths depend on it.
 
-  Only DAY is implemented so far; HOUR and MINUTE are https://github.com/0xf3cd/bazi/issues/6.
+  Because 子时 spans midnight, the tie 时辰 can start on the previous civil day: LICHUN of
+  2009 falls at 2009-02-04 00:49:48, in the 子时 that began at 02-03 23:00, so a HOUR birth
+  at 2009-02-03 23:30 ties and belongs to the new year -- on a day that DAY assigns to the
+  old side. The granularities are three readings of one rule, not nested refinements.
+
+  HOUR and MINUTE need real jieqi moments, so they require the celestial backend --
+  `Bazi.__init__` rejects the HKO backend for them (its `jieqi_moment` is a midnight
+  placeholder, see `CalendarUtilsProtocol`).
   '''
   DAY    = 0
   HOUR   = 1
@@ -99,6 +107,44 @@ class BaziPrecision(Enum):
     else:
       assert self is self.MINUTE
       return 'minute'
+
+
+'''Maps each Jie (节) to the ganzhi month it opens: 立春 -> 1 (寅月), ..., 小寒 -> 12 (丑月).'''
+_GANZHI_MONTH_OF_JIE: Final[dict[Jieqi, int]] = {
+  jie : month
+  for month, jie in enumerate(Jieqi.as_list(ganzhi_year=True)[::2], start=1)
+}
+
+
+def _truncated(dt: datetime, precision: BaziPrecision) -> datetime:
+  '''
+  Truncate `dt` to the start of `precision`'s granularity unit, so that two truncated values
+  compare per the `BaziPrecision` rule (`birth >= jieqi`, ties go new).
+  把时刻截断到 `precision` 粒度单位的起点，截断后的两个时刻即可按 `BaziPrecision` 规则比较。
+
+  Note:
+  - HOUR truncates to the start of the 时辰 (the odd clock hours: 23, 1, 3, ..., 21). The
+    start is a full datetime, not a (date, 时辰-index) pair: 子时 spans midnight, so a 23:30
+    birth must order *after* the same day's 亥时 -- an in-day index would order it first.
+  - MINUTE drops seconds and below.
+  - DAY is deliberately unsupported here: it compares dates via the `to_ganzhi` channel.
+
+  Args:
+  - dt: (datetime) The moment to truncate.
+  - precision: (BaziPrecision) `HOUR` or `MINUTE`.
+
+  Return: (datetime) The start of the granularity unit containing `dt`.
+  '''
+
+  assert isinstance(dt, datetime)
+  assert precision in (BaziPrecision.HOUR, BaziPrecision.MINUTE)
+
+  if precision is BaziPrecision.MINUTE:
+    return dt.replace(second=0, microsecond=0)
+
+  # Shift by 1 hour so 时辰 starts land on the even-hour grid, floor, then shift back.
+  shifted: Final[datetime] = dt + timedelta(hours=1)
+  return datetime.combine(shifted.date(), time(shifted.hour - (shifted.hour % 2))) - timedelta(hours=1)
 
 
 class Bazi:
@@ -162,19 +208,51 @@ class Bazi:
     self._gender: Final[BaziGender] = gender
     self._precision: Final[BaziPrecision] = precision
 
-    # Generate ganzhi-related info.
-    # TODO: Currently only supports `DAY` precision.
-    assert self._precision == BaziPrecision.DAY, 'see https://github.com/0xf3cd/bazi/issues/6'
+    # Generate ganzhi-related info: which ganzhi year / month the birth belongs to, compared
+    # per `BaziPrecision` (`birth >= jieqi` at the known granularity, ties go new).
+    ganzhi_year: int
+    ganzhi_month: int
+    bracketing_jies: Optional[tuple[JieqiTime, JieqiTime]] = None
+    if self._precision is BaziPrecision.DAY:
+      # DAY compares dates: the `to_ganzhi` channel drops the time, so a jieqi's whole day
+      # falls on its new side. `bracketing_jies` stays moment-level for DAY (see the property).
+      ganzhi_calendardate: CalendarDate = utils.to_ganzhi(self._solar_date)
+      ganzhi_year = ganzhi_calendardate.year
+      ganzhi_month = ganzhi_calendardate.month # `ganzhi_calendardate` is already at `DAY`-level precision.
+    else:
+      if self._backend is CalendarBackend.HKO:
+        raise ValueError(
+          f'{self._precision} needs real jieqi moments, which the HKO backend cannot provide '
+          '(its `jieqi_moment` is a midnight placeholder). Use `CalendarBackend.CELESTIAL`.'
+        )
 
-    ganzhi_calendardate: CalendarDate = utils.to_ganzhi(self._solar_date)
+      # The truncated birth can never exceed the truncated next jie (truncation is monotone),
+      # so `>=` can only hit as a tie -- in which case the next jie owns the birth month, and
+      # its true moment may be up to one granularity unit after the birth (子时 spans midnight,
+      # so for HOUR the tie window may even start on the previous civil day).
+      birth_moment: Final[datetime] = self.solar_datetime
+      prev_j: Final[JieqiTime] = utils.prev_jie(birth_moment)
+      next_j: Final[JieqiTime] = utils.next_jie(birth_moment)
+      if _truncated(birth_moment, self._precision) >= _truncated(next_j.moment, self._precision):
+        bracketing_jies = (next_j, utils.next_jie(next_j.moment))
+      else:
+        bracketing_jies = (prev_j, next_j)
 
-    # Figure out the solar date falls into which ganzhi year.
-    # Also figure out the Year Ganzhi / Year Pillar (年柱).
-    self._ganzhi_year: Final[int] = ganzhi_calendardate.year
+      # Derive the ganzhi year / month from the owning jie -- the same source `BaziChart`
+      # consumes via `bracketing_jies`, so the chart cannot contradict itself. 小寒 opens the
+      # last month of the *previous* ganzhi year (立春 has not come yet in its solar year).
+      owning: Final[JieqiTime] = bracketing_jies[0]
+      ganzhi_year = owning.moment.year - (1 if owning.jieqi is Jieqi.小寒 else 0)
+      ganzhi_month = _GANZHI_MONTH_OF_JIE[owning.jieqi]
+
+    self._bracketing_jies: Final[Optional[tuple[JieqiTime, JieqiTime]]] = bracketing_jies
+
+    # The Year Ganzhi / Year Pillar (年柱).
+    self._ganzhi_year: Final[int] = ganzhi_year
     self._year_pillar: Final[Ganzhi] = ganzhi_of_year(self._ganzhi_year)
 
-    # Figure out the ganzhi month. Also find out the Month Dizhi (月令).
-    self._ganzhi_month: Final[int] = ganzhi_calendardate.month # `ganzhi_calendardate` is already at `DAY`-level precision.
+    # The ganzhi month and the Month Dizhi (月令).
+    self._ganzhi_month: Final[int] = ganzhi_month
     assert 1 <= self._ganzhi_month <= 12
     self._month_dizhi: Final[Dizhi] = Dizhi.from_index((2 + self._ganzhi_month - 1) % 12)
 
@@ -308,8 +386,43 @@ class Bazi:
   
   @property
   def ganzhi_date(self) -> CalendarDate:
-    '''The birth date (in ganzhi calendar) / 干支历出生日期'''
+    '''
+    The birth date (in ganzhi calendar) / 干支历出生日期
+
+    Note: this is a day-level channel by definition -- its input is a date. Under `HOUR` /
+    `MINUTE` precision it can disagree with `ganzhi_year` / the year and month pillars inside
+    a jieqi's tie window; precision-attributed consumers should use `ganzhi_year` instead.
+    '''
     return self._utils.to_ganzhi(self._solar_date)
+
+  @property
+  def ganzhi_year(self) -> int:
+    '''
+    The ganzhi year the birth belongs to, attributed at `self.precision` -- the year pillar is
+    `ganzhi_of_year` of exactly this. 按 `self.precision` 粒度归属的出生干支年，年柱即由它推出。
+    '''
+    return self._ganzhi_year
+
+  @property
+  def bracketing_jies(self) -> tuple[JieqiTime, JieqiTime]:
+    '''
+    The two Jies (节) bracketing the birth, per `self.precision`. This is the single source
+    that the year/month attribution and `BaziChart`'s dayun counting share, so a chart cannot
+    contradict itself about which jie owns the birth month.
+    按 `self.precision` 归属的出生前后两节。年/月柱归属与大运数节共用此单一来源，保证盘面自洽。
+
+    Note:
+    - HOUR / MINUTE: `[0]` is the jie owning the birth month (granularity-aware, ties go new --
+      so its true moment may be up to one granularity unit *after* the birth), `[1]` the jie
+      after it.
+    - DAY: moment-level `prev_jie` / `next_jie` of the birth moment -- unchanged pre-existing
+      behaviour. The DAY month pillar compares dates while these compare moments, so on a
+      jieqi's day they legitimately disagree; that trade-off is pinned by `test_bazi` and
+      documented in `CalendarUtilsProtocol`.
+    '''
+    if self._bracketing_jies is not None:
+      return self._bracketing_jies
+    return (self._utils.prev_jie(self.solar_datetime), self._utils.next_jie(self.solar_datetime))
 
   @property
   def hour(self) -> int:

--- a/src/Bazi.py
+++ b/src/Bazi.py
@@ -90,6 +90,7 @@ class BaziPrecision(Enum):
   2009 falls at 2009-02-04 00:49:48, in the 子时 that began at 02-03 23:00, so a HOUR birth
   at 2009-02-03 23:30 ties and belongs to the new year -- on a day that DAY assigns to the
   old side. The granularities are three readings of one rule, not nested refinements.
+  子时跨午夜，tie 时辰可始于节气前一公历日——三档是同一规则的三种读法，不是嵌套细化。
 
   HOUR and MINUTE need real jieqi moments, so they require the celestial backend --
   `Bazi.__init__` rejects the HKO backend for them (its `jieqi_moment` is a midnight
@@ -109,7 +110,7 @@ class BaziPrecision(Enum):
       return 'minute'
 
 
-'''Maps each Jie (节) to the ganzhi month it opens: 立春 -> 1 (寅月), ..., 小寒 -> 12 (丑月).'''
+'''Maps each Jie (节) to the ganzhi month it opens: 立春 -> 1 (寅月), ..., 小寒 -> 12 (丑月). / 每个节到其所开干支月的映射：立春开寅月，……，小寒开丑月。'''
 _GANZHI_MONTH_OF_JIE: Final[dict[Jieqi, int]] = {
   jie : month
   for month, jie in enumerate(Jieqi.as_list(ganzhi_year=True)[::2], start=1)
@@ -208,8 +209,8 @@ class Bazi:
     self._gender: Final[BaziGender] = gender
     self._precision: Final[BaziPrecision] = precision
 
-    # Generate ganzhi-related info: which ganzhi year / month the birth belongs to, compared
-    # per `BaziPrecision` (`birth >= jieqi` at the known granularity, ties go new).
+    # Which ganzhi year / month owns the birth, compared per `BaziPrecision`
+    # (`birth >= jieqi` at the known granularity, ties go new).
     ganzhi_year: int
     ganzhi_month: int
     bracketing_jies: Optional[tuple[JieqiTime, JieqiTime]] = None
@@ -259,9 +260,10 @@ class Bazi:
     # Figure out the ganzhi day, as well as the Day Ganzhi / Day Pillar (日柱).
     #
     # 晚子时换日: the day pillar rolls at 23:00 (when 子时 begins), which the year and month
-    # pillars above deliberately do NOT do -- they compare dates, per `BaziPrecision`. So a
-    # birth at 23:30 takes the *next* day's day pillar while keeping the *current* date's year
-    # and month pillars. Both halves of that are variants tracked in issue #69, and a 子正换日
+    # pillars above deliberately do NOT do -- they follow `BaziPrecision`'s attribution
+    # (dates at DAY, truncated moments at HOUR/MINUTE). So a 23:30 birth takes the *next*
+    # day's day pillar while its year/month attribution stays put, except inside a tie
+    # window. Both halves of that are variants tracked in issue #69, and a 子正换日
     # variant has to say which pillars it moves; `test_bazi` pins today's answer meanwhile.
     day_offset: int = 0 if self._birth_time.hour < 23 else 1
     self._day_pillar: Final[Ganzhi] = ganzhi_of_day(timedelta(days=day_offset) + self._birth_time)

--- a/src/BaziChart.py
+++ b/src/BaziChart.py
@@ -232,9 +232,15 @@ class BaziChart:
     birthtime: Final[datetime] = self._bazi.solar_datetime
 
     def __gap() -> timedelta:
+      # Count from `Bazi.bracketing_jies` -- the same source the month pillar's attribution
+      # uses -- so the jie counted here is always the jie that owns the birth month.
+      prev_j, next_j = self._bazi.bracketing_jies
       if self.dayun_order:
-        return self._utils.next_jie(birthtime).moment - birthtime
-      return birthtime - self._utils.prev_jie(birthtime).moment
+        return next_j.moment - birthtime
+      # Ties go new, so under HOUR/MINUTE the owning jie's true moment can fall up to one
+      # granularity unit *after* the birth; the dayun then starts at the birth itself. For
+      # DAY, `prev_jie(birthtime).moment <= birthtime` always holds and the clamp is inert.
+      return max(timedelta(0), birthtime - prev_j.moment)
     
     def __diff() -> timedelta:
       gap: Final[timedelta] = __gap()
@@ -292,7 +298,9 @@ class BaziChart:
 
     step: Final[int] = 1 if self.dayun_order else -1
     utils: Final[CalendarUtilsProtocol] = self._utils
-    until_xusui_age: Final[int] = 1 + utils.to_ganzhi(self.dayun_start_moment).year - utils.to_ganzhi(self._bazi.solar_datetime).year
+    # The birth-side year is `Bazi.ganzhi_year` (precision-attributed, same source as the
+    # year pillar); the dayun start is a future moment, labelled at day level as before.
+    until_xusui_age: Final[int] = 1 + utils.to_ganzhi(self.dayun_start_moment).year - self._bazi.ganzhi_year
 
     def __xiaoyun_at_age(age: int) -> XiaoyunTuple:
       return XiaoyunTuple(age, self._bazi.hour_pillar.next(age * step))
@@ -315,7 +323,9 @@ class BaziChart:
     '''
 
     def __liunian_generator() -> Generator[LiunianTuple, None, None]:
-      year: int = self._bazi.ganzhi_date.year
+      # Start from `Bazi.ganzhi_year` (precision-attributed, same source as the year pillar),
+      # so the first liunian's ganzhi always equals the year pillar.
+      year: int = self._bazi.ganzhi_year
       while True:
         yield LiunianTuple(year, ganzhi_of_year(year))
         year += 1

--- a/src/BaziChart.py
+++ b/src/BaziChart.py
@@ -232,8 +232,9 @@ class BaziChart:
     birthtime: Final[datetime] = self._bazi.solar_datetime
 
     def __gap() -> timedelta:
-      # Count from `Bazi.bracketing_jies` -- the same source the month pillar's attribution
-      # uses -- so the jie counted here is always the jie that owns the birth month.
+      # Count from `Bazi.bracketing_jies`: under HOUR/MINUTE that is exactly the jie owning
+      # the month pillar; under DAY it keeps the adjudicated moment-level counting, which on
+      # a jieqi's day can legitimately name a different jie (see `Bazi.bracketing_jies`).
       prev_j, next_j = self._bazi.bracketing_jies
       if self.dayun_order:
         return next_j.moment - birthtime
@@ -248,7 +249,21 @@ class BaziChart:
       return years * timedelta(days=365) # Assume 1 year = 365 days.
     
     return birthtime + __diff()
-  
+
+  @property
+  def _dayun_start_ganzhi_year(self) -> int:
+    '''
+    The ganzhi year the first dayun starts in: the day-level label of `dayun_start_moment`,
+    floored at `Bazi.ganzhi_year`. The start never precedes the birth, so its year can never
+    precede the birth's attributed year -- but a clamped start IS the birth itself, and on a
+    cross-midnight tie chart (HOUR) its civil day still carries the OLD day-level year;
+    without the floor that would mislabel the first dayun and empty the xiaoyun. The floor
+    is inert for DAY, whose attribution is day-level and monotone in time.
+    交运干支年：交运时刻的日级年份标注，下限为 `Bazi.ganzhi_year`（交运不早于出生，其年份在
+    盘面自身的归属体系里也不得早于出生年）。
+    '''
+    return max(self._utils.to_ganzhi(self.dayun_start_moment).year, self._bazi.ganzhi_year)
+
   @property
   def dayun(self) -> Generator[DayunTuple, None, None]:
     '''
@@ -271,7 +286,7 @@ class BaziChart:
 
     def __dayun_generator() -> Generator[DayunTuple, None, None]:
       step: Final[int] = 1 if self.dayun_order else -1
-      ganzhi_year: int = self._utils.to_ganzhi(self.dayun_start_moment).year
+      ganzhi_year: int = self._dayun_start_ganzhi_year
       gz: Ganzhi = self._bazi.month_pillar.next(step)
 
       while True:
@@ -297,10 +312,10 @@ class BaziChart:
     '''
 
     step: Final[int] = 1 if self.dayun_order else -1
-    utils: Final[CalendarUtilsProtocol] = self._utils
-    # The birth-side year is `Bazi.ganzhi_year` (precision-attributed, same source as the
-    # year pillar); the dayun start is a future moment, labelled at day level as before.
-    until_xusui_age: Final[int] = 1 + utils.to_ganzhi(self.dayun_start_moment).year - self._bazi.ganzhi_year
+    # Xiaoyun covers the xusui ages before the first dayun starts. Both ends of the
+    # subtraction live in the chart's own attribution (see `_dayun_start_ganzhi_year`),
+    # so the count can never go below one.
+    until_xusui_age: Final[int] = 1 + self._dayun_start_ganzhi_year - self._bazi.ganzhi_year
 
     def __xiaoyun_at_age(age: int) -> XiaoyunTuple:
       return XiaoyunTuple(age, self._bazi.hour_pillar.next(age * step))

--- a/src/Transits.py
+++ b/src/Transits.py
@@ -10,7 +10,6 @@ from typing import Final, Generator
 
 from .Common import DayunTuple, frozendict
 from .Defines import Ganzhi, Dizhi
-from .Calendar import CalendarDate
 from .Utils.BaziUtils import ganzhi_of_year
 from .BaziChart import BaziChart
 
@@ -117,11 +116,14 @@ _ALL_OPTIONS: Final[tuple[TransitOptions, ...]] = tuple(_all_options())
 class TransitDatabase:
   '''A database that figures out the Ganzhis of transits.'''
   def __init__(self, chart: BaziChart) -> None:
-    self._birth_ganzhi_date: CalendarDate = chart.bazi.ganzhi_date
+    # The birth-side year is `Bazi.ganzhi_year` -- precision-attributed, same source as the
+    # year pillar -- NOT the day-level `ganzhi_date.year`, which disagrees with it inside a
+    # cross-midnight tie window (HOUR) and would shift every xiaoyun year by one and admit
+    # liunian years the chart's own generator never produces.
+    self._birth_ganzhi_year: Final[int] = chart.bazi.ganzhi_year
 
-    birth_gz_year: Final[int] = chart.bazi.ganzhi_date.year
     self._xiaoyun_ganzhis: Final[frozendict[int, Ganzhi]] = frozendict({
-      birth_gz_year + age - 1 : gz
+      self._birth_ganzhi_year + age - 1 : gz
       for age, gz in chart.xiaoyun
     })
 
@@ -156,7 +158,7 @@ class TransitDatabase:
       if gz_year < self._first_dayun_start_gz_year:
         return False
     if options.value & TransitOptions.LIUNIAN.value:
-      if gz_year < self._birth_ganzhi_date.year:
+      if gz_year < self._birth_ganzhi_year:
         return False
 
     return True
@@ -193,7 +195,7 @@ class TransitDatabase:
       assert gz_year >= self._first_dayun_start_gz_year
       transit_ganzhis.append(self._dayun_db[gz_year].ganzhi)
     if options.value & TransitOptions.LIUNIAN.value:
-      assert gz_year >= self._birth_ganzhi_date.year
+      assert gz_year >= self._birth_ganzhi_year
       transit_ganzhis.append(ganzhi_of_year(gz_year))
 
     return tuple(transit_ganzhis)

--- a/tests/test_bazi.py
+++ b/tests/test_bazi.py
@@ -5,14 +5,17 @@ import unittest
 import random
 import copy
 
+import pytest
+
 from itertools import product
-from datetime import date, datetime, timedelta
+from datetime import date, time, datetime, timedelta
 from zoneinfo import ZoneInfo
 from typing import Union
 
-from src.Defines import Tiangan, Dizhi, Ganzhi
+from src.Common import JieqiTime
+from src.Defines import Tiangan, Dizhi, Ganzhi, Jieqi
 from src.Bazi import BaziGender, BaziPrecision, Bazi, 八字
-from src.Calendar import HkoDataCalendarUtils
+from src.Calendar import HkoDataCalendarUtils, CalendarBackend, calendar_utils_of
 
 class TestBaziGender(unittest.TestCase):
   def test_basic(self) -> None:
@@ -90,6 +93,209 @@ class TestBaziPrecision(unittest.TestCase):
         self.assertEqual(str(bazi.year_pillar), year)
         self.assertEqual(str(bazi.month_pillar), month)
         self.assertEqual(str(bazi.day_pillar), day)
+
+
+class TestBaziHourMinutePrecisions(unittest.TestCase):
+  '''
+  HOUR / MINUTE precisions (issue #6): `birth >= jieqi` compared at the known granularity,
+  ties go new. The reference rule text is the `BaziPrecision` docstring.
+  '''
+
+  # The jie owning a birth month opens it: 立春 opens 寅月, and so on. Written out as data
+  # (not derived from enum order) so the tests share no derivation with `src.Bazi`.
+  JIE_MONTH_DIZHI: dict[Jieqi, Dizhi] = {
+    Jieqi.立春 : Dizhi.寅,  Jieqi.惊蛰 : Dizhi.卯,  Jieqi.清明 : Dizhi.辰,
+    Jieqi.立夏 : Dizhi.巳,  Jieqi.芒种 : Dizhi.午,  Jieqi.小暑 : Dizhi.未,
+    Jieqi.立秋 : Dizhi.申,  Jieqi.白露 : Dizhi.酉,  Jieqi.寒露 : Dizhi.戌,
+    Jieqi.立冬 : Dizhi.亥,  Jieqi.大雪 : Dizhi.子,  Jieqi.小寒 : Dizhi.丑,
+  }
+
+  @staticmethod
+  def __truncated(dt: datetime, precision: BaziPrecision) -> datetime:
+    '''Independent re-statement of the granularity truncation, for oracle use.'''
+    if precision is BaziPrecision.MINUTE:
+      return dt.replace(second=0, microsecond=0)
+    assert precision is BaziPrecision.HOUR
+    shifted: datetime = dt + timedelta(hours=1)
+    return datetime.combine(shifted.date(), time(shifted.hour - (shifted.hour % 2))) - timedelta(hours=1)
+
+  def test_goldens_from_the_docstring(self) -> None:
+    '''
+    The `BaziPrecision` docstring's worked examples, pinned:
+    - 立春 2000 = 02-04 20:40:23 -- the same-day 时辰 tie (戌时) and the minute tie.
+    - 立春 2017 = 02-03 23:34:03 -- the tie 时辰 (子时) starts at 23:00 of the jieqi's own day.
+    - 立春 2009 = 02-04 00:49:48 -- the tie 时辰 starts on the PREVIOUS civil day, so HOUR
+      attributes a 02-03 23:30 birth to the new year on a day DAY assigns to the old side.
+      The granularities are three readings of one rule, not nested refinements.
+    '''
+    expected: list[tuple[str, str, str, Dizhi]] = [
+      ('2000-02-04 19:30', 'hour',   '庚辰', Dizhi.寅), # 戌时 [19:00, 21:00) holds the jieqi: tie -> new.
+      ('2000-02-04 20:59', 'hour',   '庚辰', Dizhi.寅),
+      ('2000-02-04 18:59', 'hour',   '己卯', Dizhi.丑), # 酉时: before the jieqi's 时辰 -> old.
+      ('2000-02-04 20:40', 'minute', '庚辰', Dizhi.寅), # Same minute as the jieqi: tie -> new.
+      ('2000-02-04 20:41', 'minute', '庚辰', Dizhi.寅),
+      ('2000-02-04 20:39', 'minute', '己卯', Dizhi.丑),
+      ('2000-02-05 04:00', 'hour',   '庚辰', Dizhi.寅), # Plain interior moments, both sides.
+      ('2000-02-03 12:00', 'minute', '己卯', Dizhi.丑),
+
+      ('2017-02-03 23:10', 'hour',   '丁酉', Dizhi.寅), # 子时 starts 23:00, holds 立春 23:34:03: tie.
+      ('2017-02-04 00:30', 'hour',   '丁酉', Dizhi.寅), # Still the same 子时, next civil day.
+      ('2017-02-03 22:30', 'hour',   '丙申', Dizhi.丑), # 亥时 -> old, on a day DAY assigns new.
+      ('2017-02-03 23:10', 'minute', '丙申', Dizhi.丑), # At minute granularity 23:10 < 23:34.
+      ('2017-02-03 23:34', 'minute', '丁酉', Dizhi.寅),
+
+      ('2009-02-03 23:30', 'hour',   '己丑', Dizhi.寅), # Cross-midnight tie: 立春 02-04 00:49:48.
+      ('2009-02-04 00:30', 'hour',   '己丑', Dizhi.寅), # The tie seen from the jieqi's own day.
+      ('2009-02-03 22:59', 'hour',   '戊子', Dizhi.丑), # 亥时, right before the tie window opens.
+      ('2009-02-04 00:49', 'minute', '己丑', Dizhi.寅),
+      ('2009-02-04 00:48', 'minute', '戊子', Dizhi.丑),
+      ('2009-01-10 12:00', 'minute', '戊子', Dizhi.丑), # 丑月 interior: owned by 小寒 of 2009.
+    ]
+    for moment, precision, year_pillar, month_dizhi in expected:
+      with self.subTest(moment=moment, precision=precision):
+        bazi: Bazi = Bazi.create(moment, 'male', precision)
+        self.assertEqual(str(bazi.year_pillar), year_pillar)
+        self.assertEqual(bazi.month_commander, month_dizhi)
+
+  def test_day_and_hour_pillars_ignore_precision(self) -> None:
+    '''Precision only moves the year/month attribution; the day/hour pillars must not move.'''
+    moments: list[str] = ['2009-02-03 23:30', '2017-02-03 23:10', '2000-02-04 20:39', '1984-02-04 12:30']
+    for moment in moments:
+      day_bazi: Bazi = Bazi.create(moment, 'female', 'day')
+      for precision in ('hour', 'minute'):
+        with self.subTest(moment=moment, precision=precision):
+          bazi: Bazi = Bazi.create(moment, 'female', precision)
+          self.assertEqual(bazi.day_pillar, day_bazi.day_pillar)
+          self.assertEqual(bazi.hour_pillar, day_bazi.hour_pillar)
+
+  def test_hko_backend_rejected(self) -> None:
+    '''HOUR / MINUTE need real jieqi moments; the HKO backend's are midnight placeholders.'''
+    for precision in (BaziPrecision.HOUR, BaziPrecision.MINUTE):
+      with self.subTest(precision=precision):
+        with self.assertRaises(ValueError):
+          Bazi(datetime(2000, 2, 4, 19, 30), BaziGender.MALE, precision, CalendarBackend.HKO)
+    self.assertEqual(str(Bazi.create('2000-02-04 19:30', 'male', 'day', backend='hko').year_pillar), '庚辰')
+
+  def test_ganzhi_year_and_bracketing_jies_are_the_attribution(self) -> None:
+    '''`ganzhi_year` / `bracketing_jies` expose exactly what the pillars were derived from.'''
+    bazi: Bazi = Bazi.create('2009-02-04 00:30', 'male', 'hour')
+    self.assertEqual(bazi.ganzhi_year, 2009)
+    owning, following = bazi.bracketing_jies
+    self.assertEqual(owning, JieqiTime(Jieqi.立春, datetime(2009, 2, 4, 0, 49, 48)))
+    self.assertEqual(following.jieqi, Jieqi.惊蛰)
+    # The owning jie's true moment lies AFTER the birth -- that is what a tie looks like.
+    self.assertGreater(owning.moment, bazi.solar_datetime)
+    # `ganzhi_date` stays a day-level channel: on the jieqi's own day the two channels agree
+    # (DAY gives the whole day to the new side), but for the cross-midnight tie birth on the
+    # PREVIOUS day they legitimately disagree.
+    self.assertEqual(bazi.ganzhi_date.year, 2009)
+    advance: Bazi = Bazi.create('2009-02-03 23:30', 'male', 'hour')
+    self.assertEqual(advance.ganzhi_year, 2009)
+    self.assertEqual(advance.ganzhi_date.year, 2008)
+
+  @pytest.mark.slow
+  def test_attribution_matches_scan_oracle(self) -> None:
+    '''
+    Independent oracle, two derivations compared:
+    - Year: compare the truncated birth against the truncated 立春 of its solar year directly.
+    - Month: linearly scan all nearby Jies and take the LAST one whose truncated moment is
+      <= the truncated birth (ties go new), then map it to a month via literal data.
+    The scan shares none of `Bazi.__init__`'s bracketing/tie-flip shortcut, so a bug in
+    either derivation shows up as a mismatch.
+
+    Also pins the divergence-from-DAY shape: a finer granularity may disagree with DAY only
+    around a jie's own day -- retreating (jieqi-day birth before the jie's truncated moment)
+    or advancing (previous-day 晚子时 birth tying a 00:xx jie across midnight). Both windows
+    are sampled densely by biasing half the moments to fall near a jie.
+    '''
+    utils = calendar_utils_of(CalendarBackend.CELESTIAL)
+    rng = random.Random(6) # Deterministic sampling; seeded with the issue number.
+
+    all_jies: list[Jieqi] = Jieqi.as_list(ganzhi_year=False)[::2]
+
+    def __random_moment() -> datetime:
+      uniform: datetime = datetime(
+        rng.randint(1902, 2080), rng.randint(1, 12), rng.randint(1, 28),
+        rng.randint(0, 23), rng.randint(0, 59),
+      )
+      if rng.random() < 0.5:
+        return uniform
+      # Bias near a jie so tie windows (rare under uniform sampling) are exercised densely.
+      jie_moment: datetime = utils.jieqi_moment(uniform.year, rng.choice(all_jies))
+      biased: datetime = jie_moment + timedelta(minutes=rng.randint(-180, 180))
+      return biased.replace(second=0, microsecond=0)
+
+    total: int = 30_000
+    divergent: int = 0
+    for _ in range(total):
+      birth: datetime = __random_moment()
+      day_bazi: Bazi = Bazi(birth, BaziGender.女, BaziPrecision.DAY)
+
+      candidates: list[JieqiTime] = sorted(
+        (JieqiTime(jie, utils.jieqi_moment(year, jie))
+         for year in (birth.year - 1, birth.year) for jie in all_jies),
+        key=lambda jt: jt.moment,
+      )
+
+      for precision in (BaziPrecision.HOUR, BaziPrecision.MINUTE):
+        with self.subTest(birth=birth, precision=precision):
+          bazi: Bazi = Bazi(birth, BaziGender.女, precision)
+
+          trunc_birth: datetime = self.__truncated(birth, precision)
+          lichun: datetime = utils.jieqi_moment(birth.year, Jieqi.立春)
+          expected_year: int = birth.year if trunc_birth >= self.__truncated(lichun, precision) else birth.year - 1
+          self.assertEqual(bazi.ganzhi_year, expected_year)
+
+          owning: JieqiTime = max(
+            (jt for jt in candidates if self.__truncated(jt.moment, precision) <= trunc_birth),
+            key=lambda jt: jt.moment,
+          )
+          self.assertEqual(bazi.month_commander, self.JIE_MONTH_DIZHI[owning.jieqi])
+
+          # Divergence-from-DAY shape: only inside a tie window around a jie's own day.
+          if (bazi.year_pillar, bazi.month_commander) != (day_bazi.year_pillar, day_bazi.month_commander):
+            divergent += 1
+            day_owning: JieqiTime = max(
+              (jt for jt in candidates if jt.moment.date() <= birth.date()),
+              key=lambda jt: jt.moment,
+            )
+            if owning.moment > day_owning.moment:  # Advance: cross-midnight 晚子时 tie.
+              self.assertIs(precision, BaziPrecision.HOUR)
+              self.assertEqual(self.__truncated(owning.moment, precision), trunc_birth)
+              self.assertLess(birth.date(), owning.moment.date())
+            else:                                  # Retreat: jieqi-day birth before the moment.
+              self.assertEqual(birth.date(), day_owning.moment.date())
+              self.assertLess(trunc_birth, self.__truncated(day_owning.moment, precision))
+
+    # The biased sampling must actually have exercised the divergence windows.
+    self.assertGreater(divergent, 100)
+
+  @pytest.mark.slow
+  def test_minute_vs_moment_level_prev_jie(self) -> None:
+    '''
+    MINUTE attribution vs the moment-level `prev_jie`: the two may disagree ONLY at a
+    same-minute tie (birth in the same minute as the jieqi but before its true second --
+    ties go new, `prev_jie` stays old). At any other moment they must agree.
+    '''
+    utils = calendar_utils_of(CalendarBackend.CELESTIAL)
+    rng = random.Random(72) # Seeded with the issue this rule closes.
+
+    all_jies: list[Jieqi] = Jieqi.as_list(ganzhi_year=False)[::2]
+    for _ in range(2_000):
+      jie_moment: datetime = utils.jieqi_moment(rng.randint(1902, 2080), rng.choice(all_jies))
+      birth: datetime = (jie_moment + timedelta(seconds=rng.randint(-90, 90))).replace(second=0, microsecond=0)
+
+      bazi: Bazi = Bazi(birth, BaziGender.男, BaziPrecision.MINUTE)
+      moment_owning: JieqiTime = utils.prev_jie(birth)
+      attribution_owning: JieqiTime = bazi.bracketing_jies[0]
+
+      with self.subTest(birth=birth):
+        if attribution_owning != moment_owning:
+          next_j: JieqiTime = utils.next_jie(birth)
+          self.assertEqual(attribution_owning, next_j)
+          self.assertEqual(next_j.moment.replace(second=0, microsecond=0), birth) # Same minute.
+          self.assertLess(birth, next_j.moment)                                   # Before the true second.
+        self.assertEqual(bazi.month_commander, self.JIE_MONTH_DIZHI[attribution_owning.jieqi])
 
 
 class TestBazi(unittest.TestCase):
@@ -377,10 +583,12 @@ class TestBazi(unittest.TestCase):
       self.assertEqual(bazi.hour, expected_bazi.hour)
       self.assertEqual(bazi.minute, expected_bazi.minute)
 
-    unsupported_precision_options: list = [BaziPrecision.HOUR, BaziPrecision.MINUTE, 'hour', 'minute', 'H', 'm', '时', '小时', '分', '分钟']
-    for dt, g, p in product(dt_options, male_options + female_options, unsupported_precision_options):
-      with self.assertRaises(AssertionError):
-        Bazi.create(dt, g, p) # Other level precision is not supported at the moment
+    finer_precision_options: list = [BaziPrecision.HOUR, BaziPrecision.MINUTE, 'hour', 'minute', 'H', 'm', '时', '小时', '分', '分钟']
+    for dt, g, p in product(dt_options, male_options + female_options, finer_precision_options):
+      bazi = Bazi.create(dt, g, p) # Supported since issue #6 -- on the celestial backend only.
+      self.assertIn(bazi.precision, (BaziPrecision.HOUR, BaziPrecision.MINUTE))
+      with self.assertRaises(ValueError):
+        Bazi.create(dt, g, p, backend='hko') # HKO has no real jieqi moments.
 
   def test_eq_ne(self) -> None:
     def __random_info() -> tuple[datetime, BaziGender, BaziPrecision]:

--- a/tests/test_bazi.py
+++ b/tests/test_bazi.py
@@ -112,12 +112,18 @@ class TestBaziHourMinutePrecisions(unittest.TestCase):
 
   @staticmethod
   def __truncated(dt: datetime, precision: BaziPrecision) -> datetime:
-    '''Independent re-statement of the granularity truncation, for oracle use.'''
+    '''
+    Independent re-statement of the granularity truncation, for oracle use. HOUR scans the
+    时辰 boundaries (the odd clock hours, plus the previous day's 23:00) and takes the latest
+    one at or before `dt` -- deliberately NOT the shift-floor-shift formula `src.Bazi` uses,
+    so the oracle and the implementation cannot share a truncation error.
+    '''
     if precision is BaziPrecision.MINUTE:
       return dt.replace(second=0, microsecond=0)
     assert precision is BaziPrecision.HOUR
-    shifted: datetime = dt + timedelta(hours=1)
-    return datetime.combine(shifted.date(), time(shifted.hour - (shifted.hour % 2))) - timedelta(hours=1)
+    boundaries: list[datetime] = [datetime.combine(dt.date() - timedelta(days=1), time(23))]
+    boundaries += [datetime.combine(dt.date(), time(h)) for h in range(1, 24, 2)]
+    return max(b for b in boundaries if b <= dt)
 
   def test_goldens_from_the_docstring(self) -> None:
     '''
@@ -270,17 +276,19 @@ class TestBaziHourMinutePrecisions(unittest.TestCase):
     # The biased sampling must actually have exercised the divergence windows.
     self.assertGreater(divergent, 100)
 
-  @pytest.mark.slow
   def test_minute_vs_moment_level_prev_jie(self) -> None:
     '''
     MINUTE attribution vs the moment-level `prev_jie`: the two may disagree ONLY at a
     same-minute tie (birth in the same minute as the jieqi but before its true second --
-    ties go new, `prev_jie` stays old). At any other moment they must agree.
+    ties go new, `prev_jie` stays old). At any other moment they must agree, and the
+    sampling must actually produce ties -- without the floor assertion, an implementation
+    degenerated to pure moment-level `prev_jie` would sail through green.
     '''
     utils = calendar_utils_of(CalendarBackend.CELESTIAL)
     rng = random.Random(72) # Seeded with the issue this rule closes.
 
     all_jies: list[Jieqi] = Jieqi.as_list(ganzhi_year=False)[::2]
+    disagree: int = 0
     for _ in range(2_000):
       jie_moment: datetime = utils.jieqi_moment(rng.randint(1902, 2080), rng.choice(all_jies))
       birth: datetime = (jie_moment + timedelta(seconds=rng.randint(-90, 90))).replace(second=0, microsecond=0)
@@ -291,11 +299,14 @@ class TestBaziHourMinutePrecisions(unittest.TestCase):
 
       with self.subTest(birth=birth):
         if attribution_owning != moment_owning:
+          disagree += 1
           next_j: JieqiTime = utils.next_jie(birth)
           self.assertEqual(attribution_owning, next_j)
           self.assertEqual(next_j.moment.replace(second=0, microsecond=0), birth) # Same minute.
           self.assertLess(birth, next_j.moment)                                   # Before the true second.
         self.assertEqual(bazi.month_commander, self.JIE_MONTH_DIZHI[attribution_owning.jieqi])
+
+    self.assertGreater(disagree, 0) # At seed 72 the ties number in the hundreds.
 
 
 class TestBazi(unittest.TestCase):

--- a/tests/test_bazichart.py
+++ b/tests/test_bazichart.py
@@ -547,7 +547,6 @@ class TestBaziChart(unittest.TestCase):
     self.assertIsNot(chart._bazi, old_bazi)
 
 
-
 class TestBaziChartHourMinutePrecisions(unittest.TestCase):
   '''
   HOUR / MINUTE charts (issue #6): the dayun counting and the birth-side year consume the
@@ -591,6 +590,27 @@ class TestBaziChartHourMinutePrecisions(unittest.TestCase):
     birth: datetime = chart.bazi.solar_datetime
     gap: timedelta = datetime(2009, 2, 4, 0, 49, 48) - birth
     self.assertEqual(chart.dayun_start_moment, birth + (gap / timedelta(days=3)) * timedelta(days=365))
+
+  def test_backward_clamp_across_midnight_matches_the_same_shichen(self) -> None:
+    '''
+    R1 convergence find (grok / fable / kimi independently): the cross-midnight tie birth
+    (2009-02-03 23:30, male -> backward, clamp) must produce the SAME xiaoyun and dayun-year
+    face as its same-子时 sibling on the jieqi's own day (02-04 00:30) -- the four pillars
+    are identical, so the charts must be too. Before the fix, the day-level relabel of the
+    clamped start (= the birth itself, whose civil day still carries the OLD year) emptied
+    the xiaoyun and put the first dayun in 2008, contradicting the 己丑 2009 year pillar.
+    '''
+    across: BaziChart = BaziChart(Bazi.create('2009-02-03 23:30', 'male', 'hour'))
+    same_day: BaziChart = BaziChart(Bazi.create('2009-02-04 00:30', 'male', 'hour'))
+
+    self.assertEqual(list(across.bazi.pillars), list(same_day.bazi.pillars))
+    self.assertFalse(across.dayun_order)
+    self.assertEqual(across.dayun_start_moment, across.bazi.solar_datetime) # Clamped.
+
+    self.assertEqual(across.xiaoyun, same_day.xiaoyun)
+    self.assertEqual(len(across.xiaoyun), 1)
+    self.assertEqual(next(across.dayun).ganzhi_year, 2009)   # == the year pillar's year,
+    self.assertEqual(next(same_day.dayun).ganzhi_year, 2009) # on both sides of midnight.
 
   def test_liunian_and_xiaoyun_start_from_the_attributed_year(self) -> None:
     '''

--- a/tests/test_bazichart.py
+++ b/tests/test_bazichart.py
@@ -3,6 +3,7 @@
 
 import json
 import copy
+import random
 import itertools
 
 import pytest
@@ -11,7 +12,7 @@ import unittest
 from datetime import datetime, date, timedelta
 from typing import Optional
 
-from src.Defines import Tiangan, Ganzhi, Wuxing, Yinyang, Shishen, ShierZhangsheng
+from src.Defines import Tiangan, Dizhi, Ganzhi, Wuxing, Yinyang, Shishen, ShierZhangsheng
 from src.Bazi import BaziGender, BaziPrecision, Bazi
 from src.Utils import BaziUtils
 
@@ -406,8 +407,25 @@ class TestBaziChart(unittest.TestCase):
 
   @pytest.mark.slow
   def test_json(self) -> None:
+    def __random_chart() -> BaziChart:
+      # `Bazi.random()` is DAY-only; HOUR / MINUTE roundtrips are covered here too (issue #6).
+      precision: BaziPrecision = random.choice(list(BaziPrecision))
+      if precision is BaziPrecision.DAY:
+        return BaziChart(Bazi.random())
+      return BaziChart(Bazi.create(
+        birth_time=datetime(
+          year=random.randint(1902, 2080),
+          month=random.randint(1, 12),
+          day=random.randint(1, 28),
+          hour=random.randint(0, 23),
+          minute=random.randint(0, 59),
+        ),
+        gender=random.choice(list(BaziGender)),
+        precision=precision,
+      ))
+
     for _ in range(32):
-      chart: BaziChart = BaziChart(Bazi.random())
+      chart: BaziChart = __random_chart()
       dt: datetime = chart.bazi.solar_datetime
 
       j: BaziJson.BaziChartJsonDict = chart.json
@@ -426,15 +444,16 @@ class TestBaziChart(unittest.TestCase):
       self.assertNotEqual(chart.json, __j)
 
       self.assertEqual(datetime.fromisoformat(j['birth_time']), dt)
-      self.assertEqual(j['precision'], 'day') # Currently only supports DAY-level precision.
+      self.assertEqual(j['precision'], str(chart.bazi.precision))
 
       j_gender: BaziGender = BaziGender.MALE
       if j['gender'] == 'female':
         j_gender = BaziGender.FEMALE
       self.assertEqual(j_gender, chart.bazi.gender)
 
+      # The rebuild parses everything -- precision included -- from the json itself.
       __chart: BaziChart = BaziChart(
-        Bazi.create(datetime.fromisoformat(j['birth_time']), j_gender, BaziPrecision.DAY,
+        Bazi.create(datetime.fromisoformat(j['birth_time']), j_gender, j['precision'],
                     backend=j['backend'])
       )
 
@@ -527,3 +546,71 @@ class TestBaziChart(unittest.TestCase):
     self.assertIsNot(chart.bazi, old_bazi)
     self.assertIsNot(chart._bazi, old_bazi)
 
+
+
+class TestBaziChartHourMinutePrecisions(unittest.TestCase):
+  '''
+  HOUR / MINUTE charts (issue #6): the dayun counting and the birth-side year consume the
+  same attribution source as the pillars (`Bazi.bracketing_jies` / `Bazi.ganzhi_year`), so
+  a chart cannot contradict itself about which jie owns the birth month.
+  '''
+
+  def test_backward_dayun_counts_from_the_month_owning_jie(self) -> None:
+    '''
+    立春 2009 = 02-04 00:49:48. A HOUR birth at 02-04 00:30 ties into the new year (己丑, 阴),
+    so a male chart runs backward -- and the month-owning jie is 立春, whose true moment lies
+    19m48s AFTER the birth. Counting back to the owning jie gives a negative gap, clamped to
+    zero: the dayun starts at the birth itself. (Moment-level counting would instead walk ~29
+    days back to 小寒, starting the dayun ~9.7 years late and contradicting the 寅 month.)
+    '''
+    chart: BaziChart = BaziChart(Bazi.create('2009-02-04 00:30', 'male', 'hour'))
+    self.assertEqual(chart.bazi.month_commander, Dizhi.寅)
+    self.assertFalse(chart.dayun_order)
+    self.assertEqual(chart.dayun_start_moment, chart.bazi.solar_datetime)
+
+  def test_forward_dayun_skips_the_tie_jie(self) -> None:
+    '''
+    Same tie birth, female -> forward. The "next" jie must be the one AFTER the owning 立春,
+    i.e. 惊蛰 (2009-03-05 18:47:32) -- the owning jie already opened the birth month and does
+    not count as next, even though its true moment lies after the birth.
+    '''
+    chart: BaziChart = BaziChart(Bazi.create('2009-02-04 00:30', 'female', 'hour'))
+    self.assertTrue(chart.dayun_order)
+    birth: datetime = chart.bazi.solar_datetime
+    gap: timedelta = datetime(2009, 3, 5, 18, 47, 32) - birth
+    self.assertEqual(chart.dayun_start_moment, birth + (gap / timedelta(days=3)) * timedelta(days=365))
+
+  def test_minute_precision_counts_to_the_true_moment(self) -> None:
+    '''
+    The same birth at MINUTE precision is NOT a tie (00:30 < 00:49): the year stays 戊子 (阳,
+    male -> forward), and the next jie is 立春 itself, 19m48s away.
+    '''
+    chart: BaziChart = BaziChart(Bazi.create('2009-02-04 00:30', 'male', 'minute'))
+    self.assertEqual(chart.bazi.month_commander, Dizhi.丑)
+    self.assertTrue(chart.dayun_order)
+    birth: datetime = chart.bazi.solar_datetime
+    gap: timedelta = datetime(2009, 2, 4, 0, 49, 48) - birth
+    self.assertEqual(chart.dayun_start_moment, birth + (gap / timedelta(days=3)) * timedelta(days=365))
+
+  def test_liunian_and_xiaoyun_start_from_the_attributed_year(self) -> None:
+    '''
+    The cross-midnight tie birth (2009-02-03 23:30, HOUR) belongs to 己丑 2009; the same
+    moment at DAY belongs to 戊子 2008. In both charts the first liunian must equal the year
+    pillar -- the invariant that keeps a chart self-consistent -- and the xiaoyun age count
+    follows the same attributed year (pinned lengths: forward 己丑 chart 10, backward 戊子
+    chart 11).
+    '''
+    expected: list[tuple[str, int, str, int]] = [
+      ('hour', 2009, '己丑', 10),
+      ('day',  2008, '戊子', 11),
+    ]
+    for precision, first_year, year_pillar, xiaoyun_len in expected:
+      with self.subTest(precision=precision):
+        chart: BaziChart = BaziChart(Bazi.create('2009-02-03 23:30', 'female', precision))
+        self.assertEqual(str(chart.bazi.year_pillar), year_pillar)
+
+        first_liunian = next(chart.liunian)
+        self.assertEqual(first_liunian.ganzhi_year, first_year)
+        self.assertEqual(first_liunian.ganzhi, chart.bazi.year_pillar)
+
+        self.assertEqual(len(chart.xiaoyun), xiaoyun_len)

--- a/tests/test_transits.py
+++ b/tests/test_transits.py
@@ -198,3 +198,42 @@ class TestAllOptions(unittest.TestCase):
     for opt in _ALL_OPTIONS:
       self.assertGreater(opt.value, 0)
       self.assertEqual(full_mask, opt.value | full_mask)
+
+
+class TestTransitDatabaseHourMinutePrecisions(unittest.TestCase):
+  '''
+  HOUR / MINUTE charts (issue #6): the database's birth-side year must be the chart's own
+  precision-attributed `Bazi.ganzhi_year`, not the day-level `ganzhi_date.year`.
+  '''
+
+  def test_birth_year_is_precision_attributed(self) -> None:
+    '''
+    Cross-midnight tie chart (2009-02-03 23:30 female, HOUR): the chart's year pillar is
+    己丑 2009, its liunian generator starts at 2009, and its dayun starts in 2018 (虚岁 10).
+    Before the fix the day-level 2008 leaked in: `ganzhis(2008, LIUNIAN)` returned 戊子 --
+    a ganzhi this chart's liunian never produces -- and 虚岁 10 mapped to 2017, so the true
+    dayun-start year 2018 answered `support == False` for xiaoyun.
+    '''
+    chart: BaziChart = BaziChart(Bazi.create('2009-02-03 23:30', 'female', 'hour'))
+    self.assertEqual(chart.bazi.ganzhi_year, 2009)
+    db: TransitDatabase = TransitDatabase(chart)
+
+    for options in (TransitOptions.LIUNIAN, TransitOptions.XIAOYUN):
+      with self.subTest(options=options):
+        self.assertFalse(db.support(TransitMoment(2008), options))
+        self.assertTrue(db.support(TransitMoment(2009), options))
+
+    self.assertTrue(db.support(TransitMoment(2018), TransitOptions.XIAOYUN)) # 虚岁 10, the dayun-start year.
+    self.assertFalse(db.support(TransitMoment(2019), TransitOptions.XIAOYUN)) # Past the xiaoyun range.
+    self.assertEqual(
+      db.ganzhis(TransitMoment(2009), TransitOptions.LIUNIAN),
+      (chart.bazi.year_pillar,), # The first liunian IS the year pillar.
+    )
+
+  def test_day_precision_unchanged(self) -> None:
+    '''At DAY the two year channels agree, so the database is unaffected by the migration.'''
+    chart: BaziChart = BaziChart(Bazi.create('2009-02-03 23:30', 'female', 'day'))
+    self.assertEqual(chart.bazi.ganzhi_year, chart.bazi.ganzhi_date.year)
+    db: TransitDatabase = TransitDatabase(chart)
+    self.assertTrue(db.support(TransitMoment(2008), TransitOptions.LIUNIAN))  # 戊子 2008 IS this chart's first liunian.
+    self.assertFalse(db.support(TransitMoment(2007), TransitOptions.LIUNIAN))


### PR DESCRIPTION
## 内容

实现 #6:`BaziPrecision` 的 **HOUR / MINUTE** 档,并把出生侧归属全盘同源。#72 的 1.6% 节气日边界案例由此获得时刻级修复,随本 PR 一并关闭。

- **归属**:一个比较器 + 三截断器(`birth >= jieqi` 在已知粒度比较,相等归新;HOUR = 时辰级,截断到时辰起点时刻——子时跨日,tie 窗口可跨午夜,2009 立春 00:49:48 例已入 `BaziPrecision` docstring)。归属走 bracketing jies 直接粒度比较,小寒归前一干支年;日级 `to_ganzhi` 不再作 HOUR/MINUTE 归属通道。
- **同源**:`Bazi.ganzhi_year` / `Bazi.bracketing_jies` 单一真源,消费方全部迁移——dayun 数节与标年(`_dayun_start_ganzhi_year` floor)、xiaoyun 计数、liunian 起点、`TransitDatabase` 出生年。逆排 tie 负 gap clamp 到 0(交运下限 = 出生时刻),顺排跳过 tie 节。
- **HKO × HOUR/MINUTE 显式 `ValueError`**(其 `jieqi_moment` 是午夜占位);DAY × HKO 不受影响。
- **DAY 档一切现行为不动**(锁测试原样全绿;`bracketing_jies` 对 DAY 维持时刻级现状)。

## 测试

- golden 三组(2000/2017/2009 立春,含跨午夜 tie 双向与年柱前进);30k 扫描 oracle 对拍(年经立春直比、月经线性扫描 + 字面映射,与实现零共享推导;分歧形状断言含跨午夜方向);2k 同分 tie 对拍(带分歧下限断言);同源不变量(首流年 == 年柱,任意精度);逆排×跨午夜姊妹盘逐项对齐;Transits 定向 + DAY 恒等对照;HKO 禁用;负 gap clamp;json 三档往返(重建端解析 `precision`)。
- 本地全门禁 exit 0(coverage 100%,ruff/mypy 干净,demo/interpreter 过);突变检出 **11/11**(含「floor 摘除」「Transits 回退」定向弹)。

## 验证

- **计划审阅**(kimi,GO-WITH-CHANGES):P1×2 并入任务书——delta-on-DAY「仅回退」漏跨午夜前进向(00:xx 节 102 个)、「单调收窄」断言为伪。
- **R1 四家**(正确性 grok / fable / kimi × 风格 kimi):P1×2——clamp 交运年混粒度(**三家独立收敛**)、Transits 层日级出生年(fable 盲审独家);全部修复于 `a13a28b`,风格批同批落地。
- **R2 三家全 GO**:grok **撤销 NO-GO**(floor 非 clamp 严格恒等扫描、DAY 对 `1ec3c2e` 重载旧公式零差分);fable **FIXES VERIFIED**(12,820 盘 tie 全扫,floor 恰 16 盘激活、全部 clamp 场景,解析 + 实证双闭环;修复同时覆盖 P1-A 镜像窗口);kimi 风格五条全落。

## 范围说明

- 行为变更面仅新档位 HOUR/MINUTE;DAY 默认行为逐比特不变(R1/R2 两轮对 `1ec3c2e` 旧实现重载对拍,celestial + HKO 共 1400 例零差分)。
- 已裁决语义(#6 评论有记录):三档同一规则三个粒度、HOUR = 时辰级、跨午夜 tie 前进归新、负 gap clamp、出生侧年份与年柱同源、`ganzhi_date` 维持日级通道并 docstring 声明。
- 遗留备查(不阻塞):grok R2 P3 观察——交运时刻落在**未来**节气日 tie 窗口时的日级标注为既有契约,floor 正确不介入;记 dev log。#69 流派自由度记账不变。

Closes #6
Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)
