### PR TITLE
refactor: D3 行为卫生——deepcopy/缓存对账 + #63/#71 收尾 + #88 收敛(七提交)

### DIFF
--- a/src/analyzer/relationship.py
+++ b/src/analyzer/relationship.py
@@ -4,7 +4,7 @@ import functools
 
 from dataclasses import dataclass
 from enum import Enum, IntFlag, auto, unique
-from itertools import starmap, product, compress, chain
+from itertools import product
 from typing import Final, TypedDict
 from collections.abc import Callable, Iterable
 
@@ -31,10 +31,9 @@ def find_shensha(
   f: Callable[..., bool],
   *args: _ArgsType,
 ) -> Iterable[Dizhi]:
-  '''An fp-styled helper private/internal function for finding Shensha (神煞).'''
-  producted_args = list(chain(*(product(*a) for a in args)))
-  results = starmap(f, producted_args)
-  return (x[1] for x in compress(producted_args, results))
+  '''A private/internal helper for finding Shensha (神煞): yield the Dizhi of every
+  (key, dizhi) pair that the predicate `f` accepts.'''
+  return (dz for first, second in args for key, dz in product(first, second) if f(key, dz))
 
 
 @unique

--- a/src/analyzer/relationship.py
+++ b/src/analyzer/relationship.py
@@ -1,6 +1,5 @@
 # Copyright (C) 2024 Ningqi Wang (0xf3cd) <https://github.com/0xf3cd>
 
-import copy
 import functools
 
 from dataclasses import dataclass
@@ -125,7 +124,7 @@ class ShenshaAnalysis(TypedDict):
 class AtBirthAnalysis:
   '''Analysis of Relationship at Birth / 出生时的亲密关系分析'''
   def __init__(self, chart: BaziChart) -> None:
-    self._chart: Final[BaziChart] = copy.deepcopy(chart)
+    self._chart: Final[BaziChart] = chart
 
   @property
   def shensha(self) -> ShenshaAnalysis:
@@ -169,7 +168,7 @@ class AtBirthAnalysis:
 class TransitAnalysis:
   '''Analysis of Relationship at Transits / 流年大运等的亲密关系分析'''
   def __init__(self, chart: BaziChart) -> None:
-    self._chart: Final[BaziChart] = copy.deepcopy(chart)
+    self._chart: Final[BaziChart] = chart
     self._transit_chart: Final[TransitChart] = TransitChart(self._chart)
 
   def support(self, gz_year: int, options: TransitOptions) -> bool:
@@ -376,7 +375,7 @@ class TransitAnalysis:
 class RelationshipAnalyzer:
   '''A thin wrapper of `AtBirthAnalysis` and `TransitAnalysis`.'''
   def __init__(self, chart: BaziChart) -> None:
-    self._chart: Final[BaziChart] = copy.deepcopy(chart)
+    self._chart: Final[BaziChart] = chart
 
   @property
   def at_birth(self) -> AtBirthAnalysis:

--- a/src/analyzer/relationship.py
+++ b/src/analyzer/relationship.py
@@ -377,10 +377,10 @@ class RelationshipAnalyzer:
   def __init__(self, chart: BaziChart) -> None:
     self._chart: Final[BaziChart] = chart
 
-  @property
+  @functools.cached_property
   def at_birth(self) -> AtBirthAnalysis:
     return AtBirthAnalysis(self._chart)
 
-  @property
+  @functools.cached_property
   def transits(self) -> TransitAnalysis:
     return TransitAnalysis(self._chart)

--- a/src/analyzer/relationship.py
+++ b/src/analyzer/relationship.py
@@ -33,7 +33,7 @@ def find_shensha(
 ) -> Iterable[Dizhi]:
   '''A private/internal helper for finding Shensha (神煞): yield the Dizhi of every
   (key, dizhi) pair that the predicate `f` accepts.'''
-  return (dz for first, second in args for key, dz in product(first, second) if f(key, dz))
+  return (dz for keys, dizhis in args for key, dz in product(keys, dizhis) if f(key, dz))
 
 
 @unique

--- a/src/bazi.py
+++ b/src/bazi.py
@@ -552,9 +552,9 @@ class Bazi:
     return not self.__eq__(other)
 
   def __hash__(self) -> int:
-    # In sync with `__eq__`. All four inputs sit behind `Final` fields, so the hash
-    # is stable across the object's lifetime. 与 `__eq__` 同步；四个输入都在 `Final`
-    # 字段之后，对象生命周期内哈希稳定。
+    # Same four inputs as `__eq__`, all derived from `Final` state: stable under the
+    # public API (private reassignment is not defended against, as everywhere else).
+    # 与 `__eq__` 同源四元组，皆派生自 `Final` 状态：公开 API 下稳定（私有改写不设防，全类同此）。
     return hash((self.solar_datetime, self.gender, self.precision, self.backend))
 
 八字 = Bazi

--- a/src/bazi.py
+++ b/src/bazi.py
@@ -198,12 +198,6 @@ class Bazi:
     self._solar_date: Final[CalendarDate] = utils.to_solar(self._birth_time)
     assert utils.is_valid_solar_date(self._solar_date) # Here we are also checking if the date falls into the supported range.
 
-    self._hour: Final[int] = self._birth_time.hour
-    assert self._hour >= 0 and self._hour < 24
-
-    self._minute: Final[int] = self._birth_time.minute
-    assert self._minute >= 0 and self._minute < 60
-
     self._gender: Final[BaziGender] = gender
     self._precision: Final[BaziPrecision] = precision
 
@@ -267,7 +261,7 @@ class Bazi:
     self._day_pillar: Final[Ganzhi] = ganzhi_of_day(timedelta(days=day_offset) + self._birth_time)
 
     # Finally, find out the Hour Dizhi (时柱地支).
