### PR TITLE
feat: run_relationship_analyzer 神煞着色 + 夫妻宫/配偶星 + 流年区间循环 (#97)

### DIFF
--- a/run_relationship_analyzer.py
+++ b/run_relationship_analyzer.py
@@ -8,18 +8,16 @@ from src.analyzer.relationship import RelationshipAnalyzer, ShenshaAnalysis
 
 
 def shensha_strs(shensha: ShenshaAnalysis) -> list[str]:
-  str_list: list[str] = []
-  if len(dz_fs := shensha['taohua']) > 0:
-    str_list.append(f'桃花：{", ".join(map(colored_str, dz_fs))}')
-  if len(dz_fs := shensha['hongluan']) > 0:
-    str_list.append(f'红鸾：{", ".join(map(colored_str, dz_fs))}')
-  if len(dz_fs := shensha['hongyan']) > 0:
-    str_list.append(f'红艳：{", ".join(map(colored_str, dz_fs))}')
-  if len(dz_fs := shensha['tianxi']) > 0:
-    str_list.append(f'天喜：{", ".join(map(colored_str, dz_fs))}')
-  if len(dz_fs := shensha['yima']) > 0:
-    str_list.append(f'驿马：{", ".join(map(colored_str, dz_fs))}')
-  return str_list
+  # TypedDict access needs literal keys under mypy, so the table pairs labels
+  # with already-fetched fields instead of looping over key strings.
+  named = [
+    ('桃花', shensha['taohua']),
+    ('红鸾', shensha['hongluan']),
+    ('红艳', shensha['hongyan']),
+    ('天喜', shensha['tianxi']),
+    ('驿马', shensha['yima']),
+  ]
+  return [f'{label}：{", ".join(map(colored_str, dz_fs))}' for label, dz_fs in named if dz_fs]
 
 
 if __name__ == '__main__':
@@ -49,10 +47,11 @@ if __name__ == '__main__':
   # The birth-side anchor is `ganzhi_year` (precision-attributed), the same source
   # `TransitDatabase.support` bounds liunian by -- a relative range can never fall
   # below it, which an absolute range would for charts born after its first year.
+  transits_analysis = analyzer.transits
   start_gz_year = chart.bazi.ganzhi_year + 20
   print(f'流年神煞（{start_gz_year} 起十年）：')
   for gz_year in range(start_gz_year, start_gz_year + 10):
-    year_strs = shensha_strs(analyzer.transits.shensha(gz_year, TransitOptions.LIUNIAN))
+    year_strs = shensha_strs(transits_analysis.shensha(gz_year, TransitOptions.LIUNIAN))
     if len(year_strs) == 0:
       print(f'{gz_year}：无')
     else:

--- a/run_relationship_analyzer.py
+++ b/run_relationship_analyzer.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from run_demo import get_basic_info
+from run_demo import get_basic_info, colored_str
 
 from src.bazi_chart import BaziChart
 from src.transits import TransitOptions
@@ -10,24 +10,31 @@ from src.analyzer.relationship import RelationshipAnalyzer, ShenshaAnalysis
 def shensha_strs(shensha: ShenshaAnalysis) -> list[str]:
   str_list: list[str] = []
   if len(dz_fs := shensha['taohua']) > 0:
-    str_list.append(f'桃花：{", ".join(str(x) for x in dz_fs)}')
+    str_list.append(f'桃花：{", ".join(map(colored_str, dz_fs))}')
   if len(dz_fs := shensha['hongluan']) > 0:
-    str_list.append(f'红鸾：{", ".join(str(x) for x in dz_fs)}')
+    str_list.append(f'红鸾：{", ".join(map(colored_str, dz_fs))}')
   if len(dz_fs := shensha['hongyan']) > 0:
-    str_list.append(f'红艳：{", ".join(str(x) for x in dz_fs)}')
+    str_list.append(f'红艳：{", ".join(map(colored_str, dz_fs))}')
   if len(dz_fs := shensha['tianxi']) > 0:
-    str_list.append(f'天喜：{", ".join(str(x) for x in dz_fs)}')
+    str_list.append(f'天喜：{", ".join(map(colored_str, dz_fs))}')
   if len(dz_fs := shensha['yima']) > 0:
-    str_list.append(f'驿马：{", ".join(str(x) for x in dz_fs)}')
+    str_list.append(f'驿马：{", ".join(map(colored_str, dz_fs))}')
   return str_list
 
 
 if __name__ == '__main__':
   chart = BaziChart.random()
-  bazi = chart.bazi
   analyzer = RelationshipAnalyzer(chart)
 
   print(get_basic_info(chart))
+  print('\n' + '-' * 60 + '\n')
+
+  house = chart.house_of_relationship
+  stars = chart.relationship_stars
+  star_strs = [colored_str(stars.tiangan), *map(colored_str, stars.dizhi)]
+  print(f'夫妻宫：{colored_str(house)}')
+  print(f'配偶星：{", ".join(star_strs)}')
+
   print('\n' + '-' * 60 + '\n')
 
   shensha_str_list = shensha_strs(analyzer.at_birth.shensha)
@@ -39,10 +46,15 @@ if __name__ == '__main__':
 
   print('\n' + '-' * 60 + '\n')
 
-  gz_year = chart.bazi.ganzhi_date.year + 20
-  liunian_shensha_str_list = shensha_strs(analyzer.transits.shensha(gz_year, TransitOptions.LIUNIAN))
-  if len(liunian_shensha_str_list) == 0:
-    print(f'{gz_year} 流年无桃花、红艳、红鸾、天喜、驿马星')
-  else:
-    print(f'{gz_year} 流年神煞：')
-    print('\n'.join(liunian_shensha_str_list))
+  # The birth-side anchor is `ganzhi_year` (precision-attributed), the same source
+  # `TransitDatabase.support` bounds liunian by -- a relative range can never fall
+  # below it, which an absolute range would for charts born after its first year.
+  start_gz_year = chart.bazi.ganzhi_year + 20
+  print(f'流年神煞（{start_gz_year} 起十年）：')
+  for gz_year in range(start_gz_year, start_gz_year + 10):
+    year_strs = shensha_strs(analyzer.transits.shensha(gz_year, TransitOptions.LIUNIAN))
+    if len(year_strs) == 0:
+      print(f'{gz_year}：无')
+    else:
+      print(f'{gz_year}：')
+      print('\n'.join(f'  {s}' for s in year_strs))


### PR DESCRIPTION
Closes #97

## 改动(单文件 `run_relationship_analyzer.py`,+26/-15)

issue #97 从旧工作树捞回的展示改进,rebase 到当前 main:

- **神煞着色**:`colored_str` 扩到全五神煞——含驿马(原 diff 基线无它,维护者裁决保留 main 的驿马);
- **夫妻宫/配偶星输出**:`house_of_relationship` / `relationship_stars`;
- **流年区间循环**:单年 → 十年。

## 与原 diff 的三处刻意偏离(均有裁决/证据)

1. **保留 `BaziChart.random()`**:原 diff 写死生辰为编造测试数据,维护者裁决不保留;
2. **区间相对锚定** `ganzhi_year+20` 起十年(原 diff 绝对 2025–2035):`TransitDatabase.support` 的 LIUNIAN 下界是出生干支年,random 盘遇绝对区间会断言炸;锚源与 support 同为 `ganzhi_year`,岁首边界自动对齐(实测 1905-01-03 生 → 1924 起,立春前归旧年);
3. **输出形状**(维护者拍板):非空年打详情、空年压一行、整段单分隔区——替代原 diff 的每年整段+分隔线;另原 diff 的 `map(colored_str, 异构列表)` 被 mypy 推成 `list[Enum]` 拦下,改为分别着色再 join。

## 验证

随机盘手跑 5+2 次全过(空年/非空年/岁首边界形态均见);门禁全绿(脚本不在执行门禁内,ruff/mypy 静态面覆盖)。

## 审阅规格

门禁 + CI claude review(A2 brief 拍板降档)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
