### PR TITLE
chore: 微修小件——IntFlag 判位/地板除/docstring 勘误 (D3-1)

### DIFF
--- a/src/bazi.py
+++ b/src/bazi.py
@@ -269,7 +269,7 @@ class Bazi:
     self._day_pillar: Final[Ganzhi] = ganzhi_of_day(timedelta(days=day_offset) + self._birth_time)
 
     # Finally, find out the Hour Dizhi (时柱地支).
-    self._hour_dizhi: Final[Dizhi] = Dizhi.from_index(int((self._hour + 1) / 2) % 12)
+    self._hour_dizhi: Final[Dizhi] = Dizhi.from_index((self._hour + 1) // 2 % 12)
 
   @staticmethod
   def __parse_bazi_args(
@@ -330,18 +330,18 @@ class Bazi:
     Staticmethod that creates a `Bazi` object from the inputs.
 
     Args:
-    - birth_time: (Union[datetime, str]) The birth date. Note that no timezone should be set.
+    - birth_time: (datetime | str) The birth date. Note that no timezone should be set.
       - if `datetime` type: it will be interpreted as a solar date to feed to `Bazi`.
       - if `str` type: it will be converted by `datetime.fromisoformat`.
-    - gender: (Union[BaziGender, str]) The gender of the person.
+    - gender: (BaziGender | str) The gender of the person.
       - if `BaziGender` type: it will be directly fed to `Bazi`.
       - if `str` type: it will be converted by `BaziGender`. 
         - Supported values: "男"/"女"/"male"/"female" (case insensitive).
-    - precision: (Union[BaziPrecision, str]) The precision of the birth time.
+    - precision: (BaziPrecision | str) The precision of the birth time.
       - if `BaziPrecision` type: it will be directly fed to `Bazi`.
       - if `str` type: it will be converted by `BaziPrecision`. 
         - Supported values: "分"/"分钟"/"时"/"小时"/"天"/"日"/"m"/"min"/"minute"/"h"/"hour"/"d"/"day" (case insensitive).
-    - backend: (Union[CalendarBackend, str]) The calendar backend used for all calendar conversions.
+    - backend: (CalendarBackend | str) The calendar backend used for all calendar conversions.
       - if `CalendarBackend` type: it will be directly fed to `Bazi`.
       - if `str` type: it will be converted by `CalendarBackend.from_str`.
         - Supported values: the member names and values of `CalendarBackend` (e.g. "HKO"/"hko", case insensitive).

--- a/src/calendar/celestial_calendar_utils.py
+++ b/src/calendar/celestial_calendar_utils.py
@@ -292,7 +292,7 @@ class CelestialCalendarUtils:
     Convert the input date to a `CalendarDate` with `SOLAR` type.
 
     Args:
-    - d: (Union[date, CalendarDate]) The input date.
+    - d: (date | CalendarDate) The input date.
       - If `d` is of `date` type, it will be interpreted as a solar date.
 
     Return: (CalendarDate) a converted date with `SOLAR` type.
@@ -314,7 +314,7 @@ class CelestialCalendarUtils:
     Convert the input date to a `CalendarDate` with `LUNAR` type.
 
     Args:
-    - d: (Union[date, CalendarDate]) The input date.
+    - d: (date | CalendarDate) The input date.
       - If `d` is of `date` type, it will be interpreted as a solar date.
 
     Return: (CalendarDate) a converted date with `LUNAR` type.
@@ -336,7 +336,7 @@ class CelestialCalendarUtils:
     Convert the input date to a `CalendarDate` with `GANZHI` type.
 
     Args:
-    - d: (Union[date, CalendarDate]) The input date.
+    - d: (date | CalendarDate) The input date.
       - If `d` is of `date` type, it will be interpreted as a solar date.
 
     Return: (CalendarDate) a converted date with `GANZHI` type.
@@ -363,7 +363,7 @@ class CelestialCalendarUtils:
     Convert the input date to a `date` type.
 
     Args:
-    - d: (Union[date, CalendarDate]) The input date.
+    - d: (date | CalendarDate) The input date.
       - If `d` is of `datetime` type, it will be casted to `date` (the time of day is
         discarded -- `datetime` is accepted because it is a `date` subclass).
 

--- a/src/calendar/hko_data_calendar_utils.py
+++ b/src/calendar/hko_data_calendar_utils.py
@@ -314,7 +314,7 @@ def to_solar(d: date | CalendarDate) -> CalendarDate:
   Convert the input date to a `CalendarDate` with `SOLAR` type.
   
   Args:
-  - d: (Union[date, CalendarDate]) The input date.
+  - d: (date | CalendarDate) The input date.
     - If `d` is of `date` type, it will be interpreted as a solar date.
 
   Return: (CalendarDate) a converted date with `SOLAR` type.
@@ -337,7 +337,7 @@ def to_lunar(d: date | CalendarDate) -> CalendarDate:
   Convert the input date to a `CalendarDate` with `LUNAR` type.
 
   Args:
-  - d: (Union[date, CalendarDate]) The input date.
+  - d: (date | CalendarDate) The input date.
     - If `d` is of `date` type, it will be interpreted as a solar date.
 
   Return: (CalendarDate) a converted date with `LUNAR` type.
@@ -360,7 +360,7 @@ def to_ganzhi(d: date | CalendarDate) -> CalendarDate:
   Convert the input date to a `CalendarDate` with `GANZHI` type.
 
   Args:
-  - d: (Union[date, CalendarDate]) The input date.
+  - d: (date | CalendarDate) The input date.
     - If `d` is of `date` type, it will be interpreted as a solar date.
 
   Return: (CalendarDate) a converted date with `GANZHI` type.
@@ -383,7 +383,7 @@ def to_date(d: date | CalendarDate) -> date:
   Convert the input date to a `date` type.
 
   Args:
-  - d: (Union[date, CalendarDate]) The input date.
+  - d: (date | CalendarDate) The input date.
     - If `d` is of `datetime` type, it will be casted to `date`.
 
   Return: (date) a converted date with `date` type.

--- a/src/transits.py
+++ b/src/transits.py
@@ -5,6 +5,7 @@ import random
 from dataclasses import dataclass
 from datetime import date
 from enum import unique, IntFlag
+from functools import reduce
 from itertools import combinations
 from typing import Final
 from collections.abc import Generator
@@ -102,9 +103,9 @@ def _all_options() -> list[TransitOptions]:
   '''
   # `list(TransitOptions)` only yields single-bit members on Python 3.11+,
   # silently dropping the composite options. Filter defensively anyway.
-  singles: list[TransitOptions] = [opt for opt in TransitOptions if opt.value > 0 and opt.value & (opt.value - 1) == 0]
+  singles: list[TransitOptions] = [opt for opt in TransitOptions if opt.value.bit_count() == 1]
   return [
-    TransitOptions(sum(opt.value for opt in combo))
+    reduce(lambda acc, opt: acc | opt, combo)
     for r in range(1, len(singles) + 1)
     for combo in combinations(singles, r)
   ]
@@ -152,11 +153,11 @@ class TransitDatabase:
     _ensure_year_moment(moment)
 
     gz_year: Final[int] = moment.gz_year
-    if options.value & TransitOptions.XIAOYUN.value and gz_year not in self._xiaoyun_ganzhis:
+    if options & TransitOptions.XIAOYUN and gz_year not in self._xiaoyun_ganzhis:
       return False
-    if options.value & TransitOptions.DAYUN.value and gz_year < self._first_dayun_start_gz_year:
+    if options & TransitOptions.DAYUN and gz_year < self._first_dayun_start_gz_year:
       return False
-    if options.value & TransitOptions.LIUNIAN.value and gz_year < self._birth_ganzhi_year: # noqa: SIM103 # symmetric guard clauses, one per option
+    if options & TransitOptions.LIUNIAN and gz_year < self._birth_ganzhi_year: # noqa: SIM103 # symmetric guard clauses, one per option
       return False
 
     return True
@@ -186,13 +187,13 @@ class TransitDatabase:
 
     gz_year: Final[int] = moment.gz_year
     transit_ganzhis: list[Ganzhi] = []
-    if options.value & TransitOptions.XIAOYUN.value:
+    if options & TransitOptions.XIAOYUN:
       assert gz_year in self._xiaoyun_ganzhis
       transit_ganzhis.append(self._xiaoyun_ganzhis[gz_year])
-    if options.value & TransitOptions.DAYUN.value:
+    if options & TransitOptions.DAYUN:
       assert gz_year >= self._first_dayun_start_gz_year
       transit_ganzhis.append(self._dayun_db[gz_year].ganzhi)
-    if options.value & TransitOptions.LIUNIAN.value:
+    if options & TransitOptions.LIUNIAN:
       assert gz_year >= self._birth_ganzhi_year
       transit_ganzhis.append(ganzhi_of_year(gz_year))
 

--- a/src/utils/bazi_utils.py
+++ b/src/utils/bazi_utils.py
@@ -159,7 +159,7 @@ def shishen(day_master: Tiangan, other: Tiangan | Dizhi) -> Shishen:
 
   Args:
   - day_master: (Tiangan) The Tiangan of the Day Master.
-  - other: (Union[Tiangan, Dizhi]) The Tiangan or Dizhi of the other.
+  - other: (Tiangan | Dizhi) The Tiangan or Dizhi of the other.
 
   Return: (Shishen) The Shishen of the given Tiangan or Dizhi.
 

--- a/src/utils/dizhi_utils.py
+++ b/src/utils/dizhi_utils.py
@@ -67,7 +67,7 @@ def sanhui(dz1: Dizhi, dz2: Dizhi, dz3: Dizhi) -> Wuxing | None:
   - dz2: (Dizhi) The second Dizhi.
   - dz3: (Dizhi) The third Dizhi.
 
-  Return: (Optional[Wuxing]) The Wuxing that the Dizhis form, or `None` if the Dizhis are not in SANHUI (三会) relation.
+  Return: (Wuxing | None) The Wuxing that the Dizhis form, or `None` if the Dizhis are not in SANHUI (三会) relation.
 
   Examples:
   - sanhui(Dizhi.寅, Dizhi.卯, Dizhi.辰)
@@ -92,7 +92,7 @@ def liuhe(dz1: Dizhi, dz2: Dizhi) -> Wuxing | None:
   - dz1: (Dizhi) The first Dizhi.
   - dz2: (Dizhi) The second Dizhi.
 
-  Return: (Optional[Wuxing]) The Wuxing that the Dizhis form, or `None` if the Dizhis are not in LIUHE (六合) relation.
+  Return: (Wuxing | None) The Wuxing that the Dizhis form, or `None` if the Dizhis are not in LIUHE (六合) relation.
 
   Examples:
   - liuhe(Dizhi.寅, Dizhi.亥)
@@ -195,7 +195,7 @@ def sanhe(dz1: Dizhi, dz2: Dizhi, dz3: Dizhi) -> Wuxing | None:
   - dz2: (Dizhi) The second Dizhi.
   - dz3: (Dizhi) The third Dizhi.
 
-  Return: (Optional[Wuxing]) The corresponding Wuxing if the Dizhis form in SANHE (三合) relation. Otherwise, return `None`.
+  Return: (Wuxing | None) The corresponding Wuxing if the Dizhis form in SANHE (三合) relation. Otherwise, return `None`.
 
   Examples:
   - sanhe(Dizhi.亥, Dizhi.卯, Dizhi.未)
@@ -218,7 +218,7 @@ def banhe(dz1: Dizhi, dz2: Dizhi) -> Wuxing | None:
   - dz1: (Dizhi) The first Dizhi.
   - dz2: (Dizhi) The second Dizhi.
 
-  Return: (Optional[Wuxing]) The corresponding Wuxing if the Dizhis form in BANHE (半合) relation. Otherwise, return `None`.
+  Return: (Wuxing | None) The corresponding Wuxing if the Dizhis form in BANHE (半合) relation. Otherwise, return `None`.
 
   Examples:
   - banhe(Dizhi.亥, Dizhi.卯)
@@ -254,20 +254,20 @@ def xing(*dizhis: Dizhi, definition: DizhiRules.XingDef = DizhiRules.XingDef.LOO
   - *dizhis: (Dizhi) The Dizhis to check.
   - definition: (DizhiRules.XingDef) The definition for 刑.
 
-  Return: (Optional[DizhiRules.XingSubType]) The type of the XING relation if the Dizhis form in XING (刑) relation. Otherwise, return `None`.
+  Return: (DizhiRules.XingSubType | None) The type of the XING relation if the Dizhis form in XING (刑) relation. Otherwise, return `None`.
 
   Examples:
   - xing(*[Dizhi.寅, Dizhi.巳, Dizhi.申])
     - return: XingSubType.SANXING
-  - xing(*[Dizhi.寅, Dizhi.巳], DizhiRules.XingDef.STRICT)
+  - xing(*[Dizhi.寅, Dizhi.巳], definition=DizhiRules.XingDef.STRICT)
     - return: None
-  - xing(*[Dizhi.寅, Dizhi.巳], DizhiRules.XingDef.LOOSE)
+  - xing(*[Dizhi.寅, Dizhi.巳], definition=DizhiRules.XingDef.LOOSE)
     - return: XingSubType.SANXING
   - xing(Dizhi.午)
     - return: None
   - xing(Dizhi.午, Dizhi.午)
     - return: XingSubType.ZIXING
-  - xing(Dizhi.午, DizhiRules.XingDef.LOOSE)
+  - xing(Dizhi.午, definition=DizhiRules.XingDef.LOOSE)
     - return: None
   - xing(*[Dizhi.寅, Dizhi.巳, Dizhi.申, Dizhi.午]) # Not a exact match.
     - return: None

--- a/src/utils/shensha_utils.py
+++ b/src/utils/shensha_utils.py
@@ -5,8 +5,8 @@ from ..rules import ShenshaRules
 
 
 '''
-Functions in this file are used to find all possible Dizhi combos that satisfy different `DizhiRelation`s.
-All methods' returns are expected to be immutable.
+Predicates for Shensha (神煞) detection: 桃花 / 红艳 / 红鸾 / 天喜 / 驿马.
+Each function checks whether a Dizhi forms the Shensha against its anchor (the year/day Dizhi, or the Day Master).
 '''
 
 

--- a/src/utils/tiangan_utils.py
+++ b/src/utils/tiangan_utils.py
@@ -67,7 +67,7 @@ def he(tg1: Tiangan, tg2: Tiangan) -> Wuxing | None:
   - tg1: (Tiangan) The first Tiangan.
   - tg2: (Tiangan) The second Tiangan.
 
-  Return: (Optional[Wuxing]) The Wuxing that the two Tiangans form, or `None` if the two Tiangans are not in HE relation.
+  Return: (Wuxing | None) The Wuxing that the two Tiangans form, or `None` if the two Tiangans are not in HE relation.
 
   Examples:
   - he(Tiangan.甲, Tiangan.丙):


### PR DESCRIPTION
D3-1/6(A+D 收官批;计划 = side-projects vault D3 brief,kimi 计划快扫 GO-WITH-CHANGES 修订版)。

## 改动

- **#91.1** `bazi.py` 时辰地支索引:`int((h+1)/2) % 12` → `(h+1) // 2 % 12`,去浮点绕行。
- **#91.3** `transits.py` IntFlag 摘 `.value` 往返:6 处判位改 `options & TransitOptions.X` 直判;`_ALL_OPTIONS` 组合枚举改 `bit_count() == 1` 判单 bit + `reduce` 按位或合成,不再经 int 求和往返构造。
- **#89.5** `xing()` docstring 三处示例改 `definition=` 关键字传参(原示例按位置传会落进 `*dizhis`,示例本身跑不通)。
- **#89.6** `shensha_utils` 模块 docstring 重写(原文抄自 relation utils,说的是 DizhiRelation,与神煞无关)。
- **#91.4 尾巴**:19 处 docstring 散文 `Union[...]`/`Optional[...]` → 现代联合写法(bazi.py ×4、dizhi_utils ×5、tiangan_utils ×1、bazi_utils ×1、两 calendar utils ×8;D2 已清完代码注解,这批是文档残留)。

## 刻意不做

- **#91.2**(链式比较):`bazi.py` 两断言将随 D3-6a(#71.10)删除 `_hour`/`_minute` 字段一并消亡,先改是白做(kimi 计划快扫 P3-3)。

## 验证

- 全量门禁绿:`run_tests.py -v -s -hko -c -cr 100 -ruff -mypy -d -i`(coverage 100%)。
- 纯行为等价改写 + 文档修正,无新测试(IntFlag 判位与时辰索引语义由既有套件钉死)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