-    self._hour_dizhi: Final[Dizhi] = Dizhi.from_index((self._hour + 1) // 2 % 12)
+    self._hour_dizhi: Final[Dizhi] = Dizhi.from_index((self._birth_time.hour + 1) // 2 % 12)
 
   @staticmethod
   def __parse_bazi_args(
@@ -426,16 +420,20 @@ class Bazi:
 
   @property
   def hour(self) -> int:
-    return self._hour
-  
+    return self._birth_time.hour
+
   @property
   def minute(self) -> int:
-    return self._minute
-  
+    return self._birth_time.minute
+
   @property
   def solar_datetime(self) -> datetime:
-    '''The exact birth time (in solar/gregorian calendar) / 出生时刻（公历）'''
-    return datetime.combine(self.solar_date, time(self.hour, self.minute))
+    '''The birth time (in solar/gregorian calendar), truncated to the minute.
+    Sub-minute parts are deliberately dropped: MINUTE is the finest `BaziPrecision`, so
+    ganzhi attribution never reads below it, and `__eq__`/`__hash__` build on this value.
+    出生时刻（公历），显式截断到分钟——秒以下刻意丢弃：MINUTE 已是最细的排盘精度，
+    干支归属不读秒，`__eq__`/`__hash__` 也建立在截断值上。'''
+    return self._birth_time.replace(second=0, microsecond=0)
   
   @property
   def gender(self) -> BaziGender:

--- a/src/bazi.py
+++ b/src/bazi.py
@@ -1,6 +1,5 @@
 # Copyright (C) 2024 Ningqi Wang (0xf3cd) <https://github.com/0xf3cd>
 
-import copy
 import random
 
 from enum import Enum
@@ -193,7 +192,7 @@ class Bazi:
     self._backend: Final[CalendarBackend] = backend
     utils: Final[CalendarUtilsProtocol] = calendar_utils_of(backend)
 
-    self._birth_time: Final[datetime] = copy.deepcopy(birth_time)
+    self._birth_time: Final[datetime] = birth_time
     assert self._birth_time.tzinfo is None, 'Timezone should be well-processed outside of this class.'
 
     self._solar_date: Final[CalendarDate] = utils.to_solar(self._birth_time)

--- a/src/bazi.py
+++ b/src/bazi.py
@@ -553,4 +553,10 @@ class Bazi:
   def __ne__(self, other: object) -> bool:
     return not self.__eq__(other)
 
+  def __hash__(self) -> int:
+    # In sync with `__eq__`. All four inputs sit behind `Final` fields, so the hash
+    # is stable across the object's lifetime. 与 `__eq__` 同步；四个输入都在 `Final`
+    # 字段之后，对象生命周期内哈希稳定。
+    return hash((self.solar_datetime, self.gender, self.precision, self.backend))
+
 八字 = Bazi

--- a/src/bazi_chart.py
+++ b/src/bazi_chart.py
@@ -108,12 +108,12 @@ class BaziChart:
     '''
     return calendar_utils_of(self._bazi.backend)
   
-  @property
+  @functools.cached_property
   def house_of_relationship(self) -> Dizhi:
     '''House of Partnership / House of Relationship / 婚姻宫 / 配偶宫, which is simply the day pillar's Dizhi.'''
     return self._bazi.day_pillar.dizhi
   
-  @property
+  @functools.cached_property
   def relationship_stars(self) -> GanzhiData[Tiangan, tuple[Dizhi, ...]]:
     '''Relationship Star / 夫妻星 / 配偶星.
     
@@ -138,7 +138,7 @@ class BaziChart:
     return GanzhiData(found_tg[0], found_dz)
 
   PillarTraits = GanzhiData[TraitTuple, TraitTuple]
-  @property
+  @functools.cached_property
   def traits(self) -> BaziData[PillarTraits]:
     '''
     The traits (i.e. Yinyang and Wuxing) of Tiangans and Dizhis in pillars of Year, Month, Day, and Hour.
@@ -162,7 +162,7 @@ class BaziChart:
     pillar_data: list = [BaziChart.PillarTraits(tg_traits, dz_traits) for tg_traits, dz_traits in zip(tiangan_traits, dizhi_traits)]
     return BaziData(*pillar_data)
   
-  @property
+  @functools.cached_property
   def hidden_tiangan(self) -> BaziData[HiddenTianganDict]:
     '''
     The hidden Tiangans in all Dizhis of current bazi.
@@ -185,7 +185,7 @@ class BaziChart:
     return BaziData(*dizhi_hidden_tiangans)
   
   PillarShishens = GanzhiData[Shishen | None, Shishen]
-  @property
+  @functools.cached_property
   def shishen(self) -> BaziData[PillarShishens]:
     '''
     The Shishens of all Tiangans and Dizhis of Year, Month, Day, and Hour.
@@ -224,7 +224,7 @@ class BaziChart:
     assert len(shishen_list) == 4
     return BaziData(*shishen_list)
   
-  @property
+  @functools.cached_property
   def nayin(self) -> BaziData[str]:
     '''
     The nayins of the pillars of Year, Month, Day, and Hour.
@@ -244,7 +244,7 @@ class BaziChart:
     nayin_list: list[str] = [nayin_str(gz) for gz in self._bazi.pillars]
     return BaziData(*nayin_list)
   
-  @property
+  @functools.cached_property
   def shier_zhangsheng(self) -> BaziData[ShierZhangsheng]:
     '''
     The Shier Zhangshengs (i.e. 12 stages of growth) of 4 pillars of Year, Month, Day, and Hour.
@@ -266,7 +266,7 @@ class BaziChart:
     zhangsheng_list: list[ShierZhangsheng] = [shier_zhangsheng(day_master, gz.dizhi) for gz in self._bazi.pillars]
     return BaziData(*zhangsheng_list)
   
-  @property
+  @functools.cached_property
   def dayun_order(self) -> bool:
     '''
     `True` if the Ganzhis of Dayuns are in a forward order.
@@ -278,7 +278,7 @@ class BaziChart:
     is_year_dz_yang: bool = (traits(self._bazi.year_pillar.dizhi).yinyang is Yinyang.阳)
     return is_male == is_year_dz_yang
   
-  @property
+  @functools.cached_property
   def dayun_start_moment(self) -> datetime:
     '''
     The moment when first Dayun (大运) starts (solar/gregorian calendar).
@@ -305,7 +305,7 @@ class BaziChart:
     
     return birthtime + __diff()
 
-  @property
+  @functools.cached_property
   def _dayun_start_ganzhi_year(self) -> int:
     '''
     The ganzhi year the first dayun starts in: the day-level label of `dayun_start_moment`,
@@ -351,7 +351,7 @@ class BaziChart:
 
     return __dayun_generator()
 
-  @property
+  @functools.cached_property
   def xiaoyun(self) -> tuple[XiaoyunTuple, ...]:
     '''
     A tuple containing all Xiaoyuns (小运).

--- a/src/bazi_chart.py
+++ b/src/bazi_chart.py
@@ -96,9 +96,9 @@ class BaziChart:
 
   def __init__(self, bazi: Bazi) -> None:
     assert isinstance(bazi, Bazi)
-    # `Bazi` is the one mutable domain object; the chart is its isolation boundary,
-    # so take a private copy here (and hand out copies in the `bazi` property below).
-    # `Bazi` 是唯一可变的领域对象，命盘是它的隔离边界：进出各深拷一次。
+    # `Bazi` is not frozen (private state can be reassigned), so keep an isolated copy --
+    # `test_malicious` pins that poisoning the caller's object never reaches the chart.
+    # `Bazi` 并非 frozen（私有状态可被改写），故持隔离副本；test_malicious 钉住污染不透传。
     self._bazi: Final[Bazi] = copy.deepcopy(bazi)
 
   @classmethod
@@ -108,9 +108,9 @@ class BaziChart:
 
   @property
   def bazi(self) -> Bazi:
-    # A fresh copy per access, and deliberately NOT a `cached_property`: a cached shared
-    # `Bazi` could be mutated through the returned handle, breaking the chart's isolation.
-    # 每次访问深拷一份，故意不用 `cached_property`：缓存共享件会经返回句柄被改，破坏隔离。
+    '''A fresh deep copy per access -- deliberately NOT a `cached_property`, since a cached
+    shared `Bazi` could be mutated through the returned handle.
+    每次访问深拷一份，故意不用 `cached_property`：缓存共享件会经返回句柄被改。'''
     return copy.deepcopy(self._bazi)
 
   @property
@@ -127,7 +127,7 @@ class BaziChart:
     '''
     return calendar_utils_of(self._bazi.backend)
   
-  @functools.cached_property
+  @property
   def house_of_relationship(self) -> Dizhi:
     '''House of Partnership / House of Relationship / 婚姻宫 / 配偶宫, which is simply the day pillar's Dizhi.'''
     return self._bazi.day_pillar.dizhi

--- a/src/bazi_chart.py
+++ b/src/bazi_chart.py
@@ -38,6 +38,21 @@ class BaziJson:
     assert len(data) == 4
     return { 'year': data[0], 'month': data[1], 'day': data[2], 'hour': data[3] }
 
+  class TianganShishens(TypedDict):
+    '''Not expected to be accessed directly. Used in `JsonDict`. Entries are `None`
+    (JSON null) where no Shishen exists -- i.e. `day`, the day master itself.
+    没有十神的位置为 None（JSON null）——即日主自身所在的 `day`。'''
+    year:  str | None
+    month: str | None
+    day:   str | None
+    hour:  str | None
+
+  @staticmethod
+  def gen_tiangan_shishens(data: Sequence[Shishen | None]) -> 'BaziJson.TianganShishens':
+    assert len(data) == 4
+    strs: list[str | None] = [None if s is None else str(s) for s in data]
+    return { 'year': strs[0], 'month': strs[1], 'day': strs[2], 'hour': strs[3] }
+
   class Transits(TypedDict):
     '''Not expected to be accessed directly. Used in `JsonDict`.'''
     # start time of the dayun (isoformat string) / 大运的开始时间 (isoformat 格式的字符串)
@@ -61,7 +76,7 @@ class BaziJson:
     shier_zhangsheng: 'BaziJson.FourPillars'
     tiangan_traits: 'BaziJson.FourPillars'
     dizhi_traits: 'BaziJson.FourPillars'
-    tiangan_shishen: 'BaziJson.FourPillars'
+    tiangan_shishen: 'BaziJson.TianganShishens'
     dizhi_shishen: 'BaziJson.FourPillars'
     hidden_tiangan: 'BaziJson.FourPillars'
     transits: 'BaziJson.Transits'
@@ -425,7 +440,7 @@ class BaziChart:
       'shier_zhangsheng': f([str(sz) for sz in self.shier_zhangsheng]),
       'tiangan_traits': f([str(t.tiangan) for t in self.traits]),
       'dizhi_traits': f([str(t.dizhi) for t in self.traits]),
-      'tiangan_shishen': f([str(s.tiangan) for s in self.shishen]),
+      'tiangan_shishen': BaziJson.gen_tiangan_shishens([s.tiangan for s in self.shishen]),
       'dizhi_shishen': f([str(s.dizhi) for s in self.shishen]),
       'hidden_tiangan': f([str(h) for h in self.hidden_tiangan]),
       'transits': transits,

--- a/src/bazi_chart.py
+++ b/src/bazi_chart.py
@@ -77,6 +77,9 @@ class BaziChart:
 
   def __init__(self, bazi: Bazi) -> None:
     assert isinstance(bazi, Bazi)
+    # `Bazi` is the one mutable domain object; the chart is its isolation boundary,
+    # so take a private copy here (and hand out copies in the `bazi` property below).
+    # `Bazi` 是唯一可变的领域对象，命盘是它的隔离边界：进出各深拷一次。
     self._bazi: Final[Bazi] = copy.deepcopy(bazi)
 
   @classmethod
@@ -86,6 +89,9 @@ class BaziChart:
 
   @property
   def bazi(self) -> Bazi:
+    # A fresh copy per access, and deliberately NOT a `cached_property`: a cached shared
+    # `Bazi` could be mutated through the returned handle, breaking the chart's isolation.
+    # 每次访问深拷一份，故意不用 `cached_property`：缓存共享件会经返回句柄被改，破坏隔离。
     return copy.deepcopy(self._bazi)
 
   @property

--- a/src/bazi_chart.py
+++ b/src/bazi_chart.py
@@ -87,7 +87,11 @@ class BaziChart:
   `BaziChart` is a class that reveals the basic information of a given `Bazi`,
   for example, the traits (i.e. Wuxing and Yinyang), Shishens, ShierZhangshengs, and HiddenTiangans...
 
+  Derived quantities are cached on first access: the chart assumes its `_bazi` is never
+  rebound after construction (rebinding it leaves already-warmed caches stale).
+
   `BaziChart` 提供原盘中的一些信息，如天干地支的阴阳和五行、十神、十二长生、纳音、地支藏干等。
+  盘面派生量首次访问后缓存：命盘假定构造后 `_bazi` 不再被重绑（重绑不会刷新已暖缓存）。
   '''
 
   def __init__(self, bazi: Bazi) -> None:

--- a/src/calendar/celestial_utils.py
+++ b/src/calendar/celestial_utils.py
@@ -19,7 +19,6 @@ switch silently return results computed under the previous algorithm.  Two insta
 the choice part of the identity of the utils object instead.
 '''
 
-import copy
 import functools
 
 from datetime import date, datetime, timedelta
@@ -280,7 +279,7 @@ class CelestialCalendarUtils:
       ret = CalendarDate(d.year, d.month, d.day, CalendarType.SOLAR)
     else:
       assert isinstance(d, CalendarDate)
-      ret = copy.deepcopy(d)
+      ret = d
 
     assert self.is_valid(ret)
     return ret
@@ -300,7 +299,7 @@ class CelestialCalendarUtils:
     calendardate: CalendarDate = self.__to_calendardate(d) # Already validated.
 
     if calendardate.date_type == CalendarType.SOLAR:
-      return copy.deepcopy(calendardate)
+      return calendardate
     elif calendardate.date_type == CalendarType.LUNAR:
       return self.lunar_to_solar(calendardate)
     else:
@@ -322,7 +321,7 @@ class CelestialCalendarUtils:
     calendardate: CalendarDate = self.__to_calendardate(d) # Already validated.
 
     if calendardate.date_type == CalendarType.LUNAR:
-      return copy.deepcopy(calendardate)
+      return calendardate
     elif calendardate.date_type == CalendarType.SOLAR:
       return self.solar_to_lunar(calendardate)
     else:
@@ -349,7 +348,7 @@ class CelestialCalendarUtils:
     calendardate: CalendarDate = self.__to_calendardate(d) # Already validated.
 
     if calendardate.date_type == CalendarType.GANZHI:
-      return copy.deepcopy(calendardate)
+      return calendardate
     elif calendardate.date_type == CalendarType.SOLAR:
       return self.solar_to_ganzhi(calendardate)
     else:

--- a/src/calendar/hko_data_utils.py
+++ b/src/calendar/hko_data_utils.py
@@ -1,6 +1,5 @@
 # Copyright (C) 2024 Ningqi Wang (0xf3cd) <https://github.com/0xf3cd>
 
-import copy
 import calendar  # the stdlib module -- NOT the `src.calendar` package this file lives in
 import functools
 import itertools
@@ -299,7 +298,7 @@ def __to_calendardate(d: date | CalendarDate) -> CalendarDate:
     ret = CalendarDate(d.year, d.month, d.day, CalendarType.SOLAR)
   else:
     assert isinstance(d, CalendarDate)
-    ret = copy.deepcopy(d)
+    ret = d
 
   assert is_valid(ret)
   return ret
@@ -320,7 +319,7 @@ def to_solar(d: date | CalendarDate) -> CalendarDate:
   calendardate: CalendarDate = __to_calendardate(d) # `calendardate` is already validated.
 
   if calendardate.date_type == CalendarType.SOLAR:
-    return copy.deepcopy(calendardate)
+    return calendardate
   elif calendardate.date_type == CalendarType.LUNAR:
     return lunar_to_solar(calendardate)
   else:
@@ -343,7 +342,7 @@ def to_lunar(d: date | CalendarDate) -> CalendarDate:
   calendardate: CalendarDate = __to_calendardate(d) # `calendardate` is already validated.
 
   if calendardate.date_type == CalendarType.LUNAR:
-    return copy.deepcopy(calendardate)
+    return calendardate
   elif calendardate.date_type == CalendarType.SOLAR:
     return solar_to_lunar(calendardate)
   else:
@@ -366,7 +365,7 @@ def to_ganzhi(d: date | CalendarDate) -> CalendarDate:
   calendardate: CalendarDate = __to_calendardate(d) # `calendardate` is already validated.
 
   if calendardate.date_type == CalendarType.GANZHI:
-    return copy.deepcopy(calendardate)
+    return calendardate
   elif calendardate.date_type == CalendarType.SOLAR:
     return solar_to_ganzhi(calendardate)
   else:

--- a/src/common.py
+++ b/src/common.py
@@ -1,7 +1,5 @@
 # Copyright (C) 2024 Ningqi Wang (0xf3cd) <https://github.com/0xf3cd>
 
-import copy
-
 from typing import TypeVar, Final
 from collections.abc import Iterator, Mapping
 
@@ -14,13 +12,17 @@ FrozenDictValueType = TypeVar('FrozenDictValueType')
 class frozendict(Mapping[FrozenDictKeyType, FrozenDictValueType]):
   '''
   My simple implementation of a frozen, immutable dict.
+
+  Shallow-frozen: the mapping itself never changes, and lookups return the stored
+  values as-is (no defensive copies). A holder of mutable values protects them at
+  its own boundary (e.g. `Interpreter` deep-copies corpus entries).
+  浅冻结：映射本身不可变，取值原样返回、不做防御性拷贝。持有可变值的一方在自己的
+  边界自行防护（如 `Interpreter` 深拷语料条目）。
   '''
   def __init__(self, data: Mapping[FrozenDictKeyType, FrozenDictValueType]) -> None:
-    self._data: Final[Mapping[FrozenDictKeyType, FrozenDictValueType]] = copy.deepcopy(data)
+    self._data: Final[Mapping[FrozenDictKeyType, FrozenDictValueType]] = dict(data)
   def __getitem__(self, key: FrozenDictKeyType) -> FrozenDictValueType:
-    # Use deepcopy to avoid changing the original dict.
-    # The value may not be deepcopyable though...
-    return copy.deepcopy(self._data[key])
+    return self._data[key]
   def __iter__(self) -> Iterator[FrozenDictKeyType]:
     return iter(self._data)
   def __len__(self) -> int:

--- a/src/common.py
+++ b/src/common.py
@@ -15,9 +15,9 @@ class frozendict(Mapping[FrozenDictKeyType, FrozenDictValueType]):
 
   Shallow-frozen: the mapping itself never changes, and lookups return the stored
   values as-is (no defensive copies). A holder of mutable values protects them at
-  its own boundary (e.g. `Interpreter` deep-copies corpus entries).
+  its own boundary.
   浅冻结：映射本身不可变，取值原样返回、不做防御性拷贝。持有可变值的一方在自己的
-  边界自行防护（如 `Interpreter` 深拷语料条目）。
+  边界自行防护。
   '''
   def __init__(self, data: Mapping[FrozenDictKeyType, FrozenDictValueType]) -> None:
     self._data: Final[Mapping[FrozenDictKeyType, FrozenDictValueType]] = dict(data)

--- a/src/common.py
+++ b/src/common.py
@@ -21,12 +21,22 @@ class frozendict(Mapping[FrozenDictKeyType, FrozenDictValueType]):
   '''
   def __init__(self, data: Mapping[FrozenDictKeyType, FrozenDictValueType]) -> None:
     self._data: Final[Mapping[FrozenDictKeyType, FrozenDictValueType]] = dict(data)
+    self._hash: int | None = None
   def __getitem__(self, key: FrozenDictKeyType) -> FrozenDictValueType:
     return self._data[key]
   def __iter__(self) -> Iterator[FrozenDictKeyType]:
     return iter(self._data)
   def __len__(self) -> int:
     return len(self._data)
+  def __hash__(self) -> int:
+    # Tuple semantics, computed lazily: equal contents hash equal (in sync with
+    # `Mapping.__eq__`), and unhashable contents (e.g. the description corpus holds
+    # lists) raise TypeError on the first hash attempt.
+    # 元组语义，惰性计算：内容相等则哈希相等（与 `Mapping.__eq__` 一致），
+    # 内容不可哈希（如语料表的 list 值）则首次求哈希时抛 TypeError。
+    if self._hash is None:
+      self._hash = hash(frozenset(self._data.items()))
+    return self._hash
 
 #endregion
 

--- a/src/data_types.py
+++ b/src/data_types.py
@@ -1,8 +1,8 @@
 # Copyright (C) 2026 Ningqi Wang (0xf3cd) <https://github.com/0xf3cd>
 
 from dataclasses import dataclass
-from typing import TypeVar, Generic, NamedTuple
-from collections.abc import Iterator
+from typing import TypeVar, Generic, NamedTuple, Self
+from collections.abc import Iterator, Callable, Set as AbstractSet
 
 from .common import frozendict
 from .defines import Wuxing, Yinyang, Tiangan, Ganzhi
@@ -81,3 +81,44 @@ class GanzhiData(Generic[TianganDataType, DizhiDataType]):
   '''
   tiangan: TianganDataType
   dizhi: DizhiDataType
+
+
+RelationType = TypeVar('RelationType')
+RelationItemType = TypeVar('RelationItemType')
+class RelationDiscovery(
+  frozendict[RelationType, tuple[frozenset[RelationItemType], ...]],
+  Generic[RelationType, RelationItemType],
+):
+  '''
+  Generic base of `TianganRelationDiscovery` / `DizhiRelationDiscovery`: a frozen mapping
+  from relation to its matching combos, with combo-level filtering and merging.
+  天干/地支关系发现结果的泛型基类：关系到组合的冻结映射，支持按组合过滤与合并。
+  '''
+
+  def filter(self, f: Callable[[RelationType, frozenset[RelationItemType]], bool]) -> Self:
+    '''Keep only the combos accepted by `f`; relations left with no combo are dropped.
+    只保留 `f` 接受的组合；不再有组合的关系整键丢弃。'''
+    assert callable(f)
+    return type(self)({
+      rel : filtered
+      for rel, combos in self.items()
+      if len(filtered := tuple(c for c in combos if f(rel, c))) > 0
+    })
+
+  def merge(self, other: Self) -> Self:
+    '''Merge two discoveries together (set-union of combos per relation).
+    合并两个发现结果（每个关系下的组合做集合并）。'''
+    assert isinstance(other, type(self))
+    d: dict[RelationType, set[frozenset[RelationItemType]]] = {}
+
+    for rel, combos in self.items():
+      d[rel] = set(combos)
+    for rel, combos in other.items():
+      d[rel] = d.get(rel, set()) | set(combos)
+
+    return type(self)({ rel : tuple(combos) for rel, combos in d.items() })
+
+  def mutual_only(self, items1: AbstractSet[RelationItemType], items2: AbstractSet[RelationItemType]) -> Self:
+    '''Keep only the combos that draw from both sides (a combo disjoint from either side
+    comes from one side only). 只保留同时取材于两侧的组合（与任一侧不相交即单侧组合）。'''
+    return self.filter(lambda rel, combo: not combo.isdisjoint(items1) and not combo.isdisjoint(items2))

--- a/src/data_types.py
+++ b/src/data_types.py
@@ -1,8 +1,8 @@
 # Copyright (C) 2026 Ningqi Wang (0xf3cd) <https://github.com/0xf3cd>
 
 from dataclasses import dataclass
-from typing import TypeVar, Generic, NamedTuple, Self
-from collections.abc import Iterator, Callable, Set as AbstractSet
+from typing import TypeVar, Generic, NamedTuple
+from collections.abc import Iterator
 
 from .common import frozendict
 from .defines import Wuxing, Yinyang, Tiangan, Ganzhi
@@ -81,44 +81,3 @@ class GanzhiData(Generic[TianganDataType, DizhiDataType]):
   '''
   tiangan: TianganDataType
   dizhi: DizhiDataType
-
-
-RelationType = TypeVar('RelationType')
-RelationItemType = TypeVar('RelationItemType')
-class RelationDiscovery(
-  frozendict[RelationType, tuple[frozenset[RelationItemType], ...]],
-  Generic[RelationType, RelationItemType],
-):
-  '''
-  Generic base of `TianganRelationDiscovery` / `DizhiRelationDiscovery`: a frozen mapping
-  from relation to its matching combos, with combo-level filtering and merging.
-  天干/地支关系发现结果的泛型基类：关系到组合的冻结映射，支持按组合过滤与合并。
-  '''
-
-  def filter(self, f: Callable[[RelationType, frozenset[RelationItemType]], bool]) -> Self:
-    '''Keep only the combos accepted by `f`; relations left with no combo are dropped.
-    只保留 `f` 接受的组合；不再有组合的关系整键丢弃。'''
-    assert callable(f)
-    return type(self)({
-      rel : filtered
-      for rel, combos in self.items()
-      if len(filtered := tuple(c for c in combos if f(rel, c))) > 0
-    })
-
-  def merge(self, other: Self) -> Self:
-    '''Merge two discoveries together (set-union of combos per relation).
-    合并两个发现结果（每个关系下的组合做集合并）。'''
-    assert isinstance(other, type(self))
-    d: dict[RelationType, set[frozenset[RelationItemType]]] = {}
-
-    for rel, combos in self.items():
-      d[rel] = set(combos)
-    for rel, combos in other.items():
-      d[rel] = d.get(rel, set()) | set(combos)
-
-    return type(self)({ rel : tuple(combos) for rel, combos in d.items() })
-
-  def mutual_only(self, items1: AbstractSet[RelationItemType], items2: AbstractSet[RelationItemType]) -> Self:
-    '''Keep only the combos that draw from both sides (a combo disjoint from either side
-    comes from one side only). 只保留同时取材于两侧的组合（与任一侧不相交即单侧组合）。'''
-    return self.filter(lambda rel, combo: not combo.isdisjoint(items1) and not combo.isdisjoint(items2))

--- a/src/defines/dizhi.py
+++ b/src/defines/dizhi.py
@@ -1,9 +1,9 @@
 # Copyright (C) 2026 Ningqi Wang (0xf3cd) <https://github.com/0xf3cd>
 
-from enum import Enum
+from .enum_base import IndexedBaziEnum
 
 
-class Dizhi(Enum):
+class Dizhi(IndexedBaziEnum):
   '''Dizhi / Branch / 地支'''
   ZI   = '子'
   CHOU = '丑'
@@ -31,25 +31,5 @@ class Dizhi(Enum):
   酉   =  YOU
   戌   =   XU
   亥   =  HAI
-
-  @classmethod
-  def from_str(cls, s: str) -> 'Dizhi':
-    assert isinstance(s, str)
-    return cls(s)
-  
-  @classmethod
-  def as_list(cls) -> list['Dizhi']:
-    return list(cls)
-  
-  def __str__(self) -> str:
-    return str(self.value)
-  
-  @property
-  def index(self) -> int:
-    return Dizhi.as_list().index(self)
-  
-  @staticmethod
-  def from_index(i: int) -> 'Dizhi':
-    return Dizhi.as_list()[i]
 
 地支 = Dizhi # Alias

--- a/src/defines/enum_base.py
+++ b/src/defines/enum_base.py
@@ -1,0 +1,62 @@
+# Copyright (C) 2026 Ningqi Wang (0xf3cd) <https://github.com/0xf3cd>
+
+import functools
+
+from enum import Enum
+from typing import Self
+
+
+@functools.cache
+def _members(cls: type[Enum]) -> tuple[Enum, ...]:
+  return tuple(cls)
+
+
+@functools.cache
+def _member_indexes(cls: type[Enum]) -> dict[Enum, int]:
+  return { member : index for index, member in enumerate(cls) }
+
+
+class BaziEnum(Enum):
+  '''
+  Shared base of the domain enums, deduplicating the `from_str` / `as_list` / `__str__`
+  boilerplate. Subclass hooks must be descriptors (e.g. classmethods) -- a plain class
+  attribute in an `Enum` body would be swallowed as a member.
+  领域枚举的公共基类，收敛 `from_str` / `as_list` / `__str__` 样板。子类钩子必须是
+  描述符（如 classmethod）——Enum 类体里的普通类属性会被吃成枚举成员。
+  '''
+
+  @classmethod
+  def _str_len(cls) -> int | None:
+    '''Subclass hook: the exact `from_str` input length, or None for no length precondition.
+    子类钩子：`from_str` 输入的确切长度；None 表示不设长度前置条件。'''
+    return None
+
+  @classmethod
+  def from_str(cls, s: str) -> Self:
+    assert isinstance(s, str)
+    expected_len = cls._str_len()
+    if expected_len is not None:
+      assert len(s) == expected_len
+    return cls(s)
+
+  @classmethod
+  def as_list(cls) -> list[Self]:
+    return list(cls)
+
+  def __str__(self) -> str:
+    return str(self.value)
+
+
+class IndexedBaziEnum(BaziEnum):
+  '''`BaziEnum` plus O(1) definition-order indexing (`index` / `from_index`).
+  在 `BaziEnum` 之上另提供 O(1) 的定义序下标（`index` / `from_index`）。'''
+
+  @property
+  def index(self) -> int:
+    return _member_indexes(type(self))[self]
+
+  @classmethod
+  def from_index(cls, i: int) -> Self:
+    member = _members(cls)[i]
+    assert isinstance(member, cls)
+    return member

--- a/src/defines/enum_base.py
+++ b/src/defines/enum_base.py
@@ -13,6 +13,8 @@ def _members(cls: type[Enum]) -> tuple[Enum, ...]:
 
 @functools.cache
 def _member_indexes(cls: type[Enum]) -> dict[Enum, int]:
+  # This cached table IS the O(1) `index` mechanism (not lazy loading of a rule table).
+  # Module-private; callers only read. 缓存表即 O(1) 下标本体；模块私有，只读消费。
   return { member : index for index, member in enumerate(cls) }
 
 
@@ -57,6 +59,10 @@ class IndexedBaziEnum(BaziEnum):
 
   @classmethod
   def from_index(cls, i: int) -> Self:
+    '''Definition-order lookup with `list`-style indexing: negative indexes wrap,
+    out-of-range raises IndexError. 定义序取成员，下标语义同 `list`：负数回绕，越界 IndexError。'''
     member = _members(cls)[i]
+    # `functools.cache` erases the helper's generic type; this narrows it back for mypy
+    # and doubles as a runtime guard. cache 包装抹平泛型，此断言兼作 mypy 窄化与运行时防线。
     assert isinstance(member, cls)
     return member

--- a/src/defines/enum_base.py
+++ b/src/defines/enum_base.py
@@ -62,7 +62,8 @@ class IndexedBaziEnum(BaziEnum):
     '''Definition-order lookup with `list`-style indexing: negative indexes wrap,
     out-of-range raises IndexError. 定义序取成员，下标语义同 `list`：负数回绕，越界 IndexError。'''
     member = _members(cls)[i]
-    # `functools.cache` erases the helper's generic type; this narrows it back for mypy
-    # and doubles as a runtime guard. cache 包装抹平泛型，此断言兼作 mypy 窄化与运行时防线。
+    # The helper can't be generic (`functools.cache` erases typevars), so narrow the
+    # member back here; doubles as a runtime guard. helper 写不成泛型（cache 会抹平
+    # typevar），故在此窄回，兼作运行时防线。
     assert isinstance(member, cls)
     return member

--- a/src/defines/jieqi.py
+++ b/src/defines/jieqi.py
@@ -1,9 +1,9 @@
 # Copyright (C) 2026 Ningqi Wang (0xf3cd) <https://github.com/0xf3cd>
 
-from enum import Enum
+from .enum_base import BaziEnum
 
 
-class Jieqi(Enum):
+class Jieqi(BaziEnum):
   '''Jieqi / 节气'''
   LICHUN      = '立春'
   YUSHUI      = '雨水'
@@ -57,11 +57,9 @@ class Jieqi(Enum):
   大寒 = DAHAN
 
   @classmethod
-  def from_str(cls, s: str) -> 'Jieqi':
-    assert isinstance(s, str)
-    assert len(s) == 2
-    return cls(s)
-  
+  def _str_len(cls) -> int | None:
+    return 2
+
   @classmethod
   def as_list(cls, ganzhi_year: bool = True) -> list['Jieqi']:
     '''
@@ -75,8 +73,5 @@ class Jieqi(Enum):
       return list(cls)
     else: # Return in the order that Jieqis appear in a solar year.
       return list(cls)[-2:] + list(cls)[:-2]
-
-  def __str__(self) -> str:
-    return str(self.value)
 
 节气 = Jieqi # Alias

--- a/src/defines/relations.py
+++ b/src/defines/relations.py
@@ -1,9 +1,9 @@
 # Copyright (C) 2026 Ningqi Wang (0xf3cd) <https://github.com/0xf3cd>
 
-from enum import Enum
+from .enum_base import BaziEnum
 
 
-class TianganRelation(Enum):
+class TianganRelation(BaziEnum):
   '''TianganRelation / Tiangan Relations / 天干之间的关系'''
   HE    = '合'
   CHONG = '冲'
@@ -16,18 +16,10 @@ class TianganRelation(Enum):
   生 = SHENG
   克 = KE
 
-  def __str__(self) -> str:
-    return str(self.value)
-  
-  @classmethod
-  def from_str(cls, s: str) -> 'TianganRelation':
-    assert isinstance(s, str)
-    return cls(s)
-
 天干关系 = TianganRelation # Alias
 
 
-class DizhiRelation(Enum):
+class DizhiRelation(BaziEnum):
   '''DizhiRelation / Dizhi Relations / 地支之间的关系'''
   SANHUI   = '三会'
   LIUHE    = '六合'
@@ -57,13 +49,5 @@ class DizhiRelation(Enum):
   害    = HAI
   生    = SHENG
   克    = KE
-
-  def __str__(self) -> str:
-    return str(self.value)
-  
-  @classmethod
-  def from_str(cls, s: str) -> 'DizhiRelation':
-    assert isinstance(s, str)
-    return cls(s)
 
 地支关系 = DizhiRelation # Alias

--- a/src/defines/shier_zhangsheng.py
+++ b/src/defines/shier_zhangsheng.py
@@ -1,9 +1,9 @@
 # Copyright (C) 2026 Ningqi Wang (0xf3cd) <https://github.com/0xf3cd>
 
-from enum import Enum
+from .enum_base import IndexedBaziEnum
 
 
-class ShierZhangsheng(Enum):
+class ShierZhangsheng(IndexedBaziEnum):
   '''ShierZhangsheng / Twelve Stages of Growth / 十二长生'''
   ZHANGSHENG = '长生'
   MUYU       = '沐浴'
@@ -31,25 +31,5 @@ class ShierZhangsheng(Enum):
   绝  = JUE
   胎  = TAI
   养  = YANG
-
-  @classmethod
-  def from_str(cls, s: str) -> 'ShierZhangsheng':
-    assert isinstance(s, str)
-    return cls(s)
-  
-  @classmethod
-  def as_list(cls) -> list['ShierZhangsheng']:
-    return list(cls)
-  
-  @property
-  def index(self) -> int:
-    return ShierZhangsheng.as_list().index(self)
-  
-  @classmethod
-  def from_index(cls, index: int) -> 'ShierZhangsheng':
-    return ShierZhangsheng.as_list()[index]
-
-  def __str__(self) -> str:
-    return str(self.value)
 
 十二长生 = ShierZhangsheng # Alias

--- a/src/defines/shishen.py
+++ b/src/defines/shishen.py
@@ -1,9 +1,9 @@
 # Copyright (C) 2026 Ningqi Wang (0xf3cd) <https://github.com/0xf3cd>
 
-from enum import Enum
+from .enum_base import BaziEnum
 
 
-class Shishen(Enum):
+class Shishen(BaziEnum):
   '''Shishen / Ten Gods / 十神'''
   BIJIAN    = '比肩'
   JIECAI    = '劫财'
@@ -46,8 +46,10 @@ class Shishen(Enum):
       '枭': '偏印',
     }
 
-  @staticmethod
-  def from_str(s: str) -> 'Shishen':
+  @classmethod
+  def from_str(cls, s: str) -> 'Shishen':
+    # Overrides the base: also accepts the single-char aliases (e.g. '比' -> 比肩).
+    # 覆盖基类：额外接受单字别名。
     assert isinstance(s, str)
     assert len(s) in [1, 2]
 
@@ -57,14 +59,7 @@ class Shishen(Enum):
       s = t[s]
 
     return Shishen(s)
-  
-  @classmethod
-  def as_list(cls) -> list['Shishen']:
-    return list(cls)
-  
-  def __str__(self) -> str:
-    return str(self.value)
-  
+
   @property
   def abbr(self) -> str:
     '''

--- a/src/defines/shishen.py
+++ b/src/defines/shishen.py
@@ -1,5 +1,7 @@
 # Copyright (C) 2026 Ningqi Wang (0xf3cd) <https://github.com/0xf3cd>
 
+from typing import Self
+
 from .enum_base import BaziEnum
 
 
@@ -47,7 +49,7 @@ class Shishen(BaziEnum):
     }
 
   @classmethod
-  def from_str(cls, s: str) -> 'Shishen':
+  def from_str(cls, s: str) -> Self:
     # Overrides the base: also accepts the single-char aliases (e.g. '比' -> 比肩).
     # 覆盖基类：额外接受单字别名。
     assert isinstance(s, str)
@@ -58,7 +60,7 @@ class Shishen(BaziEnum):
       assert s in t
       s = t[s]
 
-    return Shishen(s)
+    return cls(s)
 
   @property
   def abbr(self) -> str:

--- a/src/defines/tiangan.py
+++ b/src/defines/tiangan.py
@@ -1,9 +1,9 @@
 # Copyright (C) 2026 Ningqi Wang (0xf3cd) <https://github.com/0xf3cd>
 
-from enum import Enum
+from .enum_base import IndexedBaziEnum
 
 
-class Tiangan(Enum):
+class Tiangan(IndexedBaziEnum):
   '''Tiangan / Stem / 天干'''
   JIA  = '甲'
   YI   = '乙'
@@ -27,25 +27,5 @@ class Tiangan(Enum):
   辛  =  XIN
   壬  =  REN
   癸  =  GUI
-
-  @classmethod
-  def from_str(cls, s: str) -> 'Tiangan':
-    assert isinstance(s, str)
-    return cls(s)
-  
-  @classmethod
-  def as_list(cls) -> list['Tiangan']:
-    return list(cls)
-  
-  def __str__(self) -> str:
-    return str(self.value)
-  
-  @property
-  def index(self) -> int:
-    return Tiangan.as_list().index(self)
-  
-  @staticmethod
-  def from_index(i: int) -> 'Tiangan':
-    return Tiangan.as_list()[i]
 
 天干 = Tiangan # Alias

--- a/src/defines/wuxing.py
+++ b/src/defines/wuxing.py
@@ -1,10 +1,11 @@
 # Copyright (C) 2026 Ningqi Wang (0xf3cd) <https://github.com/0xf3cd>
 
-from enum import Enum
 from typing import Final
 
+from .enum_base import BaziEnum
 
-class Wuxing(Enum):
+
+class Wuxing(BaziEnum):
   '''Wuxing / 五行'''
   WOOD  = '木'
   FIRE  = '火'
@@ -20,18 +21,9 @@ class Wuxing(Enum):
   水 = WATER
 
   @classmethod
-  def from_str(cls, s: str) -> 'Wuxing':
-    assert isinstance(s, str)
-    assert len(s) == 1
-    return cls(s)
+  def _str_len(cls) -> int | None:
+    return 1
 
-  @classmethod
-  def as_list(cls) -> list['Wuxing']:
-    return list(cls)
-
-  def __str__(self) -> str:
-    return str(self.value)
-  
   def generates(self, wx: 'Wuxing') -> bool:
     '''
     Check if the input wuxing can be generated from the current.

--- a/src/defines/wuxing.py
+++ b/src/defines/wuxing.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2026 Ningqi Wang (0xf3cd) <https://github.com/0xf3cd>
 
 from enum import Enum
+from typing import Final
 
 
 class Wuxing(Enum):
@@ -49,18 +50,8 @@ class Wuxing(Enum):
     - Wuxing.木.generates(Wuxing.火) -> True  # Wood feeds Fire / 木生火
     - Wuxing.火.generates(Wuxing.木) -> False # Fire does not generate Wood / 火不生木
     '''
-    if self is Wuxing.木:
-      return wx is Wuxing.火
-    elif self is Wuxing.火:
-      return wx is Wuxing.土
-    elif self is Wuxing.土:
-      return wx is Wuxing.金
-    elif self is Wuxing.金:
-      return wx is Wuxing.水
-    else:
-      assert self is Wuxing.水
-      return wx is Wuxing.木
-    
+    return _GENERATES[self] is wx
+
   def destructs(self, wx: 'Wuxing') -> bool:
     '''
     Check if the input wuxing can be destroyed by the current.
@@ -79,16 +70,13 @@ class Wuxing(Enum):
     - Wuxing.土.destructs(Wuxing.水) -> True  # Earth destroys Water / 土克水
     - Wuxing.水.destructs(Wuxing.土) -> False # Water does not destroy Earth / 水不克土
     '''
-    if self is Wuxing.木:
-      return wx is Wuxing.土
-    elif self is Wuxing.火:
-      return wx is Wuxing.金
-    elif self is Wuxing.土:
-      return wx is Wuxing.水
-    elif self is Wuxing.金:
-      return wx is Wuxing.木
-    else:
-      assert self is Wuxing.水
-      return wx is Wuxing.火
+    return _DESTRUCTS[self] is wx
 
 五行 = Wuxing # Alias
+
+
+# Both relations are walks along the generation cycle (相生环: 木→火→土→金→水→木):
+# generation is one step, destruction two steps (隔位相克).
+_CYCLE: Final[list[Wuxing]] = [Wuxing.木, Wuxing.火, Wuxing.土, Wuxing.金, Wuxing.水]
+_GENERATES: Final[dict[Wuxing, Wuxing]] = { wx : _CYCLE[(i + 1) % 5] for i, wx in enumerate(_CYCLE) }
+_DESTRUCTS: Final[dict[Wuxing, Wuxing]] = { wx : _CYCLE[(i + 2) % 5] for i, wx in enumerate(_CYCLE) }

--- a/src/defines/wuxing.py
+++ b/src/defines/wuxing.py
@@ -64,11 +64,11 @@ class Wuxing(BaziEnum):
     '''
     return _DESTRUCTS[self] is wx
 
-五行 = Wuxing # Alias
-
-
 # Both relations are walks along the generation cycle (相生环: 木→火→土→金→水→木):
 # generation is one step, destruction two steps (隔位相克).
-_CYCLE: Final[list[Wuxing]] = [Wuxing.木, Wuxing.火, Wuxing.土, Wuxing.金, Wuxing.水]
-_GENERATES: Final[dict[Wuxing, Wuxing]] = { wx : _CYCLE[(i + 1) % 5] for i, wx in enumerate(_CYCLE) }
-_DESTRUCTS: Final[dict[Wuxing, Wuxing]] = { wx : _CYCLE[(i + 2) % 5] for i, wx in enumerate(_CYCLE) }
+_CYCLE: Final[tuple[Wuxing, ...]] = (Wuxing.木, Wuxing.火, Wuxing.土, Wuxing.金, Wuxing.水)
+_GENERATES: Final[dict[Wuxing, Wuxing]] = { wx : _CYCLE[(i + 1) % len(_CYCLE)] for i, wx in enumerate(_CYCLE) }
+_DESTRUCTS: Final[dict[Wuxing, Wuxing]] = { wx : _CYCLE[(i + 2) % len(_CYCLE)] for i, wx in enumerate(_CYCLE) }
+
+
+五行 = Wuxing # Alias

--- a/src/defines/yinyang.py
+++ b/src/defines/yinyang.py
@@ -1,9 +1,9 @@
 # Copyright (C) 2026 Ningqi Wang (0xf3cd) <https://github.com/0xf3cd>
 
-from enum import Enum
+from .enum_base import BaziEnum
 
 
-class Yinyang(Enum):
+class Yinyang(BaziEnum):
   '''Yinyang / 阴阳'''
   YANG = '阳'
   YIN  = '阴'
@@ -13,17 +13,8 @@ class Yinyang(Enum):
   阴 = YIN
 
   @classmethod
-  def from_str(cls, s: str) -> 'Yinyang':
-    assert isinstance(s, str)
-    assert len(s) == 1
-    return cls(s)
-  
-  @classmethod
-  def as_list(cls) -> list['Yinyang']:
-    return list(cls)
-  
-  def __str__(self) -> str:
-    return str(self.value)
+  def _str_len(cls) -> int | None:
+    return 1
 
   @property
   def opposite(self) -> 'Yinyang':

--- a/src/descriptions.py
+++ b/src/descriptions.py
@@ -34,9 +34,11 @@ class TianganDescription(TypedDict):
 
 
 # This table stores the descriptions of each Shishen.
-# The corpus tables are frozen: access via `frozendict` returns a deep copy,
-# so the corpus can never be mutated from outside.
-# 语料表是冻结的：通过 `frozendict` 访问返回深拷贝，外部无法篡改语料。
+# The corpus tables are frozen mappings, but entries are returned as-is — anyone
+# reading them directly must not mutate the results. `Interpreter.interpret_*` is
+# the mutation-safe boundary: it deep-copies entries before returning.
+# 语料表是冻结映射，但取条目原样返回——直接读表者不得修改结果。
+# `Interpreter.interpret_*` 是可安全修改的边界：返回前深拷贝条目。
 SHISHEN_DESCRIPTIONS: Final[frozendict[Shishen, ShishenDescription]] = frozendict({
   Shishen.比肩 : {
     'general': [

--- a/src/descriptions.py
+++ b/src/descriptions.py
@@ -34,7 +34,7 @@ class TianganDescription(TypedDict):
 
 
 # This table stores the descriptions of each Shishen.
-# The corpus tables are frozen mappings, but entries are returned as-is — anyone
+# The corpus tables are frozen mappings, but entries are returned as-is -- anyone
 # reading them directly must not mutate the results. `Interpreter.interpret_*` is
 # the mutation-safe boundary: it deep-copies entries before returning.
 # 语料表是冻结映射，但取条目原样返回——直接读表者不得修改结果。

--- a/src/interpreter.py
+++ b/src/interpreter.py
@@ -1,5 +1,7 @@
 # Copyright (C) 2024 Ningqi Wang (0xf3cd) <https://github.com/0xf3cd>
 
+import copy
+
 from .defines import Shishen, Tiangan
 from .descriptions import (
   ShishenDescription, TianganDescription, SHISHEN_DESCRIPTIONS, TIANGAN_DESCRIPTIONS,
@@ -9,12 +11,12 @@ from .descriptions import (
 class Interpreter:
   '''
   `Interpreter` statically looks up the curated description corpus (语料库) of
-  Shishen and Tiangan. The corpus tables are frozen, and the returned descriptions
-  are deep copies (see `frozendict` in `common`), so callers may freely modify them
+  Shishen and Tiangan. The corpus tables are frozen, and the `interpret_*` methods
+  deep-copy the entries before returning, so callers may freely modify the results
   without corrupting the corpus.
 
-  `Interpreter` 以静态方法查询十神和天干的语料库。语料表是冻结的，且返回的描述是
-  深拷贝（见 `common` 中的 `frozendict`），调用方可随意修改，不会污染语料库。
+  `Interpreter` 以静态方法查询十神和天干的语料库。语料表是冻结的，且 `interpret_*`
+  返回前对条目做深拷贝，调用方可随意修改结果，不会污染语料库。
 
   Note:
   - Combining the descriptions against a specific chart (i.e. producing a whole-chart
@@ -35,7 +37,7 @@ class Interpreter:
     - (ShishenDescription) A deep copy of the corpus entry. / 语料库对应条目的深拷贝。
     '''
     assert isinstance(shishen, Shishen)
-    return SHISHEN_DESCRIPTIONS[shishen]
+    return copy.deepcopy(SHISHEN_DESCRIPTIONS[shishen])
 
   @staticmethod
   def interpret_tiangan(tg: Tiangan) -> TianganDescription:
@@ -50,4 +52,4 @@ class Interpreter:
     - (TianganDescription) A deep copy of the corpus entry. / 语料库对应条目的深拷贝。
     '''
     assert isinstance(tg, Tiangan)
-    return TIANGAN_DESCRIPTIONS[tg]
+    return copy.deepcopy(TIANGAN_DESCRIPTIONS[tg])

--- a/src/interpreter.py
+++ b/src/interpreter.py
@@ -11,12 +11,8 @@ from .descriptions import (
 class Interpreter:
   '''
   `Interpreter` statically looks up the curated description corpus (语料库) of
-  Shishen and Tiangan. The corpus tables are frozen, and the `interpret_*` methods
-  deep-copy the entries before returning, so callers may freely modify the results
-  without corrupting the corpus.
-
-  `Interpreter` 以静态方法查询十神和天干的语料库。语料表是冻结的，且 `interpret_*`
-  返回前对条目做深拷贝，调用方可随意修改结果，不会污染语料库。
+  Shishen and Tiangan; the returned entries are deep copies, safe to modify.
+  `Interpreter` 以静态方法查询十神和天干的语料库；返回条目是深拷贝，可随意修改。
 
   Note:
   - Combining the descriptions against a specific chart (i.e. producing a whole-chart

--- a/src/transit_chart.py
+++ b/src/transit_chart.py
@@ -1,7 +1,5 @@
 # Copyright (C) 2026 Ningqi Wang (0xf3cd) <https://github.com/0xf3cd>
 
-import copy
-
 from typing import Final
 
 from .defines import Ganzhi
@@ -29,13 +27,15 @@ class TransitChart:
     '''
 
     assert isinstance(bazi_chart, BaziChart)
-    self._bazi_chart: Final[BaziChart] = copy.deepcopy(bazi_chart)
+    self._bazi_chart: Final[BaziChart] = bazi_chart
     self._transit_db: Final[TransitDatabase] = TransitDatabase(self._bazi_chart)
 
   @property
   def bazi_chart(self) -> BaziChart:
-    '''The underlying `BaziChart` (原盘). A defensive copy is returned. 返回防御性拷贝。'''
-    return copy.deepcopy(self._bazi_chart)
+    '''The underlying `BaziChart` (原盘). Shared, not copied -- `BaziChart` is read-only
+    (its mutable `Bazi` is isolated inside the chart). 直接共享——`BaziChart` 只读，
+    可变的 `Bazi` 已由命盘自身隔离。'''
+    return self._bazi_chart
 
   def support(self, moment: TransitMoment, options: TransitOptions) -> bool:
     '''

--- a/src/transit_chart.py
+++ b/src/transit_chart.py
@@ -33,8 +33,8 @@ class TransitChart:
   @property
   def bazi_chart(self) -> BaziChart:
     '''The underlying `BaziChart` (原盘). Shared, not copied -- `BaziChart` is read-only
-    (its mutable `Bazi` is isolated inside the chart). 直接共享——`BaziChart` 只读，
-    可变的 `Bazi` 已由命盘自身隔离。'''
+    (its non-frozen `Bazi` is isolated inside the chart). 直接共享——`BaziChart` 只读，
+    非 frozen 的 `Bazi` 已由命盘自身隔离。'''
     return self._bazi_chart
 
   def support(self, moment: TransitMoment, options: TransitOptions) -> bool:

--- a/src/transits.py
+++ b/src/transits.py
@@ -17,7 +17,8 @@ from .bazi_chart import BaziChart
 
 
 class DayunDatabase:
-  '''A database that figures out a given Ganzhi year falls into which Dayun (大运).'''
+  '''Locates the Dayun (大运) that a given Ganzhi year falls into, by closed-form
+  arithmetic from the first Dayun. 由首运闭式定位任一干支年所属的大运。'''
   def __init__(self, chart: BaziChart) -> None:
     self._first_dayun: Final[DayunTuple] = next(chart.dayun)
     self._step: Final[int] = 1 if chart.dayun_order else -1

--- a/src/transits.py
+++ b/src/transits.py
@@ -8,7 +8,6 @@ from enum import unique, IntFlag
 from functools import reduce
 from itertools import combinations
 from typing import Final
-from collections.abc import Generator
 
 from .common import frozendict
 from .data_types import DayunTuple
@@ -20,24 +19,18 @@ from .bazi_chart import BaziChart
 class DayunDatabase:
   '''A database that figures out a given Ganzhi year falls into which Dayun (大运).'''
   def __init__(self, chart: BaziChart) -> None:
-    self._gen: Final[Generator[DayunTuple, None, None]] = chart.dayun
-    self._first_dayun: Final[DayunTuple] = next(self._gen)
-    self._cache: Final[dict[int, Ganzhi]] = {
-      self._first_dayun.ganzhi_year : self._first_dayun.ganzhi,
-    }
+    self._first_dayun: Final[DayunTuple] = next(chart.dayun)
+    self._step: Final[int] = 1 if chart.dayun_order else -1
 
   def __getitem__(self, gz_year: int) -> DayunTuple:
     assert isinstance(gz_year, int)
     assert gz_year >= self._first_dayun.ganzhi_year
 
+    # Dayuns are arithmetic: each lasts 10 years and steps the sexagenary cycle by one.
+    # 大运是等差序列：每运十年，六十甲子进（退）一位，直接按下标闭式计算。
     dayun_idx: int = (gz_year - self._first_dayun.ganzhi_year) // 10
-    expected_gz_year: int = self._first_dayun.ganzhi_year + 10 * dayun_idx
-
-    while expected_gz_year not in self._cache:
-      next_dayun: DayunTuple = next(self._gen)
-      self._cache[next_dayun.ganzhi_year] = next_dayun.ganzhi
-
-    return DayunTuple(expected_gz_year, self._cache[expected_gz_year])
+    return DayunTuple(self._first_dayun.ganzhi_year + 10 * dayun_idx,
+                      self._first_dayun.ganzhi.next(self._step * dayun_idx))
 
 
 @dataclass(frozen=True)

--- a/src/utils/bazi_utils.py
+++ b/src/utils/bazi_utils.py
@@ -1,7 +1,5 @@
 # Copyright (C) 2024 Ningqi Wang (0xf3cd) <https://github.com/0xf3cd>
 
-import copy
-
 from datetime import date, datetime
 
 from ..defines import Ganzhi, Tiangan, Dizhi, Shishen, Wuxing, Yinyang, ShierZhangsheng
@@ -100,7 +98,7 @@ def tiangan_traits(tg: Tiangan) -> TraitTuple:
   '''
 
   assert isinstance(tg, Tiangan)
-  return copy.deepcopy(BaziRules.TIANGAN_TRAITS[tg])
+  return BaziRules.TIANGAN_TRAITS[tg]
 
 
 def dizhi_traits(dz: Dizhi) -> TraitTuple:
@@ -115,7 +113,7 @@ def dizhi_traits(dz: Dizhi) -> TraitTuple:
   '''
 
   assert isinstance(dz, Dizhi)
-  return copy.deepcopy(BaziRules.DIZHI_TRAITS[dz])
+  return BaziRules.DIZHI_TRAITS[dz]
 
 
 def traits(tg_or_dz: Tiangan | Dizhi) -> TraitTuple:
@@ -149,7 +147,7 @@ def hidden_tiangans(dz: Dizhi) -> HiddenTianganDict:
   '''
 
   assert isinstance(dz, Dizhi)
-  return copy.deepcopy(BaziRules.HIDDEN_TIANGANS[dz])
+  return BaziRules.HIDDEN_TIANGANS[dz]
 
 
 def shishen(day_master: Tiangan, other: Tiangan | Dizhi) -> Shishen:

--- a/src/utils/dizhi_utils.py
+++ b/src/utils/dizhi_utils.py
@@ -419,6 +419,26 @@ def ke(dz1: Dizhi, dz2: Dizhi) -> bool:
   return (dz1, dz2) in DizhiRules.DIZHI_KE
 
 
+# The subset-style relations `search` supports, mapped to their combo tables. 暗合
+# pre-resolves `AnheDef.NORMAL_EXTENDED` (the widest definition) at build time. The
+# remaining relations deviate from the subset shape and are special-cased in `search`:
+# 刑 is multiset-sensitive, 生/克 hold directed pairs.
+# `search` 支持的子集型关系与其组合表。暗合在建表时预解最宽的 `NORMAL_EXTENDED` 定义；
+# 其余关系不符合子集形状，在 `search` 内单列：刑是多重集语义，生/克存有向对。
+_SUBSET_SEARCH_COMBOS: Final[frozendict[DizhiRelation, frozenset[DizhiCombo]]] = frozendict({
+  DizhiRelation.三会:  frozenset(DizhiRules.DIZHI_SANHUI),
+  DizhiRelation.六合:  frozenset(DizhiRules.DIZHI_LIUHE),
+  DizhiRelation.暗合:  DizhiRules.DIZHI_ANHE[DizhiRules.AnheDef.NORMAL_EXTENDED],
+  DizhiRelation.通合:  DizhiRules.DIZHI_TONGHE,
+  DizhiRelation.通禄合: DizhiRules.DIZHI_TONGLUHE,
+  DizhiRelation.三合:  frozenset(DizhiRules.DIZHI_SANHE),
+  DizhiRelation.半合:  frozenset(DizhiRules.DIZHI_BANHE),
+  DizhiRelation.冲:   DizhiRules.DIZHI_CHONG,
+  DizhiRelation.破:   DizhiRules.DIZHI_PO,
+  DizhiRelation.害:   DizhiRules.DIZHI_HAI,
+})
+
+
 def search(dizhis: Sequence[Dizhi], relation: DizhiRelation) -> DizhiRelationCombos:
   '''
   Find all possible Dizhi combos in the given `dizhis` that satisfy the `relation`.
@@ -482,56 +502,30 @@ def search(dizhis: Sequence[Dizhi], relation: DizhiRelation) -> DizhiRelationCom
   assert isinstance(dizhis, Sequence), "Non-sequence input loses the info of Dizhis' frequency."
   assert all(isinstance(dz, Dizhi) for dz in dizhis)
 
-  if relation is DizhiRelation.三会:
-    return DizhiRelationCombos(combo for combo in DizhiRules.DIZHI_SANHUI if combo.issubset(dizhis))
-  
-  elif relation is DizhiRelation.六合:
-    return DizhiRelationCombos(combo for combo in DizhiRules.DIZHI_LIUHE if combo.issubset(dizhis))
-  
-  elif relation is DizhiRelation.暗合:
-    anhe_table: frozenset[DizhiCombo] = DizhiRules.DIZHI_ANHE[DizhiRules.AnheDef.NORMAL_EXTENDED] # Use `NORMAL_EXTENDED` here, which has the widest definition.
-    return DizhiRelationCombos(combo for combo in anhe_table if combo.issubset(dizhis))
-  
-  elif relation is DizhiRelation.通合:
-    return DizhiRelationCombos(combo for combo in DizhiRules.DIZHI_TONGHE if combo.issubset(dizhis))
-  
-  elif relation is DizhiRelation.通禄合:
-    return DizhiRelationCombos(combo for combo in DizhiRules.DIZHI_TONGLUHE if combo.issubset(dizhis))
-  
-  elif relation is DizhiRelation.三合:
-    return DizhiRelationCombos(combo for combo in DizhiRules.DIZHI_SANHE if combo.issubset(dizhis))
-  
-  elif relation is DizhiRelation.半合:
-    return DizhiRelationCombos(combo for combo in DizhiRules.DIZHI_BANHE if combo.issubset(dizhis))
-  
-  elif relation is DizhiRelation.刑:
+  if relation is DizhiRelation.刑:
+    # Multiset-sensitive, so plain subset tests don't apply: 自刑 needs the same Dizhi twice.
+    # 多重集语义（自刑要求同一地支出现两次），普通子集判定不适用。
     dz_counter: Counter[Dizhi] = Counter(dizhis)
 
     ret: set[DizhiCombo] = set()
     for xing_tuple in DizhiRules.DIZHI_XING[DizhiRules.XingDef.LOOSE]:
-      # Sadly direct comparisons not implemented on `Counter` with Python 3.9.
-      # Otherwise we can use `dz_counter >= Counter(xing_tuple)` here.
       xing_dz_counter: Counter[Dizhi] = Counter(xing_tuple)
       if dz_counter & xing_dz_counter == xing_dz_counter:
         ret.add(DizhiCombo(xing_tuple))
 
     return DizhiRelationCombos(ret)
-  
-  elif relation is DizhiRelation.冲:
-    return DizhiRelationCombos(combo for combo in DizhiRules.DIZHI_CHONG if combo.issubset(dizhis))
-  
-  elif relation is DizhiRelation.破:
-    return DizhiRelationCombos(combo for combo in DizhiRules.DIZHI_PO if combo.issubset(dizhis))
-  
-  elif relation is DizhiRelation.害:
-    return DizhiRelationCombos(combo for combo in DizhiRules.DIZHI_HAI if combo.issubset(dizhis))
 
-  # Else, `relation` must be `生` or `克`.
-  assert relation is DizhiRelation.生 or relation is DizhiRelation.克
-  rules: frozenset[tuple[Dizhi, Dizhi]] = DizhiRules.DIZHI_KE if relation is DizhiRelation.克 else DizhiRules.DIZHI_SHENG
-  frozen_rules: frozenset[DizhiCombo] = frozenset(map(DizhiCombo, rules))
-  dz_set: set[Dizhi] = set(dizhis)
-  return DizhiRelationCombos(combo for combo in frozen_rules if all(dz in dz_set for dz in combo))
+  if relation is DizhiRelation.生 or relation is DizhiRelation.克:
+    # The rule tables hold directed (subject, object) pairs -- fold them into direction-less
+    # combos first. 生克规则表存的是有向对，先折叠成无向组合。
+    pairs: frozenset[tuple[Dizhi, Dizhi]] = DizhiRules.DIZHI_KE if relation is DizhiRelation.克 else DizhiRules.DIZHI_SHENG
+    pair_combos: frozenset[DizhiCombo] = frozenset(map(DizhiCombo, pairs))
+    dz_set: set[Dizhi] = set(dizhis)
+    return DizhiRelationCombos(combo for combo in pair_combos if combo.issubset(dz_set))
+
+  # Every other relation shares one shape: keep the table combos fully present in the input.
+  # 其余关系同构：保留完整出现在输入中的组合。
+  return DizhiRelationCombos(combo for combo in _SUBSET_SEARCH_COMBOS[relation] if combo.issubset(dizhis))
 
 
 def discover(dizhis: Sequence[Dizhi]) -> DizhiRelationDiscovery:

--- a/src/utils/dizhi_utils.py
+++ b/src/utils/dizhi_utils.py
@@ -3,12 +3,12 @@
 
 from collections import Counter
 from typing import Final
-from collections.abc import Sequence, Callable, Collection
+from collections.abc import Sequence, Collection
 
 from ..common import frozendict
-from ..data_types import RelationDiscovery
 from ..defines import Dizhi, Wuxing, DizhiRelation
 from ..rules import DizhiRules
+from .relation_discovery import RelationDiscovery
 
 
 '''
@@ -23,13 +23,9 @@ DizhiCombo = frozenset[Dizhi]
 '''A list of all possible Dizhi combos that satisfy a certain `DizhiRelation`.'''
 DizhiRelationCombos = tuple[DizhiCombo, ...]
 
-'''A frozendict that stores the Dizhi combos that satisfy every `DizhiRelation`.'''
 class DizhiRelationDiscovery(RelationDiscovery[DizhiRelation, Dizhi]):
-  '''`filter` / `merge` / `mutual_only` come from the generic `RelationDiscovery` base.'''
-
-
-'''A function that filters Dizhi combos based on the given `DizhiRelation` and `DizhiCombo`.'''
-DizhiRelationDiscoveryFilter = Callable[[DizhiRelation, DizhiCombo], bool]
+  '''A frozen mapping from `DizhiRelation` to the Dizhi combos that satisfy it.
+  地支关系到满足它的地支组合的冻结映射。'''
 
 
 def sanhui(dz1: Dizhi, dz2: Dizhi, dz3: Dizhi) -> Wuxing | None:

--- a/src/utils/dizhi_utils.py
+++ b/src/utils/dizhi_utils.py
@@ -6,6 +6,7 @@ from typing import Final
 from collections.abc import Sequence, Callable
 
 from ..common import frozendict
+from ..data_types import RelationDiscovery
 from ..defines import Dizhi, Wuxing, DizhiRelation
 from ..rules import DizhiRules
 
@@ -23,32 +24,8 @@ DizhiCombo = frozenset[Dizhi]
 DizhiRelationCombos = tuple[DizhiCombo, ...]
 
 '''A frozendict that stores the Dizhi combos that satisfy every `DizhiRelation`.'''
-class DizhiRelationDiscovery(frozendict[DizhiRelation, DizhiRelationCombos]):
-  def filter(self, f: 'DizhiRelationDiscoveryFilter') -> 'DizhiRelationDiscovery':
-    '''Filter out Dizhi combos based on the given filter function `f`.'''
-    assert callable(f)
-    return DizhiRelationDiscovery({
-      rel : filtered
-      for rel, combos in self.items()
-      if len(
-        filtered := DizhiRelationCombos(filter(
-          lambda c : f(rel, c), 
-          combos,
-        ))
-      ) > 0
-    })
-  
-  def merge(self, other: 'DizhiRelationDiscovery') -> 'DizhiRelationDiscovery':
-    '''Merge two `DizhiRelationDiscovery` together.'''
-    assert isinstance(other, DizhiRelationDiscovery)
-    d: dict[DizhiRelation, set[DizhiCombo]] = {}
-
-    for rel, combos in self.items():
-      d[rel] = set(combos)
-    for rel, combos in other.items():
-      d[rel] = d.get(rel, set()) | set(combos)
-
-    return DizhiRelationDiscovery({ rel : DizhiRelationCombos(combos) for rel, combos in d.items() })
+class DizhiRelationDiscovery(RelationDiscovery[DizhiRelation, Dizhi]):
+  '''`filter` / `merge` / `mutual_only` come from the generic `RelationDiscovery` base.'''
 
 
 '''A function that filters Dizhi combos based on the given `DizhiRelation` and `DizhiCombo`.'''
@@ -593,18 +570,10 @@ def discover_mutual(dizhis1: Sequence[Dizhi], dizhis2: Sequence[Dizhi]) -> Dizhi
 
   assert all(isinstance(dz, Dizhi) for dz in dizhis1)
   assert all(isinstance(dz, Dizhi) for dz in dizhis2)
-  
-  dz1_set: Final[set[Dizhi]] = set(dizhis1)
-  dz2_set: Final[set[Dizhi]] = set(dizhis2)
 
-  def __is_valid(combo: DizhiCombo) -> bool:
-    # Disjoint from either set means all Dizhis in `combo` come from the other side only.
-    return not combo.isdisjoint(dz1_set) and not combo.isdisjoint(dz2_set)
-  
-  # Discover all possible combos with `dz1_set` and `dz2_set` combined.
-  # Check each combo's validity and only keep valid ones.
-  return DizhiRelationDiscovery({
-    rel : result
-    for rel, combos in discover(list(dizhis1) + list(dizhis2)).items()
-    if len(result := DizhiRelationCombos(filter(__is_valid, combos))) > 0
-  })
+  # 自刑 depends on multiplicity (the same Dizhi appearing once on each side forms 自刑),
+  # so the two sides CONCATENATE -- a set union would silently break it. Deliberately
+  # different from `tiangan_utils.discover_mutual`.
+  # 自刑依赖重数（同一地支两侧各现一次也构成自刑），故两侧拼接——集合并会静默破坏
+  # 自刑。与天干侧的集合并是刻意分歧。
+  return discover(list(dizhis1) + list(dizhis2)).mutual_only(set(dizhis1), set(dizhis2))

--- a/src/utils/dizhi_utils.py
+++ b/src/utils/dizhi_utils.py
@@ -3,7 +3,7 @@
 
 from collections import Counter
 from typing import Final
-from collections.abc import Sequence, Callable
+from collections.abc import Sequence, Callable, Collection
 
 from ..common import frozendict
 from ..data_types import RelationDiscovery
@@ -396,20 +396,20 @@ def ke(dz1: Dizhi, dz2: Dizhi) -> bool:
   return (dz1, dz2) in DizhiRules.DIZHI_KE
 
 
-# The subset-style relations `search` supports, mapped to their combo tables. 暗合
-# pre-resolves `AnheDef.NORMAL_EXTENDED` (the widest definition) at build time. The
-# remaining relations deviate from the subset shape and are special-cased in `search`:
-# 刑 is multiset-sensitive, 生/克 hold directed pairs.
-# `search` 支持的子集型关系与其组合表。暗合在建表时预解最宽的 `NORMAL_EXTENDED` 定义；
-# 其余关系不符合子集形状，在 `search` 内单列：刑是多重集语义，生/克存有向对。
-_SUBSET_SEARCH_COMBOS: Final[frozendict[DizhiRelation, frozenset[DizhiCombo]]] = frozendict({
-  DizhiRelation.三会:  frozenset(DizhiRules.DIZHI_SANHUI),
-  DizhiRelation.六合:  frozenset(DizhiRules.DIZHI_LIUHE),
+# The subset-style relations `search` supports, mapped to their combo tables (暗合
+# pre-resolves the widest `AnheDef.NORMAL_EXTENDED` definition at build time). Tables are
+# stored as-is -- wrapping the mapping tables in `frozenset` would trade their stable
+# definition-order iteration for per-process hash order.
+# `search` 支持的子集型关系与其组合表（暗合建表时预解最宽的 `NORMAL_EXTENDED` 定义）。
+# 表原样存放——若包一层 `frozenset`，映射表稳定的定义序迭代会退化成逐进程哈希序。
+_SUBSET_SEARCH_COMBOS: Final[frozendict[DizhiRelation, Collection[DizhiCombo]]] = frozendict({
+  DizhiRelation.三会:  DizhiRules.DIZHI_SANHUI,
+  DizhiRelation.六合:  DizhiRules.DIZHI_LIUHE,
   DizhiRelation.暗合:  DizhiRules.DIZHI_ANHE[DizhiRules.AnheDef.NORMAL_EXTENDED],
   DizhiRelation.通合:  DizhiRules.DIZHI_TONGHE,
   DizhiRelation.通禄合: DizhiRules.DIZHI_TONGLUHE,
-  DizhiRelation.三合:  frozenset(DizhiRules.DIZHI_SANHE),
-  DizhiRelation.半合:  frozenset(DizhiRules.DIZHI_BANHE),
+  DizhiRelation.三合:  DizhiRules.DIZHI_SANHE,
+  DizhiRelation.半合:  DizhiRules.DIZHI_BANHE,
   DizhiRelation.冲:   DizhiRules.DIZHI_CHONG,
   DizhiRelation.破:   DizhiRules.DIZHI_PO,
   DizhiRelation.害:   DizhiRules.DIZHI_HAI,

--- a/src/utils/relation_discovery.py
+++ b/src/utils/relation_discovery.py
@@ -44,5 +44,6 @@ class RelationDiscovery(
   def mutual_only(self, items1: AbstractSet[RelationItemType], items2: AbstractSet[RelationItemType]) -> Self:
     '''Keep only the combos that draw from both sides (a combo disjoint from either side
     comes from one side only). 只保留同时取材于两侧的组合（与任一侧不相交即单侧组合）。'''
-    assert isinstance(items1, AbstractSet) and isinstance(items2, AbstractSet)
+    assert isinstance(items1, AbstractSet)
+    assert isinstance(items2, AbstractSet)
     return self.filter(lambda rel, combo: not combo.isdisjoint(items1) and not combo.isdisjoint(items2))

--- a/src/utils/relation_discovery.py
+++ b/src/utils/relation_discovery.py
@@ -1,0 +1,48 @@
+# Copyright (C) 2026 Ningqi Wang (0xf3cd) <https://github.com/0xf3cd>
+
+from typing import TypeVar, Generic, Self
+from collections.abc import Callable, Set as AbstractSet
+
+from ..common import frozendict
+
+
+RelationType = TypeVar('RelationType')
+RelationItemType = TypeVar('RelationItemType')
+class RelationDiscovery(
+  frozendict[RelationType, tuple[frozenset[RelationItemType], ...]],
+  Generic[RelationType, RelationItemType],
+):
+  '''
+  Generic base of `TianganRelationDiscovery` / `DizhiRelationDiscovery`: a frozen mapping
+  from relation to its matching combos, with combo-level filtering and merging.
+  天干/地支关系发现结果的泛型基类：关系到组合的冻结映射，支持按组合过滤与合并。
+  '''
+
+  def filter(self, f: Callable[[RelationType, frozenset[RelationItemType]], bool]) -> Self:
+    '''Keep only the combos accepted by `f`; relations left with no combo are dropped.
+    只保留 `f` 接受的组合；不再有组合的关系整键丢弃。'''
+    assert callable(f)
+    return type(self)({
+      rel : filtered
+      for rel, combos in self.items()
+      if len(filtered := tuple(c for c in combos if f(rel, c))) > 0
+    })
+
+  def merge(self, other: Self) -> Self:
+    '''Merge two discoveries together (set-union of combos per relation).
+    合并两个发现结果（每个关系下的组合做集合并）。'''
+    assert isinstance(other, type(self))
+    d: dict[RelationType, set[frozenset[RelationItemType]]] = {}
+
+    for rel, combos in self.items():
+      d[rel] = set(combos)
+    for rel, combos in other.items():
+      d[rel] = d.get(rel, set()) | set(combos)
+
+    return type(self)({ rel : tuple(combos) for rel, combos in d.items() })
+
+  def mutual_only(self, items1: AbstractSet[RelationItemType], items2: AbstractSet[RelationItemType]) -> Self:
+    '''Keep only the combos that draw from both sides (a combo disjoint from either side
+    comes from one side only). 只保留同时取材于两侧的组合（与任一侧不相交即单侧组合）。'''
+    assert isinstance(items1, AbstractSet) and isinstance(items2, AbstractSet)
+    return self.filter(lambda rel, combo: not combo.isdisjoint(items1) and not combo.isdisjoint(items2))

--- a/src/utils/tiangan_utils.py
+++ b/src/utils/tiangan_utils.py
@@ -4,7 +4,7 @@ from typing import Final
 from collections.abc import Sequence, Callable
 
 from ..defines import Tiangan, Wuxing, TianganRelation
-from ..common import frozendict
+from ..data_types import RelationDiscovery
 from ..rules import TianganRules
 
 
@@ -20,34 +20,12 @@ TianganCombo = frozenset[Tiangan]
 '''A list of all possible Tiangan combos that satisfy a certain `TianganRelation`.'''
 TianganRelationCombos = tuple[TianganCombo, ...]
 
-'''A frozendict that stores the Tiangan combos that satisfy every `TianganRelation`.'''
-class TianganRelationDiscovery(frozendict[TianganRelation, TianganRelationCombos]):
-  def filter(self, f: 'TianganRelationDiscoveryFilter') -> 'TianganRelationDiscovery':
-    '''Filter out Tiangan combos based on the given filter function `f`.'''
-    assert callable(f)
-    return TianganRelationDiscovery({
-      rel : filtered
-      for rel, combos in self.items()
-      if len(
-        filtered := TianganRelationCombos(filter(
-          lambda c : f(rel, c), 
-          combos,
-        ))
-      ) > 0
-    })
-  
-  def merge(self, other: 'TianganRelationDiscovery') -> 'TianganRelationDiscovery':
-    '''Merge two `TianganRelationDiscovery` together.'''
-    assert isinstance(other, TianganRelationDiscovery)
-    d: dict[TianganRelation, set[TianganCombo]] = {}
+'''A frozendict that stores the Tiangan combos that satisfy every `TianganRelation`.
+`filter` / `merge` / `mutual_only` come from the generic `RelationDiscovery` base.'''
+class TianganRelationDiscovery(RelationDiscovery[TianganRelation, Tiangan]):
+  pass
 
-    for rel, combos in self.items():
-      d[rel] = set(combos)
-    for rel, combos in other.items():
-      d[rel] = d.get(rel, set()) | set(combos)
 
-    return TianganRelationDiscovery({ rel : TianganRelationCombos(combos) for rel, combos in d.items() })
-    
 
 '''A function that filters Tiangan combos based on the given `TianganRelation` and `TianganCombo`.'''
 TianganRelationDiscoveryFilter = Callable[[TianganRelation, TianganCombo], bool]
@@ -282,14 +260,8 @@ def discover_mutual(tiangans1: Sequence[Tiangan], tiangans2: Sequence[Tiangan]) 
   tg1_set: Final[set[Tiangan]] = set(tiangans1)
   tg2_set: Final[set[Tiangan]] = set(tiangans2)
 
-  def __is_valid(combo: TianganCombo) -> bool:
-    # Disjoint from either set means all Tiangans in `combo` come from the other side only.
-    return not combo.isdisjoint(tg1_set) and not combo.isdisjoint(tg2_set)
-
-  # Discover all possible combos with `tg1_set` and `tg2_set` combined.
-  # Check each combo's validity and only keep valid ones.
-  return TianganRelationDiscovery({
-    rel : result
-    for rel, combos in discover(list(tg1_set | tg2_set)).items()
-    if len(result := TianganRelationCombos(filter(__is_valid, combos))) > 0
-  })
+  # Tiangan relations are multiplicity-blind, so the two sides combine by set union.
+  # Deliberately different from `dizhi_utils.discover_mutual`, which CONCATENATES the
+  # inputs because 自刑 there depends on multiplicity.
+  # 天干关系不看重数，两侧集合并即可——与地支侧的拼接是刻意分歧（自刑依赖重数）。
+  return discover(list(tg1_set | tg2_set)).mutual_only(tg1_set, tg2_set)

--- a/src/utils/tiangan_utils.py
+++ b/src/utils/tiangan_utils.py
@@ -1,11 +1,11 @@
 # Copyright (C) 2024 Ningqi Wang (0xf3cd) <https://github.com/0xf3cd>
 
 from typing import Final
-from collections.abc import Sequence, Callable
+from collections.abc import Sequence
 
 from ..defines import Tiangan, Wuxing, TianganRelation
-from ..data_types import RelationDiscovery
 from ..rules import TianganRules
+from .relation_discovery import RelationDiscovery
 
 
 '''
@@ -20,15 +20,9 @@ TianganCombo = frozenset[Tiangan]
 '''A list of all possible Tiangan combos that satisfy a certain `TianganRelation`.'''
 TianganRelationCombos = tuple[TianganCombo, ...]
 
-'''A frozendict that stores the Tiangan combos that satisfy every `TianganRelation`.
-`filter` / `merge` / `mutual_only` come from the generic `RelationDiscovery` base.'''
 class TianganRelationDiscovery(RelationDiscovery[TianganRelation, Tiangan]):
-  pass
-
-
-
-'''A function that filters Tiangan combos based on the given `TianganRelation` and `TianganCombo`.'''
-TianganRelationDiscoveryFilter = Callable[[TianganRelation, TianganCombo], bool]
+  '''A frozen mapping from `TianganRelation` to the Tiangan combos that satisfy it.
+  天干关系到满足它的天干组合的冻结映射。'''
 
 
 def he(tg1: Tiangan, tg2: Tiangan) -> Wuxing | None:

--- a/tests/calendar/test_celestial_utils.py
+++ b/tests/calendar/test_celestial_utils.py
@@ -149,14 +149,6 @@ class TestConversions(unittest.TestCase):
       self.assertEqual(ALGO1.to_ganzhi(d).date_type, CalendarType.GANZHI)
       self.assertEqual(ALGO1.to_date(d), date(2024, 2, 4))
 
-  def test_to_family_may_share(self) -> None:
-    # `CalendarDate` is a frozen dataclass, so the `to_*` family and its caches share
-    # objects freely: the identity path may hand the caller's own object back.
-    d: CalendarDate = solar(2024, 2, 4)
-    self.assertEqual(ALGO1.to_solar(d), d)
-    self.assertEqual(ALGO1.to_lunar(ALGO1.to_lunar(d)), ALGO1.to_lunar(d))
-
-
 class TestJieqi(unittest.TestCase):
   def test_real_moments_not_placeholders(self) -> None:
     # The whole point of this backend: HKO can only say 00:00:00.

--- a/tests/calendar/test_celestial_utils.py
+++ b/tests/calendar/test_celestial_utils.py
@@ -149,13 +149,12 @@ class TestConversions(unittest.TestCase):
       self.assertEqual(ALGO1.to_ganzhi(d).date_type, CalendarType.GANZHI)
       self.assertEqual(ALGO1.to_date(d), date(2024, 2, 4))
 
-  def test_to_family_returns_copies(self) -> None:
-    # The identity paths must not hand the caller its own object back.  Two calls with the
-    # same argument *do* share one object (the cache holds it), which is harmless because
-    # `CalendarDate` exposes only getters over `Final` fields -- and it matches HKO.
+  def test_to_family_may_share(self) -> None:
+    # `CalendarDate` is a frozen dataclass, so the `to_*` family and its caches share
+    # objects freely: the identity path may hand the caller's own object back.
     d: CalendarDate = solar(2024, 2, 4)
-    self.assertIsNot(ALGO1.to_solar(d), d)
-    self.assertIsNot(ALGO1.to_lunar(ALGO1.to_lunar(d)), ALGO1.to_lunar(d))
+    self.assertEqual(ALGO1.to_solar(d), d)
+    self.assertEqual(ALGO1.to_lunar(ALGO1.to_lunar(d)), ALGO1.to_lunar(d))
 
 
 class TestJieqi(unittest.TestCase):

--- a/tests/calendar/test_celestial_utils.py
+++ b/tests/calendar/test_celestial_utils.py
@@ -149,6 +149,7 @@ class TestConversions(unittest.TestCase):
       self.assertEqual(ALGO1.to_ganzhi(d).date_type, CalendarType.GANZHI)
       self.assertEqual(ALGO1.to_date(d), date(2024, 2, 4))
 
+
 class TestJieqi(unittest.TestCase):
   def test_real_moments_not_placeholders(self) -> None:
     # The whole point of this backend: HKO can only say 00:00:00.

--- a/tests/test_bazi.py
+++ b/tests/test_bazi.py
@@ -640,3 +640,17 @@ class TestBazi(unittest.TestCase):
 
     other: Bazi = Bazi.create(dt, BaziGender.FEMALE, BaziPrecision.DAY)
     self.assertEqual(len({bazi, same, other}), 2)
+
+  def test_sub_minute_truncation(self) -> None:
+    # `solar_datetime` deliberately truncates to the minute (MINUTE is the finest
+    # `BaziPrecision`), and `__eq__`/`__hash__` build on the truncated value: two births
+    # in the same minute are the same Bazi.
+    dt: datetime = datetime(2000, 2, 4, 22, 1)
+    bazi: Bazi = Bazi.create(dt, BaziGender.MALE, BaziPrecision.DAY)
+    sub_minute: Bazi = Bazi.create(dt.replace(second=37, microsecond=999999),
+                                   BaziGender.MALE, BaziPrecision.DAY)
+    self.assertEqual(sub_minute.solar_datetime, dt)
+    self.assertEqual(sub_minute.hour, 22)
+    self.assertEqual(sub_minute.minute, 1)
+    self.assertEqual(bazi, sub_minute)
+    self.assertEqual(hash(bazi), hash(sub_minute))

--- a/tests/test_bazi.py
+++ b/tests/test_bazi.py
@@ -642,9 +642,8 @@ class TestBazi(unittest.TestCase):
     self.assertEqual(len({bazi, same, other}), 2)
 
   def test_sub_minute_truncation(self) -> None:
-    # `solar_datetime` deliberately truncates to the minute (MINUTE is the finest
-    # `BaziPrecision`), and `__eq__`/`__hash__` build on the truncated value: two births
-    # in the same minute are the same Bazi.
+    # Two births in the same minute are the same Bazi -- `Bazi.solar_datetime` is the
+    # SSOT on why sub-minute parts are dropped.
     dt: datetime = datetime(2000, 2, 4, 22, 1)
     bazi: Bazi = Bazi.create(dt, BaziGender.MALE, BaziPrecision.DAY)
     sub_minute: Bazi = Bazi.create(dt.replace(second=37, microsecond=999999),

--- a/tests/test_bazi.py
+++ b/tests/test_bazi.py
@@ -630,3 +630,13 @@ class TestBazi(unittest.TestCase):
       bazi_hacked: Bazi = Bazi.create(dt, gender, precision)
       bazi_hacked._precision = BaziPrecision.HOUR # type: ignore # Intended for testing only.
       self.assertNotEqual(bazi, bazi_hacked)
+
+  def test_hash(self) -> None:
+    dt: datetime = datetime(2000, 2, 4, 22, 1)
+    bazi: Bazi = Bazi.create(dt, BaziGender.MALE, BaziPrecision.DAY)
+    same: Bazi = Bazi.create(dt, BaziGender.MALE, BaziPrecision.DAY)
+    self.assertEqual(hash(bazi), hash(same))
+    self.assertEqual(len({bazi, same}), 1) # In sync with `__eq__`: usable for set dedup.
+
+    other: Bazi = Bazi.create(dt, BaziGender.FEMALE, BaziPrecision.DAY)
+    self.assertEqual(len({bazi, same, other}), 2)

--- a/tests/test_bazi_chart.py
+++ b/tests/test_bazi_chart.py
@@ -507,7 +507,7 @@ class TestBaziChart(unittest.TestCase):
     self.assertEqual(j['tiangan_shishen'], {
       'year': '偏印',
       'month': '劫财',
-      'day': 'None',
+      'day': None, # The day master itself has no Shishen -- a real JSON null, not 'None'.
       'hour': '偏财',
     })
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -47,7 +47,8 @@ class TestCommon(unittest.TestCase):
     with self.assertRaises(TypeError):
       hash(frozendict({1: [2, 3]}))
 
-    # The chain #63.4 cares about: `BaziData[HiddenTianganDict]` is hashable.
+    # `BaziData[HiddenTianganDict]` must stay hashable -- the hidden-tiangan chain
+    # is frozendict all the way down.
     htd: HiddenTianganDict = HiddenTianganDict({Tiangan.甲: 60, Tiangan.丙: 30, Tiangan.戊: 10})
     bd: BaziData[HiddenTianganDict] = BaziData(htd, htd, htd, htd)
     self.assertEqual(hash(bd), hash(BaziData(htd, htd, htd, htd)))

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -5,9 +5,9 @@ import unittest
 
 
 
-from src.defines import Shishen
+from src.defines import Shishen, Tiangan
 from src.common import frozendict
-from src.data_types import GanzhiData, BaziData
+from src.data_types import GanzhiData, BaziData, HiddenTianganDict
 
 
 
@@ -33,6 +33,25 @@ class TestCommon(unittest.TestCase):
     # ...but the frozendict is shallow-frozen: values are returned as-is, not copied.
     self.assertIs(fd2[1], fd2[1])
     self.assertIs(fd2[1], src_dict[1])
+
+  def test_frozendict_hash(self) -> None:
+    # Tuple semantics: equal contents hash equal, regardless of insertion order.
+    fd1: frozendict[int, int] = frozendict({1: 2, 3: 4})
+    fd2: frozendict[int, int] = frozendict({3: 4, 1: 2})
+    self.assertEqual(fd1, fd2)
+    self.assertEqual(hash(fd1), hash(fd2))
+    self.assertEqual(len({fd1, fd2}), 1)
+    self.assertEqual(len({fd1, frozendict({1: 2})}), 2)
+
+    # Unhashable contents surface as TypeError on the first hash attempt.
+    with self.assertRaises(TypeError):
+      hash(frozendict({1: [2, 3]}))
+
+    # The chain #63.4 cares about: `BaziData[HiddenTianganDict]` is hashable.
+    htd: HiddenTianganDict = HiddenTianganDict({Tiangan.甲: 60, Tiangan.丙: 30, Tiangan.戊: 10})
+    bd: BaziData[HiddenTianganDict] = BaziData(htd, htd, htd, htd)
+    self.assertEqual(hash(bd), hash(BaziData(htd, htd, htd, htd)))
+    self.assertIn(bd, {bd})
 
   def test_pillardata(self) -> None:
     combo1: GanzhiData[str, int] = GanzhiData('a', 1)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -20,15 +20,19 @@ class TestCommon(unittest.TestCase):
     with self.assertRaises(TypeError):
       fd[1] = 100 # type: ignore
 
-    fd2: frozendict[int, list[int]] = frozendict({1: [2, 3]})
-    self.assertEqual(fd2[1], [2, 3])
+    # The mapping itself is detached from the source dict...
+    src_dict: dict[int, list[int]] = {1: [2, 3]}
+    fd2: frozendict[int, list[int]] = frozendict(src_dict)
+    src_dict[9] = [9]
+    self.assertNotIn(9, fd2)
     with self.assertRaises(TypeError):
       fd2[1] = [4, 5] # type: ignore
     with self.assertRaises(KeyError):
       fd2[2]
-    
-    fd2[1].append(6)
-    self.assertEqual(fd2[1], [2, 3])
+
+    # ...but the frozendict is shallow-frozen: values are returned as-is, not copied.
+    self.assertIs(fd2[1], fd2[1])
+    self.assertIs(fd2[1], src_dict[1])
 
   def test_pillardata(self) -> None:
     combo1: GanzhiData[str, int] = GanzhiData('a', 1)


### PR DESCRIPTION
D3 PR C「行为卫生」(A+D 收官批终件;计划 = vault D3 brief v2 的 D3-5+D3-6,用户批准合并为单 PR)。七个实质提交 + 三个审阅修复提交,每步门禁独立全绿(coverage 100%)。

## 裁决准绳(本 PR 的深拷/共享总纲)

`Bazi` 是唯一非 frozen 的领域对象(全 `Final` 字段、无 mutator,但私有状态可被改写);`BaziChart` 在构造与 `bazi` 属性两处深拷,是它的隔离边界(`test_malicious` 钉死);**边界以上一律共享**。语料表浅冻结,防污染下沉到 `Interpreter.interpret_*` 边界深拷。各处代码注释只留局部结论,总纲以此处与提交信息为准。

## 提交序列

1. **c1 (#71.3)** frozendict 去深拷(浅冻结);语料防污染搬到 interpret_* 边界;bazi_utils 三处双重深拷陪葬。
2. **c2 (#45)** 深拷对账:拆 14 处,幸存 4 处写明理由。
3. **c3 (#71.6)** cached_property:BaziChart 派生量 + 关系分析器两入口;`bazi`/`_utils`/双生成器/`json` 排除各有案。
4. **c4 (#71.7)** DayunDatabase 闭式直算,生成器+增量缓存退役。
5. **c5 (#63.3/.4)** frozendict/Bazi `__hash__`;json 十神日主位 `'None'`→真 null。
6. **c6 (#71.8/.9/.10/.11)** wuxing 生克查表;find_shensha 直白化;`Bazi._hour/_minute` 删除(秒截断显式化+亚分钟定向测试);dizhi search 查表化。
7. **c7 (#88)** 枚举基类收敛(BaziEnum/IndexedBaziEnum)+ Discovery 泛型基类(重数分歧双侧互注)。
8. **c8** 补交 c7 遗漏的新文件(工艺教训:代签脚本跳过未跟踪文件,对拍改以 porcelain 全空为准)。
9. **c9** R1 修复:search 查表恢复定义序(kimi 抓的顺序退化,唯一真行为发现)+ BaziChart 对 `_bazi` 重绑的契约声明。
10. **c10** R1 六路风格修复批(跨家收敛项全落;驳回项在提交信息记理由)。

## 审阅

- **R1 全阵容六路**(用户升档):正确性 = kimi 清单家(GO-WITH-CHANGES,P2×2 全修)+ grok 清单家(GO)+ fable 盲审(GO,重建旧实现对拍零推翻);风格 = kimi/opus/grok(三家 GO-WITH-CHANGES,跨家收敛项全采,冲突按论证强度裁决:opus 落位案胜 grok、kimi 保留反例判读胜 opus 的 TypeVar 案〔mypy 探针证伪〕)。
- **R2 原发现家复验**:kimi + opus 对修复批复核(进行中);CI + claude review 随推送重跑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
