### PR TITLE
test: #90 pytest 化——31 测试文件 TestCase→纯函数(PR-A)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,7 +126,8 @@ Bilingual is mandatory in knowledge-dense layers (`rules` / `defines` / `utils` 
 
 ## Tests
 - Mirror src layout (`src/utils/tiangan_utils.py` → `tests/utils/test_tiangan_utils.py`).
-- `unittest.TestCase` subclasses, `self.assertEqual/assertTrue`; pytest runs them.
+- Plain pytest style: module-level `test_*` functions, bare `assert`, `pytest.raises`;
+  `pytest.mark.parametrize` for literal case tables, plain loops for derived ones.
 - Data-driven: inline expected combos as literal sets. Integration → `tests/integration/`.
 
 ## AI do / don't

--- a/tests/analyzer/test_relationship_analyzer.py
+++ b/tests/analyzer/test_relationship_analyzer.py
@@ -33,7 +33,7 @@ def test_at_birth_shensha() -> None:
       if shensha_utils.taohua(dz1, dz2):
         expected_taohua.append(dz2)
     assert at_birth.shensha['taohua'] == set(expected_taohua)
-    assert at_birth.shensha['taohua'] == at_birth.shensha['taohua'], 'Constancy'
+    assert at_birth.shensha['taohua'] == at_birth.shensha['taohua'] # Repeated lookup must answer the same.
 
     # Hongyan / 红艳
     expected_hongyan: list[Dizhi] = []
@@ -41,7 +41,7 @@ def test_at_birth_shensha() -> None:
       if shensha_utils.hongyan(tg, dz):
         expected_hongyan.append(dz)
     assert at_birth.shensha['hongyan'] == set(expected_hongyan)
-    assert at_birth.shensha['hongyan'] == at_birth.shensha['hongyan'], 'Constancy'
+    assert at_birth.shensha['hongyan'] == at_birth.shensha['hongyan'] # Repeated lookup must answer the same.
 
     # Hongluan / 红鸾
     expected_hongluan: list[Dizhi] = []
@@ -49,7 +49,7 @@ def test_at_birth_shensha() -> None:
       if shensha_utils.hongluan(dz1, dz2):
         expected_hongluan.append(dz2)
     assert at_birth.shensha['hongluan'] == set(expected_hongluan)
-    assert at_birth.shensha['hongluan'] == at_birth.shensha['hongluan'], 'Constancy'
+    assert at_birth.shensha['hongluan'] == at_birth.shensha['hongluan'] # Repeated lookup must answer the same.
 
     # Tianxi / 天喜
     expected_tianxi: list[Dizhi] = []
@@ -57,7 +57,7 @@ def test_at_birth_shensha() -> None:
       if shensha_utils.tianxi(dz1, dz2):
         expected_tianxi.append(dz2)
     assert at_birth.shensha['tianxi'] == set(expected_tianxi)
-    assert at_birth.shensha['tianxi'] == at_birth.shensha['tianxi'], 'Constancy'
+    assert at_birth.shensha['tianxi'] == at_birth.shensha['tianxi'] # Repeated lookup must answer the same.
 
     # Yima / 驿马
     expected_yima: list[Dizhi] = []
@@ -68,7 +68,8 @@ def test_at_birth_shensha() -> None:
       if shensha_utils.yima(dz1, dz2):
         expected_yima.append(dz2)
     assert at_birth.shensha['yima'] == set(expected_yima)
-    assert at_birth.shensha['yima'] == at_birth.shensha['yima'], 'Constancy'
+    assert at_birth.shensha['yima'] == at_birth.shensha['yima'] # Repeated lookup must answer the same.
+
 
 @pytest.mark.slow
 def test_at_birth_day_master_relations() -> None:
@@ -84,7 +85,8 @@ def test_at_birth_day_master_relations() -> None:
       chart.bazi.month_pillar.tiangan,
       chart.bazi.hour_pillar.tiangan
     ], [dm])
-    assert at_birth.day_master_relations == at_birth.day_master_relations, 'Constancy'
+    assert at_birth.day_master_relations == at_birth.day_master_relations # Repeated lookup must answer the same.
+
 
 @pytest.mark.slow
 def test_at_birth_house_relations() -> None:
@@ -101,7 +103,8 @@ def test_at_birth_house_relations() -> None:
     )
     assert at_birth.house_relations == dizhi_utils.discover_mutual([y, m, h], [d])
 
-    assert at_birth.house_relations == at_birth.house_relations, 'Constancy'
+    assert at_birth.house_relations == at_birth.house_relations # Repeated lookup must answer the same.
+
 
 @pytest.mark.slow
 def test_at_birth_star_relations() -> None:
@@ -119,8 +122,9 @@ def test_at_birth_star_relations() -> None:
       for dz_combo in dz_combos:
         assert any(dz in dz_combo for dz in stars.dizhi)
 
-    assert at_birth.star_relations.tiangan == at_birth.star_relations.tiangan, 'Constancy'
-    assert at_birth.star_relations.dizhi == at_birth.star_relations.dizhi, 'Constancy'
+    assert at_birth.star_relations.tiangan == at_birth.star_relations.tiangan # Repeated lookup must answer the same.
+    assert at_birth.star_relations.dizhi == at_birth.star_relations.dizhi # Repeated lookup must answer the same.
+
 
 @pytest.mark.slow
 def test_filtered() -> None:
@@ -147,15 +151,17 @@ def test_filtered() -> None:
           assert any(dz in dz_combo for dz in stars.dizhi) == (dz_combo in at_birth.star_relations.dizhi[dz_rel])
 
 
-def _equal(discovery1, discovery2) -> bool:
+DiscoveryType = tiangan_utils.TianganRelationDiscovery | dizhi_utils.DizhiRelationDiscovery
+def _equal(discovery1: DiscoveryType, discovery2: DiscoveryType) -> bool:
   if type(discovery1) is not type(discovery2):
     return False
   if set(discovery1.keys()) != set(discovery2.keys()):
     return False
   for key in discovery1:
-    if set(discovery1[key]) != set(discovery2[key]):
+    if set(discovery1[key]) != set(discovery2[key]):  # type: ignore
       return False
   return True
+
 
 @pytest.mark.slow
 def test_transit_shensha() -> None:
@@ -218,6 +224,7 @@ def test_transit_shensha() -> None:
           expected.append(dz)
       assert actual['yima'] == set(expected)
 
+
 @pytest.mark.slow
 def test_transit_day_master_relations() -> None:
   for _ in range(32):
@@ -237,6 +244,7 @@ def test_transit_day_master_relations() -> None:
       actual = transits_analysis.day_master_relations(randon_year, random_options)
 
       assert _equal(expected, actual)
+
 
 @pytest.mark.slow
 def test_transit_house_relations() -> None:
@@ -277,6 +285,7 @@ def test_transit_house_relations() -> None:
       expected = dizhi_utils.discover_mutual(bazi.four_dizhis, transit_dz).filter(__expected_filter)
 
       assert _equal(expected, actual)
+
 
 @pytest.mark.slow
 def test_transit_star_relations() -> None:
@@ -343,6 +352,7 @@ def test_transit_star_relations() -> None:
         lambda _, combo : len(combo & set(stars.dizhi)) > 0
       ))
 
+
 @pytest.mark.slow
 def test_zhengyin() -> None:
   for _ in range(32):
@@ -368,6 +378,7 @@ def test_zhengyin() -> None:
       actual = transits_analysis.zhengyin(randon_year, random_options)
       assert expected_tg == actual.tiangan
       assert expected_dz == actual.dizhi
+
 
 @pytest.mark.slow
 def test_star() -> None:

--- a/tests/analyzer/test_relationship_analyzer.py
+++ b/tests/analyzer/test_relationship_analyzer.py
@@ -151,8 +151,8 @@ def test_filtered() -> None:
           assert any(dz in dz_combo for dz in stars.dizhi) == (dz_combo in at_birth.star_relations.dizhi[dz_rel])
 
 
-DiscoveryType = tiangan_utils.TianganRelationDiscovery | dizhi_utils.DizhiRelationDiscovery
 '''Operand type of `_equal`: either relation-discovery flavor.'''
+DiscoveryType = tiangan_utils.TianganRelationDiscovery | dizhi_utils.DizhiRelationDiscovery
 def _equal(discovery1: DiscoveryType, discovery2: DiscoveryType) -> bool:
   if type(discovery1) is not type(discovery2):
     return False

--- a/tests/analyzer/test_relationship_analyzer.py
+++ b/tests/analyzer/test_relationship_analyzer.py
@@ -152,6 +152,7 @@ def test_filtered() -> None:
 
 
 DiscoveryType = tiangan_utils.TianganRelationDiscovery | dizhi_utils.DizhiRelationDiscovery
+'''Operand type of `_equal`: either relation-discovery flavor.'''
 def _equal(discovery1: DiscoveryType, discovery2: DiscoveryType) -> bool:
   if type(discovery1) is not type(discovery2):
     return False

--- a/tests/analyzer/test_relationship_analyzer.py
+++ b/tests/analyzer/test_relationship_analyzer.py
@@ -2,7 +2,6 @@
 # test_relationship_analyzer.py
 
 import pytest
-import unittest
 
 import random
 import itertools
@@ -14,396 +13,389 @@ from src.transits import TransitMoment, TransitOptions, TransitDatabase
 from src.analyzer.relationship import RelationshipAnalyzer, TransitAnalysis, ShenshaAnalysis, _REGISTRY
 
 
-class TestAtBirthAnalysis(unittest.TestCase):
-  @pytest.mark.slow
-  def test_shensha(self) -> None:
-    for _ in range(100):
-      chart = BaziChart.random()
-      analyzer = RelationshipAnalyzer(chart)
+@pytest.mark.slow
+def test_at_birth_shensha() -> None:
+  for _ in range(100):
+    chart = BaziChart.random()
+    analyzer = RelationshipAnalyzer(chart)
 
-      dm: Tiangan = chart.bazi.day_master
-      y, m, d, h = chart.bazi.four_dizhis
+    dm: Tiangan = chart.bazi.day_master
+    y, m, d, h = chart.bazi.four_dizhis
 
-      at_birth = analyzer.at_birth
+    at_birth = analyzer.at_birth
 
-      with self.subTest('Taohua / 桃花'):
-        expected_taohua: list[Dizhi] = []
-        for dz1, dz2 in itertools.product([y], [m, d, h]):
-          if shensha_utils.taohua(dz1, dz2):
-            expected_taohua.append(dz2)
-        for dz1, dz2 in itertools.product([d], [y, m, h]):
-          if shensha_utils.taohua(dz1, dz2):
-            expected_taohua.append(dz2)
-        self.assertSetEqual(at_birth.shensha['taohua'], set(expected_taohua))
-        self.assertSetEqual(at_birth.shensha['taohua'], at_birth.shensha['taohua'], 'Constancy')
+    # Taohua / 桃花
+    expected_taohua: list[Dizhi] = []
+    for dz1, dz2 in itertools.product([y], [m, d, h]):
+      if shensha_utils.taohua(dz1, dz2):
+        expected_taohua.append(dz2)
+    for dz1, dz2 in itertools.product([d], [y, m, h]):
+      if shensha_utils.taohua(dz1, dz2):
+        expected_taohua.append(dz2)
+    assert at_birth.shensha['taohua'] == set(expected_taohua)
+    assert at_birth.shensha['taohua'] == at_birth.shensha['taohua'], 'Constancy'
 
-      with self.subTest('Hongyan / 红艳'):
-        expected_hongyan: list[Dizhi] = []
-        for tg, dz in itertools.product([dm], [y, m, d, h]):
-          if shensha_utils.hongyan(tg, dz):
-            expected_hongyan.append(dz)
-        self.assertSetEqual(at_birth.shensha['hongyan'], set(expected_hongyan))
-        self.assertSetEqual(at_birth.shensha['hongyan'], at_birth.shensha['hongyan'], 'Constancy')
+    # Hongyan / 红艳
+    expected_hongyan: list[Dizhi] = []
+    for tg, dz in itertools.product([dm], [y, m, d, h]):
+      if shensha_utils.hongyan(tg, dz):
+        expected_hongyan.append(dz)
+    assert at_birth.shensha['hongyan'] == set(expected_hongyan)
+    assert at_birth.shensha['hongyan'] == at_birth.shensha['hongyan'], 'Constancy'
 
-      with self.subTest('Hongluan / 红鸾'):
-        expected_hongluan: list[Dizhi] = []
-        for dz1, dz2 in itertools.product([y], [m, d, h]):
-          if shensha_utils.hongluan(dz1, dz2):
-            expected_hongluan.append(dz2)
-        self.assertSetEqual(at_birth.shensha['hongluan'], set(expected_hongluan))
-        self.assertSetEqual(at_birth.shensha['hongluan'], at_birth.shensha['hongluan'], 'Constancy')
+    # Hongluan / 红鸾
+    expected_hongluan: list[Dizhi] = []
+    for dz1, dz2 in itertools.product([y], [m, d, h]):
+      if shensha_utils.hongluan(dz1, dz2):
+        expected_hongluan.append(dz2)
+    assert at_birth.shensha['hongluan'] == set(expected_hongluan)
+    assert at_birth.shensha['hongluan'] == at_birth.shensha['hongluan'], 'Constancy'
 
-      with self.subTest('Tianxi / 天喜'):
-        expected_tianxi: list[Dizhi] = []
-        for dz1, dz2 in itertools.product([y], [m, d, h]):
-          if shensha_utils.tianxi(dz1, dz2):
-            expected_tianxi.append(dz2)
-        self.assertSetEqual(at_birth.shensha['tianxi'], set(expected_tianxi))
-        self.assertSetEqual(at_birth.shensha['tianxi'], at_birth.shensha['tianxi'], 'Constancy')
+    # Tianxi / 天喜
+    expected_tianxi: list[Dizhi] = []
+    for dz1, dz2 in itertools.product([y], [m, d, h]):
+      if shensha_utils.tianxi(dz1, dz2):
+        expected_tianxi.append(dz2)
+    assert at_birth.shensha['tianxi'] == set(expected_tianxi)
+    assert at_birth.shensha['tianxi'] == at_birth.shensha['tianxi'], 'Constancy'
 
-      with self.subTest('Yima / 驿马'):
-        expected_yima: list[Dizhi] = []
-        for dz1, dz2 in itertools.product([y], [m, d, h]):
-          if shensha_utils.yima(dz1, dz2):
-            expected_yima.append(dz2)
-        for dz1, dz2 in itertools.product([d], [y, m, h]):
-          if shensha_utils.yima(dz1, dz2):
-            expected_yima.append(dz2)
-        self.assertSetEqual(at_birth.shensha['yima'], set(expected_yima))
-        self.assertSetEqual(at_birth.shensha['yima'], at_birth.shensha['yima'], 'Constancy')
+    # Yima / 驿马
+    expected_yima: list[Dizhi] = []
+    for dz1, dz2 in itertools.product([y], [m, d, h]):
+      if shensha_utils.yima(dz1, dz2):
+        expected_yima.append(dz2)
+    for dz1, dz2 in itertools.product([d], [y, m, h]):
+      if shensha_utils.yima(dz1, dz2):
+        expected_yima.append(dz2)
+    assert at_birth.shensha['yima'] == set(expected_yima)
+    assert at_birth.shensha['yima'] == at_birth.shensha['yima'], 'Constancy'
 
-  @pytest.mark.slow
-  def test_day_master_relations(self) -> None:
-    for _ in range(100):
-      chart = BaziChart.random()
-      analyzer = RelationshipAnalyzer(chart)
+@pytest.mark.slow
+def test_at_birth_day_master_relations() -> None:
+  for _ in range(100):
+    chart = BaziChart.random()
+    analyzer = RelationshipAnalyzer(chart)
 
-      dm = chart.bazi.day_master
-      at_birth = analyzer.at_birth
+    dm = chart.bazi.day_master
+    at_birth = analyzer.at_birth
 
-      self.assertEqual(at_birth.day_master_relations, tiangan_utils.discover_mutual([
-        chart.bazi.year_pillar.tiangan, 
-        chart.bazi.month_pillar.tiangan,
-        chart.bazi.hour_pillar.tiangan
-      ], [dm]))
-      self.assertEqual(at_birth.day_master_relations, at_birth.day_master_relations, 'Constancy')
+    assert at_birth.day_master_relations == tiangan_utils.discover_mutual([
+      chart.bazi.year_pillar.tiangan,
+      chart.bazi.month_pillar.tiangan,
+      chart.bazi.hour_pillar.tiangan
+    ], [dm])
+    assert at_birth.day_master_relations == at_birth.day_master_relations, 'Constancy'
 
-  @pytest.mark.slow
-  def test_house_relations(self) -> None:
-    for _ in range(100):
-      chart = BaziChart.random()
-      analyzer = RelationshipAnalyzer(chart)
+@pytest.mark.slow
+def test_at_birth_house_relations() -> None:
+  for _ in range(100):
+    chart = BaziChart.random()
+    analyzer = RelationshipAnalyzer(chart)
 
-      y, m, d, h = chart.bazi.four_dizhis
-      at_birth = analyzer.at_birth
+    y, m, d, h = chart.bazi.four_dizhis
+    at_birth = analyzer.at_birth
 
-      # For AtBirth analysis, the following two algorithms are equivalent.
-      self.assertEqual(at_birth.house_relations, dizhi_utils.discover([y, m, d, h]).filter(
-        lambda _, combo : d in combo
-      )) 
-      self.assertEqual(at_birth.house_relations, dizhi_utils.discover_mutual([y, m, h], [d]))
+    # For AtBirth analysis, the following two algorithms are equivalent.
+    assert at_birth.house_relations == dizhi_utils.discover([y, m, d, h]).filter(
+      lambda _, combo : d in combo
+    )
+    assert at_birth.house_relations == dizhi_utils.discover_mutual([y, m, h], [d])
 
-      self.assertEqual(at_birth.house_relations, at_birth.house_relations, 'Constancy')
+    assert at_birth.house_relations == at_birth.house_relations, 'Constancy'
 
-  @pytest.mark.slow
-  def test_star_relations(self) -> None:
-    for _ in range(100):
-      chart = BaziChart.random()
-      analyzer = RelationshipAnalyzer(chart)
+@pytest.mark.slow
+def test_at_birth_star_relations() -> None:
+  for _ in range(100):
+    chart = BaziChart.random()
+    analyzer = RelationshipAnalyzer(chart)
 
-      at_birth = analyzer.at_birth
-      stars = chart.relationship_stars
-      
-      for tg_combos in at_birth.star_relations.tiangan.values():
+    at_birth = analyzer.at_birth
+    stars = chart.relationship_stars
+
+    for tg_combos in at_birth.star_relations.tiangan.values():
+      for tg_combo in tg_combos:
+        assert stars.tiangan in tg_combo
+    for dz_combos in at_birth.star_relations.dizhi.values():
+      for dz_combo in dz_combos:
+        assert any(dz in dz_combo for dz in stars.dizhi)
+
+    assert at_birth.star_relations.tiangan == at_birth.star_relations.tiangan, 'Constancy'
+    assert at_birth.star_relations.dizhi == at_birth.star_relations.dizhi, 'Constancy'
+
+@pytest.mark.slow
+def test_filtered() -> None:
+  '''Test "star_relations" only contain filtered combos.'''
+  for _ in range(16):
+    chart: BaziChart = BaziChart.random()
+    analyzer: RelationshipAnalyzer = RelationshipAnalyzer(chart)
+
+    stars = chart.relationship_stars
+    at_birth = analyzer.at_birth
+
+    for tg_rel, tg_combos in tiangan_utils.discover(chart.bazi.four_tiangans).items():
+      if tg_rel not in at_birth.star_relations.tiangan:
+        assert all(stars.tiangan not in tg_combo for tg_combo in tg_combos)
+      else:
         for tg_combo in tg_combos:
-          self.assertIn(stars.tiangan, tg_combo)
-      for dz_combos in at_birth.star_relations.dizhi.values():
+          assert (stars.tiangan in tg_combo) == (tg_combo in at_birth.star_relations.tiangan[tg_rel])
+
+    for dz_rel, dz_combos in dizhi_utils.discover(chart.bazi.four_dizhis).items():
+      if dz_rel not in at_birth.star_relations.dizhi:
+        assert all(dz not in dz_combo for dz_combo in dz_combos for dz in stars.dizhi)
+      else:
         for dz_combo in dz_combos:
-          self.assertTrue(any(dz in dz_combo for dz in stars.dizhi))
-
-      self.assertEqual(at_birth.star_relations.tiangan, at_birth.star_relations.tiangan, 'Constancy')
-      self.assertEqual(at_birth.star_relations.dizhi, at_birth.star_relations.dizhi, 'Constancy')
-
-  @pytest.mark.slow
-  def test_filtered(self) -> None:
-    '''Test "star_relations" only contain filtered combos.'''
-    for _ in range(16):
-      chart: BaziChart = BaziChart.random()
-      analyzer: RelationshipAnalyzer = RelationshipAnalyzer(chart)
-
-      stars = chart.relationship_stars
-      at_birth = analyzer.at_birth
-
-      for tg_rel, tg_combos in tiangan_utils.discover(chart.bazi.four_tiangans).items():
-        if tg_rel not in at_birth.star_relations.tiangan:
-          self.assertTrue(all(stars.tiangan not in tg_combo for tg_combo in tg_combos))
-        else:
-          for tg_combo in tg_combos:
-            self.assertEqual(stars.tiangan in tg_combo,
-                             tg_combo in at_birth.star_relations.tiangan[tg_rel])
-            
-      for dz_rel, dz_combos in dizhi_utils.discover(chart.bazi.four_dizhis).items():
-        if dz_rel not in at_birth.star_relations.dizhi:
-          self.assertTrue(all(dz not in dz_combo for dz_combo in dz_combos for dz in stars.dizhi))
-        else:
-          for dz_combo in dz_combos:
-            self.assertEqual(any(dz in dz_combo for dz in stars.dizhi),
-                             dz_combo in at_birth.star_relations.dizhi[dz_rel])
+          assert any(dz in dz_combo for dz in stars.dizhi) == (dz_combo in at_birth.star_relations.dizhi[dz_rel])
 
 
-class TestTransitAnalysis(unittest.TestCase):
-  @staticmethod
-  def __equal(discovery1, discovery2) -> bool:
-    if type(discovery1) is not type(discovery2):
+def _equal(discovery1, discovery2) -> bool:
+  if type(discovery1) is not type(discovery2):
+    return False
+  if set(discovery1.keys()) != set(discovery2.keys()):
+    return False
+  for key in discovery1:
+    if set(discovery1[key]) != set(discovery2[key]):
       return False
-    if set(discovery1.keys()) != set(discovery2.keys()):
-      return False
-    for key in discovery1:
-      if set(discovery1[key]) != set(discovery2[key]):
-        return False
-    return True
+  return True
 
-  @pytest.mark.slow
-  def test_shensha(self) -> None:
-    for _ in range(32):
-      chart = BaziChart.random()      
-      db = TransitDatabase(chart)
+@pytest.mark.slow
+def test_transit_shensha() -> None:
+  for _ in range(32):
+    chart = BaziChart.random()
+    db = TransitDatabase(chart)
 
-      dm = chart.bazi.day_master
-      y_dz = chart.bazi.year_pillar.dizhi
-      d_dz = chart.bazi.day_pillar.dizhi
+    dm = chart.bazi.day_master
+    y_dz = chart.bazi.year_pillar.dizhi
+    d_dz = chart.bazi.day_pillar.dizhi
 
-      analyzer = RelationshipAnalyzer(chart)
-      transits_analysis = analyzer.transits
+    analyzer = RelationshipAnalyzer(chart)
+    transits_analysis = analyzer.transits
 
-      for __ in range(128):
-        randon_year = chart.bazi.ganzhi_date.year + random.randint(0, 100)
-        random_options = TransitOptions.random()
-        if not transits_analysis.support(randon_year, random_options):
-          continue
+    for __ in range(128):
+      randon_year = chart.bazi.ganzhi_date.year + random.randint(0, 100)
+      random_options = TransitOptions.random()
+      if not transits_analysis.support(randon_year, random_options):
+        continue
 
-        transit_dz = tuple(gz.dizhi for gz in db.ganzhis(TransitMoment(randon_year), random_options))
-        actual = transits_analysis.shensha(randon_year, random_options)
+      transit_dz = tuple(gz.dizhi for gz in db.ganzhis(TransitMoment(randon_year), random_options))
+      actual = transits_analysis.shensha(randon_year, random_options)
 
-        with self.subTest('Taohua / 桃花'):
-          expected = []
-          for dz in transit_dz:
-            if shensha_utils.taohua(y_dz, dz):
-              expected.append(dz)
-            if shensha_utils.taohua(d_dz, dz):
-              expected.append(dz)
-          self.assertSetEqual(actual['taohua'], set(expected))
+      # Taohua / 桃花
+      expected = []
+      for dz in transit_dz:
+        if shensha_utils.taohua(y_dz, dz):
+          expected.append(dz)
+        if shensha_utils.taohua(d_dz, dz):
+          expected.append(dz)
+      assert actual['taohua'] == set(expected)
 
-        with self.subTest('Hongyan / 红艳'):
-          expected = []
-          for dz in transit_dz:
-            if shensha_utils.hongyan(dm, dz):
-              expected.append(dz)
-          self.assertSetEqual(actual['hongyan'], set(expected))
+      # Hongyan / 红艳
+      expected = []
+      for dz in transit_dz:
+        if shensha_utils.hongyan(dm, dz):
+          expected.append(dz)
+      assert actual['hongyan'] == set(expected)
 
-        with self.subTest('Hongluan / 红鸾'):
-          expected = []
-          for dz in transit_dz:
-            if shensha_utils.hongluan(y_dz, dz):
-              expected.append(dz)
-          self.assertSetEqual(actual['hongluan'], set(expected))
+      # Hongluan / 红鸾
+      expected = []
+      for dz in transit_dz:
+        if shensha_utils.hongluan(y_dz, dz):
+          expected.append(dz)
+      assert actual['hongluan'] == set(expected)
 
-        with self.subTest('Tianxi / 天喜'):
-          expected = []
-          for dz in transit_dz:
-            if shensha_utils.tianxi(y_dz, dz):
-              expected.append(dz)
-          self.assertSetEqual(actual['tianxi'], set(expected))
+      # Tianxi / 天喜
+      expected = []
+      for dz in transit_dz:
+        if shensha_utils.tianxi(y_dz, dz):
+          expected.append(dz)
+      assert actual['tianxi'] == set(expected)
 
-        with self.subTest('Yima / 驿马'):
-          expected = []
-          for dz in transit_dz:
-            if shensha_utils.yima(y_dz, dz):
-              expected.append(dz)
-            if shensha_utils.yima(d_dz, dz):
-              expected.append(dz)
-          self.assertSetEqual(actual['yima'], set(expected))
+      # Yima / 驿马
+      expected = []
+      for dz in transit_dz:
+        if shensha_utils.yima(y_dz, dz):
+          expected.append(dz)
+        if shensha_utils.yima(d_dz, dz):
+          expected.append(dz)
+      assert actual['yima'] == set(expected)
 
-  @pytest.mark.slow
-  def test_day_master_relations(self) -> None:
-    for _ in range(32):
-      chart = BaziChart.random()
-      db = TransitDatabase(chart)
-      analyzer = RelationshipAnalyzer(chart)
-      transits_analysis = analyzer.transits
+@pytest.mark.slow
+def test_transit_day_master_relations() -> None:
+  for _ in range(32):
+    chart = BaziChart.random()
+    db = TransitDatabase(chart)
+    analyzer = RelationshipAnalyzer(chart)
+    transits_analysis = analyzer.transits
 
-      for __ in range(128):
-        randon_year = chart.bazi.ganzhi_date.year + random.randint(0, 100)
-        random_options = TransitOptions.random()
-        if not transits_analysis.support(randon_year, random_options):
-          continue
-        
-        transit_tg = tuple(gz.tiangan for gz in db.ganzhis(TransitMoment(randon_year), random_options))
-        expected = tiangan_utils.discover_mutual([chart.bazi.day_master], transit_tg)
-        actual = transits_analysis.day_master_relations(randon_year, random_options)
+    for __ in range(128):
+      randon_year = chart.bazi.ganzhi_date.year + random.randint(0, 100)
+      random_options = TransitOptions.random()
+      if not transits_analysis.support(randon_year, random_options):
+        continue
 
-        self.assertTrue(TestTransitAnalysis.__equal(expected, actual))
+      transit_tg = tuple(gz.tiangan for gz in db.ganzhis(TransitMoment(randon_year), random_options))
+      expected = tiangan_utils.discover_mutual([chart.bazi.day_master], transit_tg)
+      actual = transits_analysis.day_master_relations(randon_year, random_options)
 
-  @pytest.mark.slow
-  def test_house_relations(self) -> None:
-    for _ in range(32):
-      chart = BaziChart.random()
-      house = chart.house_of_relationship
-      bazi = chart.bazi
-      db = TransitDatabase(chart)
-      analyzer = RelationshipAnalyzer(chart)
-      transits_analysis = analyzer.transits
+      assert _equal(expected, actual)
 
-      for __ in range(128):
-        randon_year = chart.bazi.ganzhi_date.year + random.randint(0, 100)
-        random_options = TransitOptions.random()
-        if not transits_analysis.support(randon_year, random_options):
-          continue
+@pytest.mark.slow
+def test_transit_house_relations() -> None:
+  for _ in range(32):
+    chart = BaziChart.random()
+    house = chart.house_of_relationship
+    bazi = chart.bazi
+    db = TransitDatabase(chart)
+    analyzer = RelationshipAnalyzer(chart)
+    transits_analysis = analyzer.transits
 
-        transit_dz = [gz.dizhi for gz in db.ganzhis(TransitMoment(randon_year), random_options)]
+    for __ in range(128):
+      randon_year = chart.bazi.ganzhi_date.year + random.randint(0, 100)
+      random_options = TransitOptions.random()
+      if not transits_analysis.support(randon_year, random_options):
+        continue
 
-        actual = transits_analysis.house_relations(randon_year, random_options)
-        for combos in actual.values():
-          for combo in combos:
-            self.assertTrue(house in combo)
-            self.assertFalse(set(transit_dz).isdisjoint(combo))
+      transit_dz = [gz.dizhi for gz in db.ganzhis(TransitMoment(randon_year), random_options)]
 
-        def __expected_filter(dz_rel: DizhiRelation, combo: dizhi_utils.DizhiCombo):
-          # `house` must appear in the combo.
-          if house not in combo:
-            return False
+      actual = transits_analysis.house_relations(randon_year, random_options)
+      for combos in actual.values():
+        for combo in combos:
+          assert house in combo
+          assert not set(transit_dz).isdisjoint(combo)
 
-          # Special handling for 自刑 cases.
-          if len(combo) == 1:
-            assert dz_rel is DizhiRelation.刑
-            return house in transit_dz
+      def __expected_filter(dz_rel: DizhiRelation, combo: dizhi_utils.DizhiCombo):
+        # `house` must appear in the combo.
+        if house not in combo:
+          return False
 
-          return not (combo - {house}).isdisjoint(transit_dz)
- 
-        expected = dizhi_utils.discover_mutual(bazi.four_dizhis, transit_dz).filter(__expected_filter)
-        
-        self.assertTrue(TestTransitAnalysis.__equal(expected, actual))
+        # Special handling for 自刑 cases.
+        if len(combo) == 1:
+          assert dz_rel is DizhiRelation.刑
+          return house in transit_dz
 
-  @pytest.mark.slow
-  def test_star_relations(self) -> None:
-    for _ in range(32):
-      chart = BaziChart.random()
-      stars = chart.relationship_stars
+        return not (combo - {house}).isdisjoint(transit_dz)
 
-      db = TransitDatabase(chart)
-      analyzer = RelationshipAnalyzer(chart)
-      transits_analysis = analyzer.transits
+      expected = dizhi_utils.discover_mutual(bazi.four_dizhis, transit_dz).filter(__expected_filter)
 
-      for __ in range(64):
-        randon_year = chart.bazi.ganzhi_date.year + random.randint(0, 100)
-        random_options = TransitOptions.random()
-        random_level = random.choice([
-          TransitAnalysis.Level.TRANSITS_ONLY, 
-          TransitAnalysis.Level.MUTUAL, 
-          TransitAnalysis.Level.ALL
-        ]) # mypy with Python 3.12 is problematic here on type checking... Explicitly list all enum values.
-        if not transits_analysis.support(randon_year, random_options):
-          continue
-        
-        transit_tg = tuple(gz.tiangan for gz in db.ganzhis(TransitMoment(randon_year), random_options))
-        transit_dz = tuple(gz.dizhi for gz in db.ganzhis(TransitMoment(randon_year), random_options))
+      assert _equal(expected, actual)
 
-        tg_discovery = tiangan_utils.TianganRelationDiscovery({})
-        dz_discovery = dizhi_utils.DizhiRelationDiscovery({})
-        if random_level in [TransitAnalysis.Level.TRANSITS_ONLY, TransitAnalysis.Level.ALL]:
-          tg_discovery = tg_discovery.merge(tiangan_utils.discover(transit_tg))
-          dz_discovery = dz_discovery.merge(dizhi_utils.discover(transit_dz))
-        if random_level in [TransitAnalysis.Level.MUTUAL, TransitAnalysis.Level.ALL]:
-          tg_discovery = tg_discovery.merge(tiangan_utils.discover_mutual(chart.bazi.four_tiangans, transit_tg))
-          dz_discovery = dz_discovery.merge(dizhi_utils.discover_mutual(chart.bazi.four_dizhis, transit_dz))
+@pytest.mark.slow
+def test_transit_star_relations() -> None:
+  for _ in range(32):
+    chart = BaziChart.random()
+    stars = chart.relationship_stars
 
-        actual = transits_analysis.star_relations(randon_year, random_options, level=random_level)
+    db = TransitDatabase(chart)
+    analyzer = RelationshipAnalyzer(chart)
+    transits_analysis = analyzer.transits
 
-        with self.subTest('Tiangan'):
-          for tg_rel, tg_combos in actual.tiangan.items():
-            self.assertIn(tg_rel, tg_discovery)
-            for tg_combo in tg_combos:
-              self.assertIn(tg_combo, tg_discovery[tg_rel])
-          
-          for tg_rel, tg_combos in tg_discovery.items():
-            for tg_combo in tg_combos:
-              if stars.tiangan in tg_combo:
-                self.assertIn(tg_combo, actual.tiangan[tg_rel])
+    for __ in range(64):
+      randon_year = chart.bazi.ganzhi_date.year + random.randint(0, 100)
+      random_options = TransitOptions.random()
+      random_level = random.choice([
+        TransitAnalysis.Level.TRANSITS_ONLY,
+        TransitAnalysis.Level.MUTUAL,
+        TransitAnalysis.Level.ALL
+      ]) # mypy with Python 3.12 is problematic here on type checking... Explicitly list all enum values.
+      if not transits_analysis.support(randon_year, random_options):
+        continue
 
-          self.assertTrue(TestTransitAnalysis.__equal(actual.tiangan, tg_discovery.filter(
-            lambda _, combo : stars.tiangan in combo
-          )))
+      transit_tg = tuple(gz.tiangan for gz in db.ganzhis(TransitMoment(randon_year), random_options))
+      transit_dz = tuple(gz.dizhi for gz in db.ganzhis(TransitMoment(randon_year), random_options))
 
-        with self.subTest('Dizhi'):
-          for dz_rel, dz_combos in actual.dizhi.items():
-            self.assertIn(dz_rel, dz_discovery)
-            for dz_combo in dz_combos:
-              self.assertIn(dz_combo, dz_discovery[dz_rel])
-          
-          for dz_rel, dz_combos in dz_discovery.items():
-            for dz_combo in dz_combos:
-              if len(dz_combo & set(stars.dizhi)) > 0:
-                self.assertIn(dz_combo, actual.dizhi[dz_rel])
+      tg_discovery = tiangan_utils.TianganRelationDiscovery({})
+      dz_discovery = dizhi_utils.DizhiRelationDiscovery({})
+      if random_level in [TransitAnalysis.Level.TRANSITS_ONLY, TransitAnalysis.Level.ALL]:
+        tg_discovery = tg_discovery.merge(tiangan_utils.discover(transit_tg))
+        dz_discovery = dz_discovery.merge(dizhi_utils.discover(transit_dz))
+      if random_level in [TransitAnalysis.Level.MUTUAL, TransitAnalysis.Level.ALL]:
+        tg_discovery = tg_discovery.merge(tiangan_utils.discover_mutual(chart.bazi.four_tiangans, transit_tg))
+        dz_discovery = dz_discovery.merge(dizhi_utils.discover_mutual(chart.bazi.four_dizhis, transit_dz))
 
-          self.assertTrue(TestTransitAnalysis.__equal(actual.dizhi, dz_discovery.filter(
-            lambda _, combo : len(combo & set(stars.dizhi)) > 0
-          )))
+      actual = transits_analysis.star_relations(randon_year, random_options, level=random_level)
 
-  @pytest.mark.slow
-  def test_zhengyin(self) -> None:
-    for _ in range(32):
-      chart = BaziChart.random()
-      db = TransitDatabase(chart)
-      analyzer = RelationshipAnalyzer(chart)
-      transits_analysis = analyzer.transits
+      # Tiangan
+      for tg_rel, tg_combos in actual.tiangan.items():
+        assert tg_rel in tg_discovery
+        for tg_combo in tg_combos:
+          assert tg_combo in tg_discovery[tg_rel]
 
-      for __ in range(128):
-        randon_year = chart.bazi.ganzhi_date.year + random.randint(0, 100)
-        random_options = TransitOptions.random()
-        if not transits_analysis.support(randon_year, random_options):
-          continue
+      for tg_rel, tg_combos in tg_discovery.items():
+        for tg_combo in tg_combos:
+          if stars.tiangan in tg_combo:
+            assert tg_combo in actual.tiangan[tg_rel]
 
-        expected_tg: bool = False
-        expected_dz: bool = False
-        for gz in db.ganzhis(TransitMoment(randon_year), random_options):
-          if bazi_utils.shishen(chart.bazi.day_master, gz.tiangan) == Shishen.正印:
-            expected_tg = True
-          if bazi_utils.shishen(chart.bazi.day_master, gz.dizhi) == Shishen.正印:
-            expected_dz = True
+      assert _equal(actual.tiangan, tg_discovery.filter(
+        lambda _, combo : stars.tiangan in combo
+      ))
 
-        actual = transits_analysis.zhengyin(randon_year, random_options)
-        self.assertEqual(expected_tg, actual.tiangan)
-        self.assertEqual(expected_dz, actual.dizhi)
+      # Dizhi
+      for dz_rel, dz_combos in actual.dizhi.items():
+        assert dz_rel in dz_discovery
+        for dz_combo in dz_combos:
+          assert dz_combo in dz_discovery[dz_rel]
 
-  @pytest.mark.slow
-  def test_star(self) -> None:
-    for _ in range(16):
-      chart = BaziChart.random()
-      db = TransitDatabase(chart)
-      analyzer = RelationshipAnalyzer(chart)
-      transits_analysis = analyzer.transits
+      for dz_rel, dz_combos in dz_discovery.items():
+        for dz_combo in dz_combos:
+          if len(dz_combo & set(stars.dizhi)) > 0:
+            assert dz_combo in actual.dizhi[dz_rel]
 
-      for __ in range(64):
-        randon_year = chart.bazi.ganzhi_date.year + random.randint(0, 100)
-        random_options = TransitOptions.random()
-        if not transits_analysis.support(randon_year, random_options):
-          continue
+      assert _equal(actual.dizhi, dz_discovery.filter(
+        lambda _, combo : len(combo & set(stars.dizhi)) > 0
+      ))
 
-        expected_tg: bool = False
-        expected_dz: bool = False
-        for gz in db.ganzhis(TransitMoment(randon_year), random_options):
-          if gz.tiangan == chart.relationship_stars.tiangan:
-            expected_tg = True
-          if gz.dizhi in chart.relationship_stars.dizhi:
-            expected_dz = True
+@pytest.mark.slow
+def test_zhengyin() -> None:
+  for _ in range(32):
+    chart = BaziChart.random()
+    db = TransitDatabase(chart)
+    analyzer = RelationshipAnalyzer(chart)
+    transits_analysis = analyzer.transits
 
-        actual = transits_analysis.star(randon_year, random_options)
-        self.assertEqual(expected_tg, actual.tiangan)
-        self.assertEqual(expected_dz, actual.dizhi)
+    for __ in range(128):
+      randon_year = chart.bazi.ganzhi_date.year + random.randint(0, 100)
+      random_options = TransitOptions.random()
+      if not transits_analysis.support(randon_year, random_options):
+        continue
+
+      expected_tg: bool = False
+      expected_dz: bool = False
+      for gz in db.ganzhis(TransitMoment(randon_year), random_options):
+        if bazi_utils.shishen(chart.bazi.day_master, gz.tiangan) == Shishen.正印:
+          expected_tg = True
+        if bazi_utils.shishen(chart.bazi.day_master, gz.dizhi) == Shishen.正印:
+          expected_dz = True
+
+      actual = transits_analysis.zhengyin(randon_year, random_options)
+      assert expected_tg == actual.tiangan
+      assert expected_dz == actual.dizhi
+
+@pytest.mark.slow
+def test_star() -> None:
+  for _ in range(16):
+    chart = BaziChart.random()
+    db = TransitDatabase(chart)
+    analyzer = RelationshipAnalyzer(chart)
+    transits_analysis = analyzer.transits
+
+    for __ in range(64):
+      randon_year = chart.bazi.ganzhi_date.year + random.randint(0, 100)
+      random_options = TransitOptions.random()
+      if not transits_analysis.support(randon_year, random_options):
+        continue
+
+      expected_tg: bool = False
+      expected_dz: bool = False
+      for gz in db.ganzhis(TransitMoment(randon_year), random_options):
+        if gz.tiangan == chart.relationship_stars.tiangan:
+          expected_tg = True
+        if gz.dizhi in chart.relationship_stars.dizhi:
+          expected_dz = True
+
+      actual = transits_analysis.star(randon_year, random_options)
+      assert expected_tg == actual.tiangan
+      assert expected_dz == actual.dizhi
 
 
-class TestShenshaRegistry(unittest.TestCase):
-  def test_registry_matches_shensha_analysis_keys(self) -> None:
-    '''The Shensha registry and `ShenshaAnalysis` must stay in sync / 神煞注册表和 ShenshaAnalysis 的键必须保持同步。'''
-    self.assertSetEqual(set(_REGISTRY.keys()),
-                        set(ShenshaAnalysis.__required_keys__ | ShenshaAnalysis.__optional_keys__))
+def test_registry_matches_shensha_analysis_keys() -> None:
+  '''The Shensha registry and `ShenshaAnalysis` must stay in sync / 神煞注册表和 ShenshaAnalysis 的键必须保持同步。'''
+  assert set(_REGISTRY.keys()) == set(ShenshaAnalysis.__required_keys__ | ShenshaAnalysis.__optional_keys__)

--- a/tests/calendar/test_backend.py
+++ b/tests/calendar/test_backend.py
@@ -3,7 +3,8 @@
 
 import copy
 import types
-import unittest
+
+import pytest
 
 from datetime import datetime
 
@@ -15,164 +16,167 @@ from src.bazi import Bazi, BaziGender, BaziPrecision
 from src.bazi_chart import BaziChart
 
 
-class TestCalendarBackend(unittest.TestCase):
-  def test_basic(self) -> None:
-    self.assertEqual(len(CalendarBackend), 3)
-    self.assertEqual(str(CalendarBackend.HKO), 'hko')
-    self.assertEqual(str(CalendarBackend.CELESTIAL), 'celestial')
-    self.assertEqual(str(CalendarBackend.CELESTIAL_ALGO2), 'celestial-algo2')
-
-  def test_from_str(self) -> None:
-    for s in ['hko', 'HKO', 'Hko']:
-      self.assertIs(CalendarBackend.from_str(s), CalendarBackend.HKO)
-    for s in ['celestial', 'CELESTIAL', 'Celestial']:
-      self.assertIs(CalendarBackend.from_str(s), CalendarBackend.CELESTIAL)
-    # Both the member name and the value resolve, and they differ in spelling here.
-    for s in ['celestial-algo2', 'CELESTIAL_ALGO2', 'celestial_algo2']:
-      self.assertIs(CalendarBackend.from_str(s), CalendarBackend.CELESTIAL_ALGO2)
-
-    with self.assertRaises(ValueError):
-      CalendarBackend.from_str('lunar') # Not a supported backend.
-
-    with self.assertRaises(AssertionError):
-      CalendarBackend.from_str(42) # type: ignore[arg-type]
-
-  def test_calendar_utils_of(self) -> None:
-    utils = calendar_utils_of(CalendarBackend.HKO)
-    self.assertIs(utils, hko_data_utils)
-    self.assertIsInstance(utils, CalendarUtilsProtocol)
-
-    self.assertIs(calendar_utils_of(CalendarBackend.CELESTIAL), ALGO1)
-    self.assertIs(calendar_utils_of(CalendarBackend.CELESTIAL_ALGO2), ALGO2)
-
-    # Strings are also accepted and resolved the same way.
-    self.assertIs(calendar_utils_of('hko'), hko_data_utils)
-    self.assertIs(calendar_utils_of('celestial'), ALGO1)
-
-    for backend in CalendarBackend:
-      self.assertIsInstance(calendar_utils_of(backend), CalendarUtilsProtocol)
-
-    with self.assertRaises(ValueError):
-      calendar_utils_of('lunar')
-
-    with self.assertRaises(AssertionError):
-      calendar_utils_of(42) # type: ignore[arg-type]
+def test_basic() -> None:
+  assert len(CalendarBackend) == 3
+  assert str(CalendarBackend.HKO) == 'hko'
+  assert str(CalendarBackend.CELESTIAL) == 'celestial'
+  assert str(CalendarBackend.CELESTIAL_ALGO2) == 'celestial-algo2'
 
 
-class TestBaziBackend(unittest.TestCase):
-  def test_create_with_backend(self) -> None:
-    bazi_enum: Bazi = Bazi.create('1984-04-02 04:02', 'male', 'day', backend=CalendarBackend.HKO)
-    bazi_str: Bazi = Bazi.create('1984-04-02 04:02', 'male', 'day', backend='hko')
+def test_from_str() -> None:
+  for s in ['hko', 'HKO', 'Hko']:
+    assert CalendarBackend.from_str(s) is CalendarBackend.HKO
+  for s in ['celestial', 'CELESTIAL', 'Celestial']:
+    assert CalendarBackend.from_str(s) is CalendarBackend.CELESTIAL
+  # Both the member name and the value resolve, and they differ in spelling here.
+  for s in ['celestial-algo2', 'CELESTIAL_ALGO2', 'celestial_algo2']:
+    assert CalendarBackend.from_str(s) is CalendarBackend.CELESTIAL_ALGO2
 
-    self.assertEqual(bazi_enum, bazi_str) # enum and string spellings resolve the same way
+  with pytest.raises(ValueError):
+    CalendarBackend.from_str('lunar') # Not a supported backend.
 
-    with self.assertRaises(ValueError):
-      Bazi.create('1984-04-02 04:02', 'male', 'day', backend='lunar')
+  with pytest.raises(AssertionError):
+    CalendarBackend.from_str(42) # type: ignore[arg-type]
 
-    with self.assertRaises(AssertionError):
-      Bazi.create('1984-04-02 04:02', 'male', 'day', backend=42) # type: ignore[arg-type]
 
-  def test_consistent_with_hko_utils(self) -> None:
-    # The backend-resolved utils should produce results identical to direct HKO calls.
-    bazi: Bazi = Bazi(datetime(2000, 2, 4, 20, 35), BaziGender.FEMALE, BaziPrecision.DAY,
-                      backend=CalendarBackend.HKO)
-    self.assertEqual(bazi.solar_date, hko_data_utils.to_date(datetime(2000, 2, 4)))
-    self.assertEqual(bazi.ganzhi_date, hko_data_utils.to_ganzhi(bazi.solar_date))
+def test_calendar_utils_of() -> None:
+  utils = calendar_utils_of(CalendarBackend.HKO)
+  assert utils is hko_data_utils
+  assert isinstance(utils, CalendarUtilsProtocol)
 
-  def test_init_rejects_str_backend(self) -> None:
-    # `__init__` only takes the enum; strings go through `Bazi.create` (same
-    # contract split as `gender` / `precision`).
-    with self.assertRaises(AssertionError):
-      Bazi(datetime(1984, 4, 2, 4, 2), BaziGender.MALE, BaziPrecision.DAY,
-           backend='hko') # type: ignore[arg-type]
+  assert calendar_utils_of(CalendarBackend.CELESTIAL) is ALGO1
+  assert calendar_utils_of(CalendarBackend.CELESTIAL_ALGO2) is ALGO2
 
-  def test_default_backend_is_celestial(self) -> None:
-    '''
-    #93 flipped the default from HKO to CELESTIAL.  The switch is two quiet keyword
-    defaults, so pin every construction path that can pick it up implicitly.
-    '''
-    self.assertIs(Bazi(datetime(2000, 2, 4, 22, 1), BaziGender.MALE, BaziPrecision.DAY).backend,
-                  CalendarBackend.CELESTIAL)
-    self.assertIs(Bazi.create('2000-02-04 22:01', 'male', 'day').backend, CalendarBackend.CELESTIAL)
-    self.assertIs(Bazi.random().backend, CalendarBackend.CELESTIAL)
+  # Strings are also accepted and resolved the same way.
+  assert calendar_utils_of('hko') is hko_data_utils
+  assert calendar_utils_of('celestial') is ALGO1
 
-  def test_json_contains_backend(self) -> None:
-    chart: BaziChart = BaziChart(Bazi(datetime(1984, 4, 2, 4, 2), BaziGender.MALE, BaziPrecision.DAY))
-    self.assertEqual(chart.json['backend'], 'celestial') # the default
-    hko_chart: BaziChart = BaziChart(Bazi(datetime(1984, 4, 2, 4, 2), BaziGender.MALE, BaziPrecision.DAY,
-                                          backend=CalendarBackend.HKO))
-    self.assertEqual(hko_chart.json['backend'], 'hko')
+  for backend in CalendarBackend:
+    assert isinstance(calendar_utils_of(backend), CalendarUtilsProtocol)
 
-  def test_celestial_backend_end_to_end(self) -> None:
-    '''
-    F1's claim is that the backend is *in place*, so the whole path gets exercised here --
-    `Bazi.create` from a string, the bare `datetime` that `__init__` hands to the utils, and
-    the json round-trip -- not just the utils in isolation.  Without this, refactoring
-    `to_solar`'s `isinstance(d, date)` into `type(d) is date` would break every celestial
-    chart while the calendar unit tests stayed green.
-    '''
-    for spelling, backend in (('celestial', CalendarBackend.CELESTIAL),
-                              ('celestial-algo2', CalendarBackend.CELESTIAL_ALGO2)):
-      with self.subTest(backend=spelling):
-        bazi: Bazi = Bazi.create('1984-04-02 04:02', 'male', 'day', backend=spelling)
-        self.assertIs(bazi.backend, backend)
-        self.assertEqual(bazi, Bazi.create('1984-04-02 04:02', 'male', 'day', backend=backend))
-        # The bare-`datetime` call shape, which is what `Bazi.__init__` actually uses.
-        self.assertEqual(bazi.solar_date,
-                         calendar_utils_of(backend).to_date(datetime(1984, 4, 2)))
-        self.assertEqual(BaziChart(bazi).json['backend'], spelling)
+  with pytest.raises(ValueError):
+    calendar_utils_of('lunar')
 
-  def test_celestial_differs_from_hko_exactly_where_the_whitelist_says(self) -> None:
-    '''
-    celestial puts 1917 大雪 at 12-08 00:01:05; the HKO almanac dates it 12-07.  So on 12-07
-    the two backends genuinely build different charts.  This is the one place F1's opt-in
-    path is *meant* to disagree, and `(1917, 10, 30)` is one of the four ganzhi dates the
-    layer-c derivation predicts from that whitelist row -- so this pins the propagation
-    end to end, not just inside the calendar layer.
-    '''
-    hko: Bazi = Bazi.create('1917-12-07 12:00', 'male', 'day', backend='hko')
-    cel: Bazi = Bazi.create('1917-12-07 12:00', 'male', 'day', backend='celestial')
+  with pytest.raises(AssertionError):
+    calendar_utils_of(42) # type: ignore[arg-type]
 
-    self.assertEqual(str(hko.month_pillar), '壬子')
-    self.assertEqual(str(cel.month_pillar), '辛亥')
-    self.assertEqual((hko.ganzhi_date.month, hko.ganzhi_date.day), (11, 1))
-    self.assertEqual((cel.ganzhi_date.month, cel.ganzhi_date.day), (10, 30))
-    # The moved 节 shifts the month, nothing else: year and day pillars still agree.
-    self.assertEqual(hko.year_pillar, cel.year_pillar)
-    self.assertEqual(hko.day_pillar, cel.day_pillar)
 
-  def test_deepcopy(self) -> None:
-    # Every backend, not only HKO.  The celestial ones resolve to *instances*, so a leak
-    # into an instance dict would deepcopy silently -- cloning both tables -- where the HKO
-    # module would have raised.  Hence the guard names the resolved objects themselves
-    # rather than just excluding `ModuleType`.
-    forbidden: tuple[object, ...] = tuple(calendar_utils_of(b) for b in CalendarBackend)
+def test_create_with_backend() -> None:
+  bazi_enum: Bazi = Bazi.create('1984-04-02 04:02', 'male', 'day', backend=CalendarBackend.HKO)
+  bazi_str: Bazi = Bazi.create('1984-04-02 04:02', 'male', 'day', backend='hko')
 
-    for backend in CalendarBackend:
-      with self.subTest(backend=backend):
-        bazi: Bazi = Bazi(datetime(1984, 4, 2, 4, 2), BaziGender.MALE, BaziPrecision.DAY,
-                          backend=backend)
-        chart: BaziChart = BaziChart(bazi) # `BaziChart` deepcopies the bazi internally.
+  assert bazi_enum == bazi_str # enum and string spellings resolve the same way
 
-        # Trigger the utils-resolving paths before copying.
-        _ = bazi.solar_date, bazi.ganzhi_date
-        _ = chart.dayun_start_moment
+  with pytest.raises(ValueError):
+    Bazi.create('1984-04-02 04:02', 'male', 'day', backend='lunar')
 
-        # Only the `CalendarBackend` enum may be stored on the instances (deepcopy-safe).
-        # `_utils` must stay a plain property: no resolved utils object may ever land in
-        # the instance dicts.
-        for obj in (bazi, chart):
-          for value in vars(obj).values():
-            self.assertNotIsInstance(value, types.ModuleType)
-            for utils in forbidden:
-              self.assertIsNot(value, utils)
+  with pytest.raises(AssertionError):
+    Bazi.create('1984-04-02 04:02', 'male', 'day', backend=42) # type: ignore[arg-type]
 
-        bazi2: Bazi = copy.deepcopy(bazi)
-        self.assertEqual(bazi, bazi2)
-        self.assertIs(bazi2.backend, backend)
-        # The copy still resolves the calendar utils on demand.
-        self.assertEqual(bazi2.ganzhi_date, bazi.ganzhi_date)
 
-        chart2: BaziChart = copy.deepcopy(chart)
-        self.assertIs(chart2.bazi.backend, backend)
-        self.assertEqual(chart2.dayun_start_moment, chart.dayun_start_moment)
+def test_consistent_with_hko_utils() -> None:
+  # The backend-resolved utils should produce results identical to direct HKO calls.
+  bazi: Bazi = Bazi(datetime(2000, 2, 4, 20, 35), BaziGender.FEMALE, BaziPrecision.DAY,
+                    backend=CalendarBackend.HKO)
+  assert bazi.solar_date == hko_data_utils.to_date(datetime(2000, 2, 4))
+  assert bazi.ganzhi_date == hko_data_utils.to_ganzhi(bazi.solar_date)
+
+
+def test_init_rejects_str_backend() -> None:
+  # `__init__` only takes the enum; strings go through `Bazi.create` (same
+  # contract split as `gender` / `precision`).
+  with pytest.raises(AssertionError):
+    Bazi(datetime(1984, 4, 2, 4, 2), BaziGender.MALE, BaziPrecision.DAY,
+         backend='hko') # type: ignore[arg-type]
+
+
+def test_default_backend_is_celestial() -> None:
+  '''
+  #93 flipped the default from HKO to CELESTIAL.  The switch is two quiet keyword
+  defaults, so pin every construction path that can pick it up implicitly.
+  '''
+  assert Bazi(datetime(2000, 2, 4, 22, 1), BaziGender.MALE, BaziPrecision.DAY).backend is CalendarBackend.CELESTIAL
+  assert Bazi.create('2000-02-04 22:01', 'male', 'day').backend is CalendarBackend.CELESTIAL
+  assert Bazi.random().backend is CalendarBackend.CELESTIAL
+
+
+def test_json_contains_backend() -> None:
+  chart: BaziChart = BaziChart(Bazi(datetime(1984, 4, 2, 4, 2), BaziGender.MALE, BaziPrecision.DAY))
+  assert chart.json['backend'] == 'celestial' # the default
+  hko_chart: BaziChart = BaziChart(Bazi(datetime(1984, 4, 2, 4, 2), BaziGender.MALE, BaziPrecision.DAY,
+                                        backend=CalendarBackend.HKO))
+  assert hko_chart.json['backend'] == 'hko'
+
+
+def test_celestial_backend_end_to_end() -> None:
+  '''
+  F1's claim is that the backend is *in place*, so the whole path gets exercised here --
+  `Bazi.create` from a string, the bare `datetime` that `__init__` hands to the utils, and
+  the json round-trip -- not just the utils in isolation.  Without this, refactoring
+  `to_solar`'s `isinstance(d, date)` into `type(d) is date` would break every celestial
+  chart while the calendar unit tests stayed green.
+  '''
+  for spelling, backend in (('celestial', CalendarBackend.CELESTIAL),
+                            ('celestial-algo2', CalendarBackend.CELESTIAL_ALGO2)):
+    bazi: Bazi = Bazi.create('1984-04-02 04:02', 'male', 'day', backend=spelling)
+    assert bazi.backend is backend
+    assert bazi == Bazi.create('1984-04-02 04:02', 'male', 'day', backend=backend)
+    # The bare-`datetime` call shape, which is what `Bazi.__init__` actually uses.
+    assert bazi.solar_date == calendar_utils_of(backend).to_date(datetime(1984, 4, 2))
+    assert BaziChart(bazi).json['backend'] == spelling
+
+
+def test_celestial_differs_from_hko_exactly_where_the_whitelist_says() -> None:
+  '''
+  celestial puts 1917 大雪 at 12-08 00:01:05; the HKO almanac dates it 12-07.  So on 12-07
+  the two backends genuinely build different charts.  This is the one place F1's opt-in
+  path is *meant* to disagree, and `(1917, 10, 30)` is one of the four ganzhi dates the
+  layer-c derivation predicts from that whitelist row -- so this pins the propagation
+  end to end, not just inside the calendar layer.
+  '''
+  hko: Bazi = Bazi.create('1917-12-07 12:00', 'male', 'day', backend='hko')
+  cel: Bazi = Bazi.create('1917-12-07 12:00', 'male', 'day', backend='celestial')
+
+  assert str(hko.month_pillar) == '壬子'
+  assert str(cel.month_pillar) == '辛亥'
+  assert (hko.ganzhi_date.month, hko.ganzhi_date.day) == (11, 1)
+  assert (cel.ganzhi_date.month, cel.ganzhi_date.day) == (10, 30)
+  # The moved 节 shifts the month, nothing else: year and day pillars still agree.
+  assert hko.year_pillar == cel.year_pillar
+  assert hko.day_pillar == cel.day_pillar
+
+
+def test_deepcopy() -> None:
+  # Every backend, not only HKO.  The celestial ones resolve to *instances*, so a leak
+  # into an instance dict would deepcopy silently -- cloning both tables -- where the HKO
+  # module would have raised.  Hence the guard names the resolved objects themselves
+  # rather than just excluding `ModuleType`.
+  forbidden: tuple[object, ...] = tuple(calendar_utils_of(b) for b in CalendarBackend)
+
+  for backend in CalendarBackend:
+    bazi: Bazi = Bazi(datetime(1984, 4, 2, 4, 2), BaziGender.MALE, BaziPrecision.DAY,
+                      backend=backend)
+    chart: BaziChart = BaziChart(bazi) # `BaziChart` deepcopies the bazi internally.
+
+    # Trigger the utils-resolving paths before copying.
+    _ = bazi.solar_date, bazi.ganzhi_date
+    _ = chart.dayun_start_moment
+
+    # Only the `CalendarBackend` enum may be stored on the instances (deepcopy-safe).
+    # `_utils` must stay a plain property: no resolved utils object may ever land in
+    # the instance dicts.
+    for obj in (bazi, chart):
+      for value in vars(obj).values():
+        assert not isinstance(value, types.ModuleType)
+        for utils in forbidden:
+          assert value is not utils
+
+    bazi2: Bazi = copy.deepcopy(bazi)
+    assert bazi == bazi2
+    assert bazi2.backend is backend
+    # The copy still resolves the calendar utils on demand.
+    assert bazi2.ganzhi_date == bazi.ganzhi_date
+
+    chart2: BaziChart = copy.deepcopy(chart)
+    assert chart2.bazi.backend is backend
+    assert chart2.dayun_start_moment == chart.dayun_start_moment

--- a/tests/calendar/test_celestial_loader.py
+++ b/tests/calendar/test_celestial_loader.py
@@ -2,8 +2,7 @@
 # test_celestial_loader.py
 
 import hashlib
-import tempfile
-import unittest
+import pytest
 
 from datetime import date, datetime
 from pathlib import Path
@@ -23,245 +22,267 @@ def data_lines(path: Path) -> list[str]:
   return [line for line in path.read_text(encoding='utf-8').splitlines() if not line.startswith('#')]
 
 
-class TestShippedTables(unittest.TestCase):
-  '''The tables that actually ship, loaded with the strict contiguity check.'''
+# The shipped tables: the tables that actually ship, loaded with the strict contiguity check.
 
-  def test_they_cover_the_whole_window(self) -> None:
-    self.assertEqual(JieqiMomentTable().supported_year_range(), range(1901, 2101))
-    for algo in (1, 2):
-      table = LunarYearTable(DATA_DIR / f'lunar_years_algo{algo}.txt')
-      self.assertEqual(table.supported_year_range(), range(1901, 2100))
-
-  def test_data_sections_are_frozen(self) -> None:
-    '''
-    The real moments are the reason this backend exists, yet only a handful of the 4,800 are
-    pinned by value anywhere else in the suite -- the parity whitelist plus a few directed
-    cases.  So the data sections are hashed: a re-bake stays possible, but it has to come
-    with a deliberate update to this expectation instead of slipping through.  `#` lines are
-    excluded, so re-generating on another day does not trip it.
-    '''
-    digests: dict[str, str] = {
-      'jieqi_moments.txt':     '93475d53800b683dedd4b23c03232e992212cf6369938120e829e1cd0c686c9d',
-      'lunar_years_algo1.txt': '3e238a2e0494b5af8a53f24e2cae150406972e7ecaa3ce673ceba785bbf3b51d',
-      'lunar_years_algo2.txt': '787229f4d253280f5fc0fc5b47adeb9292228ca503aab7032307d6dbde83bb53',
-    }
-    self.assertEqual(sorted(digests), sorted(TABLE_NAMES)) # Every shipped table is covered.
-    for name, digest in digests.items():
-      payload: str = '\n'.join(data_lines(DATA_DIR / name))
-      self.assertEqual(hashlib.sha256(payload.encode('utf-8')).hexdigest(), digest, name)
-
-  def test_dylib_provenance_value_is_pinned(self) -> None:
-    '''
-    The closed header namespace (test_celestial_tables.py) pins key *names* only, and the data
-    digests above exclude `#` lines -- so without this test the recorded dylib identity could
-    be swapped for any 64-hex string unnoticed.  Re-baking with a new dylib is legitimate, but
-    it has to update this expectation deliberately in the same commit.
-    '''
-    expected: str = '4e102e614e392607720ea24e6b9979bec11cc09338e071ca3f335c0f9914e2d5'
-    self.assertEqual(JieqiMomentTable().provenance['dylib_sha256'], expected)
-    for algo in (1, 2):
-      table = LunarYearTable(DATA_DIR / f'lunar_years_algo{algo}.txt')
-      self.assertEqual(table.provenance['dylib_sha256'], expected)
-
-  def test_fixture_rows_appear_verbatim_in_the_shipped_tables(self) -> None:
-    '''
-    The fixtures and the shipped tables were written by two generators that never shared
-    code (the fixtures came from a throwaway script, the tables from
-    `celestial_data/generator.py`).  Byte-identical data lines on
-    the overlapping years is therefore a check on `SCHEMA.md` itself, not just on the data.
-    '''
-    for name in TABLE_NAMES:
-      fixture_rows: list[str] = data_lines(FIXTURES / name)
-      shipped_rows: set[str] = set(data_lines(DATA_DIR / name))
-      self.assertEqual(len(fixture_rows), 120 if name.startswith('jieqi') else 5, name)
-      for row in fixture_rows:
-        self.assertIn(row, shipped_rows, f'{name}: fixture row absent from the shipped table')
+def test_they_cover_the_whole_window() -> None:
+  assert JieqiMomentTable().supported_year_range() == range(1901, 2101)
+  for algo in (1, 2):
+    table = LunarYearTable(DATA_DIR / f'lunar_years_algo{algo}.txt')
+    assert table.supported_year_range() == range(1901, 2100)
 
 
-class TestFixtureTables(unittest.TestCase):
+def test_data_sections_are_frozen() -> None:
   '''
-  The fixtures are a 5-year slice in the shipped format, frozen when the schema was.  Being a sparse
-  slice, they are loaded with `contiguous_years=False`; the shipped tables use the strict
-  default.
+  The real moments are the reason this backend exists, yet only a handful of the 4,800 are
+  pinned by value anywhere else in the suite -- the parity whitelist plus a few directed
+  cases.  So the data sections are hashed: a re-bake stays possible, but it has to come
+  with a deliberate update to this expectation instead of slipping through.  `#` lines are
+  excluded, so re-generating on another day does not trip it.
   '''
+  digests: dict[str, str] = {
+    'jieqi_moments.txt':     '93475d53800b683dedd4b23c03232e992212cf6369938120e829e1cd0c686c9d',
+    'lunar_years_algo1.txt': '3e238a2e0494b5af8a53f24e2cae150406972e7ecaa3ce673ceba785bbf3b51d',
+    'lunar_years_algo2.txt': '787229f4d253280f5fc0fc5b47adeb9292228ca503aab7032307d6dbde83bb53',
+  }
+  assert sorted(digests) == sorted(TABLE_NAMES) # Every shipped table is covered.
+  for name, digest in digests.items():
+    payload: str = '\n'.join(data_lines(DATA_DIR / name))
+    assert hashlib.sha256(payload.encode('utf-8')).hexdigest() == digest, name
 
-  def test_jieqi_fixture(self) -> None:
-    table = JieqiMomentTable(FIXTURES / 'jieqi_moments.txt', contiguous_years=False)
-    self.assertEqual(table.supported_year_range(), range(1901, 2025)) # min..max of the slice
 
-    # Spot values, deliberately the ones that carry signal.
-    self.assertEqual(table.get(2024, Jieqi.立春), datetime(2024, 2, 4, 16, 27, 6))
-    self.assertEqual(table.get(1917, Jieqi.大雪), datetime(1917, 12, 8, 0, 1, 5))
-    self.assertEqual(table.get(1979, Jieqi.大寒), datetime(1979, 1, 20, 23, 59, 56))
+def test_dylib_provenance_value_is_pinned() -> None:
+  '''
+  The closed header namespace (test_celestial_tables.py) pins key *names* only, and the data
+  digests above exclude `#` lines -- so without this test the recorded dylib identity could
+  be swapped for any 64-hex string unnoticed.  Re-baking with a new dylib is legitimate, but
+  it has to update this expectation deliberately in the same commit.
+  '''
+  expected: str = '4e102e614e392607720ea24e6b9979bec11cc09338e071ca3f335c0f9914e2d5'
+  assert JieqiMomentTable().provenance['dylib_sha256'] == expected
+  for algo in (1, 2):
+    table = LunarYearTable(DATA_DIR / f'lunar_years_algo{algo}.txt')
+    assert table.provenance['dylib_sha256'] == expected
 
-    # 小寒/大寒 of year Y land in January of Y, so rows are not date-sorted within a year.
-    self.assertEqual(table.get(2024, Jieqi.小寒).month, 1)
-    self.assertLess(table.get(2024, Jieqi.大寒), table.get(2024, Jieqi.立春))
 
-  def test_jieqi_provenance(self) -> None:
-    table = JieqiMomentTable(FIXTURES / 'jieqi_moments.txt', contiguous_years=False)
-    provenance = table.provenance
-    self.assertEqual(provenance['schema_version'], SCHEMA_VERSION)
-    self.assertEqual(provenance['celestial_version'], '0.4.0')
-    self.assertEqual(provenance['columns'], JIEQI_COLUMNS)
-    self.assertEqual(len(provenance['dylib_sha256']), 64)
-    # A copy, so a caller cannot mutate the table's own record.
-    provenance['celestial_version'] = 'tampered'
-    self.assertEqual(table.provenance['celestial_version'], '0.4.0')
+def test_fixture_rows_appear_verbatim_in_the_shipped_tables() -> None:
+  '''
+  The fixtures and the shipped tables were written by two generators that never shared
+  code (the fixtures came from a throwaway script, the tables from
+  `celestial_data/generator.py`).  Byte-identical data lines on
+  the overlapping years is therefore a check on `SCHEMA.md` itself, not just on the data.
+  '''
+  for name in TABLE_NAMES:
+    fixture_rows: list[str] = data_lines(FIXTURES / name)
+    shipped_rows: set[str] = set(data_lines(DATA_DIR / name))
+    assert len(fixture_rows) == (120 if name.startswith('jieqi') else 5), name
+    for row in fixture_rows:
+      assert row in shipped_rows, f'{name}: fixture row absent from the shipped table'
 
-  def test_lunar_fixture(self) -> None:
-    for algo in (1, 2):
-      table = LunarYearTable(FIXTURES / f'lunar_years_algo{algo}.txt', contiguous_years=False)
-      self.assertEqual(table.provenance['columns'], LUNAR_COLUMNS)
-      self.assertEqual(table.provenance['algo'], str(algo))
 
-      info = table.get(1901)
-      self.assertEqual(info['first_solar_day'], date(1901, 2, 19))
-      self.assertFalse(info['leap'])
-      self.assertIsNone(info['leap_month']) # The table spells this as 0; hko_data as None.
-      self.assertEqual(len(info['days_counts']), 12)
-      self.assertEqual(info['ganzhi'], Ganzhi.from_str('辛丑'))
+# The fixture tables: a 5-year slice in the shipped format, frozen when the schema was.  Being a
+# sparse slice, they are loaded with `contiguous_years=False`; the shipped tables use the strict
+# default.
 
-      leap = table.get(1917)
-      self.assertTrue(leap['leap'])
-      self.assertEqual(leap['leap_month'], 2)
-      self.assertEqual(len(leap['days_counts']), 13)
+def test_jieqi_fixture() -> None:
+  table = JieqiMomentTable(FIXTURES / 'jieqi_moments.txt', contiguous_years=False)
+  assert table.supported_year_range() == range(1901, 2025) # min..max of the slice
 
-  def test_lunar_get_returns_a_copy(self) -> None:
-    # A copy, so a caller's in-place edit cannot corrupt the table's own record (issue #92).
-    table = LunarYearTable(FIXTURES / 'lunar_years_algo1.txt', contiguous_years=False)
+  # Spot values, deliberately the ones that carry signal.
+  assert table.get(2024, Jieqi.立春) == datetime(2024, 2, 4, 16, 27, 6)
+  assert table.get(1917, Jieqi.大雪) == datetime(1917, 12, 8, 0, 1, 5)
+  assert table.get(1979, Jieqi.大寒) == datetime(1979, 1, 20, 23, 59, 56)
+
+  # 小寒/大寒 of year Y land in January of Y, so rows are not date-sorted within a year.
+  assert table.get(2024, Jieqi.小寒).month == 1
+  assert table.get(2024, Jieqi.大寒) < table.get(2024, Jieqi.立春)
+
+
+def test_jieqi_provenance() -> None:
+  table = JieqiMomentTable(FIXTURES / 'jieqi_moments.txt', contiguous_years=False)
+  provenance = table.provenance
+  assert provenance['schema_version'] == SCHEMA_VERSION
+  assert provenance['celestial_version'] == '0.4.0'
+  assert provenance['columns'] == JIEQI_COLUMNS
+  assert len(provenance['dylib_sha256']) == 64
+  # A copy, so a caller cannot mutate the table's own record.
+  provenance['celestial_version'] = 'tampered'
+  assert table.provenance['celestial_version'] == '0.4.0'
+
+
+def test_lunar_fixture() -> None:
+  for algo in (1, 2):
+    table = LunarYearTable(FIXTURES / f'lunar_years_algo{algo}.txt', contiguous_years=False)
+    assert table.provenance['columns'] == LUNAR_COLUMNS
+    assert table.provenance['algo'] == str(algo)
+
     info = table.get(1901)
-    self.assertIsNot(info, table.get(1901))
-    self.assertIsNot(info['days_counts'], table.get(1901)['days_counts'])
+    assert info['first_solar_day'] == date(1901, 2, 19)
+    assert not info['leap']
+    assert info['leap_month'] is None # The table spells this as 0; hko_data as None.
+    assert len(info['days_counts']) == 12
+    assert info['ganzhi'] == Ganzhi.from_str('辛丑')
 
-    original = list(info['days_counts'])
-    info['days_counts'][0] = 999
-    self.assertEqual(table.get(1901)['days_counts'], original)
-
-  def test_the_two_algos_differ_on_1914(self) -> None:
-    # 1914 is one of the six years celestial's own diff_test.cpp records as divergent.
-    algo1 = LunarYearTable(FIXTURES / 'lunar_years_algo1.txt', contiguous_years=False).get(1914)
-    algo2 = LunarYearTable(FIXTURES / 'lunar_years_algo2.txt', contiguous_years=False).get(1914)
-    self.assertEqual(algo1['first_solar_day'], algo2['first_solar_day'])
-    self.assertNotEqual(algo1['days_counts'], algo2['days_counts'])
-
-  def test_index_matches_the_jieqi_enum(self) -> None:
-    # The table stores celestial's `jq_idx`; the loader trusts it to be this enum's index.
-    self.assertEqual(len(JIEQI_BY_INDEX), 24)
-    self.assertIs(JIEQI_BY_INDEX[0], Jieqi.立春)
-    self.assertIs(JIEQI_BY_INDEX[23], Jieqi.大寒)
-    # Even indices are 节 (they start ganzhi months), odd ones are 气.
-    self.assertEqual(JIEQI_BY_INDEX[::2], Jieqi.as_list()[::2])
+    leap = table.get(1917)
+    assert leap['leap']
+    assert leap['leap_month'] == 2
+    assert len(leap['days_counts']) == 13
 
 
-class TestCorruptTables(unittest.TestCase):
+def test_lunar_get_returns_a_copy() -> None:
+  # A copy, so a caller's in-place edit cannot corrupt the table's own record (issue #92).
+  table = LunarYearTable(FIXTURES / 'lunar_years_algo1.txt', contiguous_years=False)
+  info = table.get(1901)
+  assert info is not table.get(1901)
+  assert info['days_counts'] is not table.get(1901)['days_counts']
+
+  original = list(info['days_counts'])
+  info['days_counts'][0] = 999
+  assert table.get(1901)['days_counts'] == original
+
+
+def test_the_two_algos_differ_on_1914() -> None:
+  # 1914 is one of the six years celestial's own diff_test.cpp records as divergent.
+  algo1 = LunarYearTable(FIXTURES / 'lunar_years_algo1.txt', contiguous_years=False).get(1914)
+  algo2 = LunarYearTable(FIXTURES / 'lunar_years_algo2.txt', contiguous_years=False).get(1914)
+  assert algo1['first_solar_day'] == algo2['first_solar_day']
+  assert algo1['days_counts'] != algo2['days_counts']
+
+
+def test_index_matches_the_jieqi_enum() -> None:
+  # The table stores celestial's `jq_idx`; the loader trusts it to be this enum's index.
+  assert len(JIEQI_BY_INDEX) == 24
+  assert JIEQI_BY_INDEX[0] is Jieqi.立春
+  assert JIEQI_BY_INDEX[23] is Jieqi.大寒
+  # Even indices are 节 (they start ganzhi months), odd ones are 气.
+  assert JIEQI_BY_INDEX[::2] == Jieqi.as_list()[::2]
+
+
+# Corrupt tables: every rejection path, exercised by mutating a fixture.  A stale or hand-edited
+# table is the one failure mode that would otherwise silently produce wrong charts everywhere.
+
+@pytest.fixture
+def jieqi_lines() -> list[str]:
+  return (FIXTURES / 'jieqi_moments.txt').read_text(encoding='utf-8').splitlines()
+
+
+@pytest.fixture
+def lunar_lines() -> list[str]:
+  return (FIXTURES / 'lunar_years_algo1.txt').read_text(encoding='utf-8').splitlines()
+
+
+def _write(tmp_path: Path, lines: list[str], name: str = 'table.txt') -> Path:
+  path: Path = tmp_path / name
+  path.write_text('\n'.join(lines) + '\n', encoding='utf-8')
+  return path
+
+
+def _replace(lines: list[str], old_prefix: str, new: str) -> list[str]:
+  out = list(lines)
+  for i, line in enumerate(out):
+    if line.startswith(old_prefix):
+      out[i] = new
+      return out
+  raise AssertionError(f'No line starts with {old_prefix!r}') # pragma: no cover # Test-helper guard.
+
+
+def test_missing_file() -> None:
+  with pytest.raises(RuntimeError) as ctx:
+    JieqiMomentTable(FIXTURES / 'does_not_exist.txt')
+  assert 'generator' in str(ctx.value) # Tell the reader how to regenerate it.
+
+
+def test_schema_version_mismatch(jieqi_lines: list[str], tmp_path: Path) -> None:
+  path = _write(tmp_path, _replace(jieqi_lines, '# schema_version:', '# schema_version: 999'))
+  with pytest.raises(ValueError):
+    JieqiMomentTable(path)
+
+
+def test_columns_mismatch(jieqi_lines: list[str], tmp_path: Path) -> None:
+  path = _write(tmp_path, _replace(jieqi_lines, '# columns:', '# columns: year name'))
+  with pytest.raises(ValueError):
+    JieqiMomentTable(path)
+
+
+def test_row_count_mismatch(jieqi_lines: list[str], tmp_path: Path) -> None:
+  path = _write(tmp_path, _replace(jieqi_lines, '# rows:', '# rows: 119'))
+  with pytest.raises(ValueError):
+    JieqiMomentTable(path)
+
+
+def test_jieqi_name_does_not_match_index(jieqi_lines: list[str], tmp_path: Path) -> None:
+  path = _write(tmp_path, _replace(jieqi_lines, '1901 00 ', '1901 00 大寒 1901-02-04 19:39:57'))
+  with pytest.raises(ValueError):
+    JieqiMomentTable(path)
+
+
+def test_jieqi_index_out_of_range(jieqi_lines: list[str], tmp_path: Path) -> None:
+  # 24 is past the end; -1 would otherwise alias from the *end* of the list and read as
+  # 大寒, letting a corrupt row through as long as its name matched that alias.
+  for bad in ('1901 24 立春 1901-02-04 19:39:57', '1901 -1 大寒 1901-02-04 19:39:57'):
+    with pytest.raises(ValueError):
+      JieqiMomentTable(_write(tmp_path, _replace(jieqi_lines, '1901 00 ', bad)))
+
+
+def test_duplicate_jieqi_row(jieqi_lines: list[str], tmp_path: Path) -> None:
+  lines = _replace(jieqi_lines, '1901 01 ', '1901 00 立春 1901-02-19 15:45:00')
+  with pytest.raises(ValueError):
+    JieqiMomentTable(_write(tmp_path, lines))
+
+
+def _synthetic(tmp_path: Path, lines: list[str], sample_prefix: str, years: list[int]) -> Path:
   '''
-  Every rejection path, exercised by mutating a fixture.  A stale or hand-edited table is
-  the one failure mode that would otherwise silently produce wrong charts everywhere.
+  Build a table covering exactly `years`, by restamping one sample year's rows.  Only
+  the structure matters here, so the other columns keep the sample year's values.
   '''
+  sample: list[str] = [line for line in lines if line.startswith(sample_prefix)]
+  data: list[str] = [f'{year}{row[len(str(year)):]}' for year in years for row in sample]
+  header: list[str] = [line for line in lines if line.startswith('#')]
+  return _write(tmp_path, _replace(header, '# rows:', f'# rows: {len(data)}') + data)
 
-  def setUp(self) -> None:
-    self.jieqi_lines: list[str] = (FIXTURES / 'jieqi_moments.txt').read_text(encoding='utf-8').splitlines()
-    self.lunar_lines: list[str] = (FIXTURES / 'lunar_years_algo1.txt').read_text(encoding='utf-8').splitlines()
 
-  def __write(self, lines: list[str], name: str = 'table.txt') -> Path:
-    path: Path = Path(self.enterContext(tempfile.TemporaryDirectory())) / name
-    path.write_text('\n'.join(lines) + '\n', encoding='utf-8')
-    return path
+def test_jieqi_years_not_fully_covered(jieqi_lines: list[str], tmp_path: Path) -> None:
+  # A hole at 1903: the row count header matches, but the year range is not covered.
+  with pytest.raises(ValueError):
+    JieqiMomentTable(_synthetic(tmp_path, jieqi_lines, '1901 ', [1901, 1902, 1904]))
+  # Positive control: the same builder with no hole passes the strict check.
+  table = JieqiMomentTable(_synthetic(tmp_path, jieqi_lines, '1901 ', [1901, 1902, 1903]))
+  assert table.supported_year_range() == range(1901, 1904)
 
-  def __replace(self, lines: list[str], old_prefix: str, new: str) -> list[str]:
-    out = list(lines)
-    for i, line in enumerate(out):
-      if line.startswith(old_prefix):
-        out[i] = new
-        return out
-    raise AssertionError(f'No line starts with {old_prefix!r}') # pragma: no cover # Test-helper guard.
 
-  def test_missing_file(self) -> None:
-    with self.assertRaises(RuntimeError) as ctx:
-      JieqiMomentTable(FIXTURES / 'does_not_exist.txt')
-    self.assertIn('generator', str(ctx.exception)) # Tell the reader how to regenerate it.
+def test_lunar_bits_disagree_with_days_counts(lunar_lines: list[str], tmp_path: Path) -> None:
+  path = _write(tmp_path, _replace(
+    lunar_lines, '1901 ',
+    '1901 1901-02-19 0 0x0752 30,30,29,29,30,29,30,29,30,30,30,29 辛丑'))
+  with pytest.raises(ValueError):
+    LunarYearTable(path)
 
-  def test_schema_version_mismatch(self) -> None:
-    path = self.__write(self.__replace(self.jieqi_lines, '# schema_version:', '# schema_version: 999'))
-    with self.assertRaises(ValueError):
-      JieqiMomentTable(path)
 
-  def test_columns_mismatch(self) -> None:
-    path = self.__write(self.__replace(self.jieqi_lines, '# columns:', '# columns: year name'))
-    with self.assertRaises(ValueError):
-      JieqiMomentTable(path)
+def test_lunar_leap_month_disagrees_with_month_count(lunar_lines: list[str], tmp_path: Path) -> None:
+  # 12 months but a non-zero leap month.
+  path = _write(tmp_path, _replace(
+    lunar_lines, '1901 ',
+    '1901 1901-02-19 5 0x0752 29,30,29,29,30,29,30,29,30,30,30,29 辛丑'))
+  with pytest.raises(ValueError):
+    LunarYearTable(path)
 
-  def test_row_count_mismatch(self) -> None:
-    path = self.__write(self.__replace(self.jieqi_lines, '# rows:', '# rows: 119'))
-    with self.assertRaises(ValueError):
-      JieqiMomentTable(path)
 
-  def test_jieqi_name_does_not_match_index(self) -> None:
-    path = self.__write(self.__replace(self.jieqi_lines, '1901 00 ', '1901 00 大寒 1901-02-04 19:39:57'))
-    with self.assertRaises(ValueError):
-      JieqiMomentTable(path)
+def test_duplicate_lunar_year(lunar_lines: list[str], tmp_path: Path) -> None:
+  path = _write(tmp_path, _replace(
+    lunar_lines, '1914 ',
+    '1901 1901-02-19 0 0x0752 29,30,29,29,30,29,30,29,30,30,30,29 辛丑'))
+  with pytest.raises(ValueError):
+    LunarYearTable(path)
 
-  def test_jieqi_index_out_of_range(self) -> None:
-    # 24 is past the end; -1 would otherwise alias from the *end* of the list and read as
-    # 大寒, letting a corrupt row through as long as its name matched that alias.
-    for bad in ('1901 24 立春 1901-02-04 19:39:57', '1901 -1 大寒 1901-02-04 19:39:57'):
-      with self.assertRaises(ValueError):
-        JieqiMomentTable(self.__write(self.__replace(self.jieqi_lines, '1901 00 ', bad)))
 
-  def test_duplicate_jieqi_row(self) -> None:
-    lines = self.__replace(self.jieqi_lines, '1901 01 ', '1901 00 立春 1901-02-19 15:45:00')
-    with self.assertRaises(ValueError):
-      JieqiMomentTable(self.__write(lines))
+def test_lunar_years_not_contiguous(lunar_lines: list[str], tmp_path: Path) -> None:
+  with pytest.raises(ValueError):
+    LunarYearTable(_synthetic(tmp_path, lunar_lines, '1901 ', [1901, 1902, 1904]))
+  table = LunarYearTable(_synthetic(tmp_path, lunar_lines, '1901 ', [1901, 1902, 1903]))
+  assert table.supported_year_range() == range(1901, 1904)
 
-  def __synthetic(self, lines: list[str], sample_prefix: str, years: list[int]) -> Path:
-    '''
-    Build a table covering exactly `years`, by restamping one sample year's rows.  Only
-    the structure matters here, so the other columns keep the sample year's values.
-    '''
-    sample: list[str] = [line for line in lines if line.startswith(sample_prefix)]
-    data: list[str] = [f'{year}{row[len(str(year)):]}' for year in years for row in sample]
-    header: list[str] = [line for line in lines if line.startswith('#')]
-    return self.__write(self.__replace(header, '# rows:', f'# rows: {len(data)}') + data)
 
-  def test_jieqi_years_not_fully_covered(self) -> None:
-    # A hole at 1903: the row count header matches, but the year range is not covered.
-    with self.assertRaises(ValueError):
-      JieqiMomentTable(self.__synthetic(self.jieqi_lines, '1901 ', [1901, 1902, 1904]))
-    # Positive control: the same builder with no hole passes the strict check.
-    table = JieqiMomentTable(self.__synthetic(self.jieqi_lines, '1901 ', [1901, 1902, 1903]))
-    self.assertEqual(table.supported_year_range(), range(1901, 1904))
-
-  def test_lunar_bits_disagree_with_days_counts(self) -> None:
-    path = self.__write(self.__replace(
-      self.lunar_lines, '1901 ',
-      '1901 1901-02-19 0 0x0752 30,30,29,29,30,29,30,29,30,30,30,29 辛丑'))
-    with self.assertRaises(ValueError):
-      LunarYearTable(path)
-
-  def test_lunar_leap_month_disagrees_with_month_count(self) -> None:
-    # 12 months but a non-zero leap month.
-    path = self.__write(self.__replace(
-      self.lunar_lines, '1901 ',
-      '1901 1901-02-19 5 0x0752 29,30,29,29,30,29,30,29,30,30,30,29 辛丑'))
-    with self.assertRaises(ValueError):
-      LunarYearTable(path)
-
-  def test_duplicate_lunar_year(self) -> None:
-    path = self.__write(self.__replace(
-      self.lunar_lines, '1914 ',
-      '1901 1901-02-19 0 0x0752 29,30,29,29,30,29,30,29,30,30,30,29 辛丑'))
-    with self.assertRaises(ValueError):
-      LunarYearTable(path)
-
-  def test_lunar_years_not_contiguous(self) -> None:
-    with self.assertRaises(ValueError):
-      LunarYearTable(self.__synthetic(self.lunar_lines, '1901 ', [1901, 1902, 1904]))
-    table = LunarYearTable(self.__synthetic(self.lunar_lines, '1901 ', [1901, 1902, 1903]))
-    self.assertEqual(table.supported_year_range(), range(1901, 1904))
-
-  def test_header_continuation_lines_are_not_keys(self) -> None:
-    # Prose continuation lines are indented further; they must not become header keys.
-    table = JieqiMomentTable(FIXTURES / 'jieqi_moments.txt', contiguous_years=False)
-    self.assertNotIn('Measured', table.provenance)
-    self.assertIn('timescale_caveat', table.provenance)
+def test_header_continuation_lines_are_not_keys() -> None:
+  # Prose continuation lines are indented further; they must not become header keys.
+  table = JieqiMomentTable(FIXTURES / 'jieqi_moments.txt', contiguous_years=False)
+  assert 'Measured' not in table.provenance
+  assert 'timescale_caveat' in table.provenance

--- a/tests/calendar/test_celestial_loader.py
+++ b/tests/calendar/test_celestial_loader.py
@@ -2,6 +2,7 @@
 # test_celestial_loader.py
 
 import hashlib
+
 import pytest
 
 from datetime import date, datetime
@@ -23,6 +24,7 @@ def data_lines(path: Path) -> list[str]:
 
 
 # The shipped tables: the tables that actually ship, loaded with the strict contiguity check.
+
 
 def test_they_cover_the_whole_window() -> None:
   assert JieqiMomentTable().supported_year_range() == range(1901, 2101)
@@ -82,6 +84,7 @@ def test_fixture_rows_appear_verbatim_in_the_shipped_tables() -> None:
 # The fixture tables: a 5-year slice in the shipped format, frozen when the schema was.  Being a
 # sparse slice, they are loaded with `contiguous_years=False`; the shipped tables use the strict
 # default.
+
 
 def test_jieqi_fixture() -> None:
   table = JieqiMomentTable(FIXTURES / 'jieqi_moments.txt', contiguous_years=False)
@@ -159,6 +162,7 @@ def test_index_matches_the_jieqi_enum() -> None:
 
 # Corrupt tables: every rejection path, exercised by mutating a fixture.  A stale or hand-edited
 # table is the one failure mode that would otherwise silently produce wrong charts everywhere.
+
 
 @pytest.fixture
 def jieqi_lines() -> list[str]:

--- a/tests/calendar/test_celestial_parity_derived.py
+++ b/tests/calendar/test_celestial_parity_derived.py
@@ -92,8 +92,9 @@ def test_whitelist_is_exact_through_the_backend() -> None:
       if cel != hko:
         measured.append((year, jq_idx, cel))
   # Sorted: the signal is the key set, not the scan order (layer (b) compares as a set too).
-  assert sorted(measured) == \
-         sorted((row.year, row.jq_idx, row.celestial_moment.date()) for row in JIEQI_DATE_DIVERGENCES)
+  assert sorted(measured) == sorted(
+    (row.year, row.jq_idx, row.celestial_moment.date()) for row in JIEQI_DATE_DIVERGENCES
+  )
 
 
 def test_moments_match_the_whitelist() -> None:
@@ -178,6 +179,7 @@ def test_the_derivations_preconditions_hold() -> None:
 
 # Layer (a): celestial's algo1 is the same HKO almanac data, so this is strict.
 
+
 def test_no_disagreement_anywhere() -> None:
   day: date = HKO.to_date(HKO.get_min_supported_date(CalendarType.SOLAR))
   last: date = HKO.to_date(HKO.get_max_supported_date(CalendarType.SOLAR))
@@ -205,6 +207,7 @@ def test_bounds() -> None:
 
 
 # Layer (c): every expectation below is computed from the whitelist.
+
 
 def test_solar_side_disagreements_are_exactly_derived() -> None:
   expected: set[date] = affected_solar_days()
@@ -234,8 +237,7 @@ def test_days_counts_disagrees_on_exactly_the_derived_years() -> None:
   assert measured == expected
   # A moved 节 makes one month longer and its neighbour shorter, so the year still adds up.
   for year in expected:
-    assert sum(CEL.days_counts_in_ganzhi_year(year)) == \
-           sum(HKO.days_counts_in_ganzhi_year(year))
+    assert sum(CEL.days_counts_in_ganzhi_year(year)) == sum(HKO.days_counts_in_ganzhi_year(year))
 
 
 def test_ganzhi_side_disagreements_stay_in_the_derived_months() -> None:

--- a/tests/calendar/test_celestial_parity_derived.py
+++ b/tests/calendar/test_celestial_parity_derived.py
@@ -21,8 +21,6 @@ being the famous one).  The truth side is covered upstream, by celestial-calenda
 HKO x DE441 dual-axis golden tests (0.525 min agreement over 2022-2028).
 '''
 
-import unittest
-
 from datetime import date, datetime, time, timedelta
 
 from src.calendar import hko_data_utils as HKO
@@ -81,194 +79,193 @@ def affected_ganzhi_months() -> set[tuple[int, int]]:
   return months
 
 
-class TestJieqiDateWhitelist(unittest.TestCase):
-  def test_whitelist_is_exact_through_the_backend(self) -> None:
-    '''
-    The anchor for layer (c).  Layer (b) checks the same whitelist against the raw table
-    with its own minimal parser; this one goes through `loader` + `CelestialCalendarUtils`,
-    so the two together also prove that the consumer path reproduces the table faithfully.
-    '''
-    measured: list[tuple[int, int, date]] = []
-    for year in range(1901, 2101):
-      for jq_idx, jq in enumerate(JIEQI_BY_INDEX):
-        cel, hko = CEL.jieqi_date(year, jq), HKO.jieqi_date(year, jq)
-        if cel != hko:
-          measured.append((year, jq_idx, cel))
-    # Sorted: the signal is the key set, not the scan order (layer (b) compares as a set too).
-    self.assertEqual(
-      sorted(measured),
-      sorted((row.year, row.jq_idx, row.celestial_moment.date()) for row in JIEQI_DATE_DIVERGENCES),
-    )
-
-  def test_moments_match_the_whitelist(self) -> None:
-    # Not just the dates: the stored moments themselves, so a re-baked table with a
-    # different rounding policy cannot pass by accident.
-    for row in JIEQI_DATE_DIVERGENCES:
-      self.assertEqual(CEL.jieqi_moment(row.year, jieqi_of(row)), row.celestial_moment)
-      self.assertEqual(HKO.jieqi_date(row.year, jieqi_of(row)), row.hko_date)
-
-  def test_only_two_of_them_are_jie(self) -> None:
-    # Only 节 start ganzhi months, so only these two can propagate into ganzhi methods.
-    self.assertEqual([(row.year, row.name) for row in flipped_jies()],
-                     [(1917, '大雪'), (1927, '白露')])
-
-  def test_prev_next_jie_diverge_only_inside_the_moment_window(self) -> None:
-    '''
-    `prev_jie`/`next_jie` escape layer (c) by design (see the protocol's carve-out): inside
-    the window between the two backends' ideas of when a jie starts, they legitimately name
-    different jie -- and `dayun_start_moment` rides on it.  Both backends answer over the 12
-    节 only, so this pins the shape of that escape for every 节: the window is
-    [min(hko_date, true date) midnight, true moment); inside it the backends are exactly one
-    节 apart, outside it they agree.  A day-level regression that *narrows* a window turns
-    red here; a widening one moves the probes along with it and is caught by the whitelist
-    tests above instead.
-    '''
-    cel_first, cel_last = CEL.supported_jie_boundaries()
-    hko_first, hko_last = HKO.supported_jie_boundaries()
-    cycle: list[Jieqi] = JIES
-    for year in range(1901, 2101):
-      for jq_idx, jq in enumerate(cycle):
-        moment: datetime = CEL.jieqi_moment(year, jq)
-        window_start: datetime = datetime.combine(
-          min(HKO.jieqi_date(year, jq), moment.date()),
-          time.min,
-        )
-        prev_jq: Jieqi = cycle[(jq_idx - 1) % len(cycle)]
-        next_jq: Jieqi = cycle[(jq_idx + 1) % len(cycle)]
-
-        inside: datetime = window_start + (moment - window_start) / 2
-        if inside >= cel_first: # else both queries fall off the table edge (小寒 1901)
-          self.assertEqual(CEL.prev_jie(inside).jieqi, prev_jq, (year, jq))
-          self.assertEqual(CEL.next_jie(inside).jieqi, jq, (year, jq))
-        if inside < hko_last: # else both queries fall off the table edge (大雪 2100)
-          self.assertEqual(HKO.prev_jie(inside).jieqi, jq, (year, jq))
-          self.assertEqual(HKO.next_jie(inside).jieqi, next_jq, (year, jq))
-
-        before: datetime = window_start - timedelta(seconds=1)
-        if before >= cel_first and before >= hko_first:
-          self.assertEqual(CEL.prev_jie(before).jieqi, HKO.prev_jie(before).jieqi, (year, jq))
-          self.assertEqual(CEL.next_jie(before).jieqi, HKO.next_jie(before).jieqi, (year, jq))
-        after: datetime = moment + timedelta(seconds=1)
-        if after < cel_last and after < hko_last:
-          self.assertEqual(CEL.prev_jie(after).jieqi, HKO.prev_jie(after).jieqi, (year, jq))
-          self.assertEqual(CEL.next_jie(after).jieqi, HKO.next_jie(after).jieqi, (year, jq))
-
-  def test_the_derivations_preconditions_hold(self) -> None:
-    '''
-    `affected_ganzhi_months` models a flipped 节 as moving the start of exactly one ganzhi
-    month.  That holds for every 节 except 立春, which is also the *end* of the previous
-    ganzhi year's twelfth month: a flipped 立春 would perturb `(Y - 1, 12)` too, and would
-    falsify the "yearly totals unchanged" check below, since the day gained and the day lost
-    would land in different ganzhi years.
-
-    No shipped table flips 立春, so rather than carry untested branches for a configuration
-    that does not exist, the assumption is asserted here: if a re-baked table ever flips one,
-    this fails first and names what to generalise.  Layer (c) stays *sound* either way --
-    every test there compares a measured set against the derived one, so an unmodelled
-    divergence still turns the suite red.  What this guard protects is the diagnosis.
-    '''
-    self.assertNotIn(
-      Jieqi.立春, {jieqi_of(row) for row in flipped_jies()},
-      'a flipped 立春 also moves (Y - 1, 12): generalise `affected_ganzhi_months` and the '
-      'yearly-total assertion before deleting this guard')
-
-    # The same reasoning at the window edge: the derived days are checked against a scan
-    # bounded by the supported solar range, so a flip in the final month would push the
-    # derived set past where that scan can see it.
-    last: date = HKO.to_date(HKO.get_max_supported_date(CalendarType.SOLAR))
-    self.assertLessEqual(max(affected_solar_days()), last)
+def test_whitelist_is_exact_through_the_backend() -> None:
+  '''
+  The anchor for layer (c).  Layer (b) checks the same whitelist against the raw table
+  with its own minimal parser; this one goes through `loader` + `CelestialCalendarUtils`,
+  so the two together also prove that the consumer path reproduces the table faithfully.
+  '''
+  measured: list[tuple[int, int, date]] = []
+  for year in range(1901, 2101):
+    for jq_idx, jq in enumerate(JIEQI_BY_INDEX):
+      cel, hko = CEL.jieqi_date(year, jq), HKO.jieqi_date(year, jq)
+      if cel != hko:
+        measured.append((year, jq_idx, cel))
+  # Sorted: the signal is the key set, not the scan order (layer (b) compares as a set too).
+  assert sorted(measured) == \
+         sorted((row.year, row.jq_idx, row.celestial_moment.date()) for row in JIEQI_DATE_DIVERGENCES)
 
 
-class TestLunarSurfaceIsIdentical(unittest.TestCase):
-  '''Layer (a): celestial's algo1 is the same HKO almanac data, so this is strict.'''
-
-  def test_no_disagreement_anywhere(self) -> None:
-    day: date = HKO.to_date(HKO.get_min_supported_date(CalendarType.SOLAR))
-    last: date = HKO.to_date(HKO.get_max_supported_date(CalendarType.SOLAR))
-    while day <= last:
-      d: CalendarDate = solar(day)
-      self.assertEqual(CEL.solar_to_lunar(d), HKO.solar_to_lunar(d), day)
-      day += timedelta(days=1)
-
-  def test_lunar_dates_round_trip_identically(self) -> None:
-    for year in range(1901, 2100):
-      for month in range(1, 14):
-        d: CalendarDate = CalendarDate(year, month, 1, CalendarType.LUNAR)
-        self.assertEqual(CEL.is_valid_lunar_date(d), HKO.is_valid_lunar_date(d))
-        if CEL.is_valid_lunar_date(d):
-          self.assertEqual(CEL.lunar_to_solar(d), HKO.lunar_to_solar(d))
+def test_moments_match_the_whitelist() -> None:
+  # Not just the dates: the stored moments themselves, so a re-baked table with a
+  # different rounding policy cannot pass by accident.
+  for row in JIEQI_DATE_DIVERGENCES:
+    assert CEL.jieqi_moment(row.year, jieqi_of(row)) == row.celestial_moment
+    assert HKO.jieqi_date(row.year, jieqi_of(row)) == row.hko_date
 
 
-class TestSupportedRangeIsIdentical(unittest.TestCase):
-  def test_bounds(self) -> None:
-    # celestial derives these from its tables, HKO hardcodes them; they must still agree,
-    # because the two backends cover the same physical window.
-    for date_type in CalendarType:
-      self.assertEqual(CEL.get_min_supported_date(date_type), HKO.get_min_supported_date(date_type))
-      self.assertEqual(CEL.get_max_supported_date(date_type), HKO.get_max_supported_date(date_type))
+def test_only_two_of_them_are_jie() -> None:
+  # Only 节 start ganzhi months, so only these two can propagate into ganzhi methods.
+  assert [(row.year, row.name) for row in flipped_jies()] == [(1917, '大雪'), (1927, '白露')]
 
 
-class TestGanzhiDerivedMethods(unittest.TestCase):
-  '''Layer (c): every expectation below is computed from the whitelist.'''
+def test_prev_next_jie_diverge_only_inside_the_moment_window() -> None:
+  '''
+  `prev_jie`/`next_jie` escape layer (c) by design (see the protocol's carve-out): inside
+  the window between the two backends' ideas of when a jie starts, they legitimately name
+  different jie -- and `dayun_start_moment` rides on it.  Both backends answer over the 12
+  节 only, so this pins the shape of that escape for every 节: the window is
+  [min(hko_date, true date) midnight, true moment); inside it the backends are exactly one
+  节 apart, outside it they agree.  A day-level regression that *narrows* a window turns
+  red here; a widening one moves the probes along with it and is caught by the whitelist
+  tests above instead.
+  '''
+  cel_first, cel_last = CEL.supported_jie_boundaries()
+  hko_first, hko_last = HKO.supported_jie_boundaries()
+  cycle: list[Jieqi] = JIES
+  for year in range(1901, 2101):
+    for jq_idx, jq in enumerate(cycle):
+      moment: datetime = CEL.jieqi_moment(year, jq)
+      window_start: datetime = datetime.combine(
+        min(HKO.jieqi_date(year, jq), moment.date()),
+        time.min,
+      )
+      prev_jq: Jieqi = cycle[(jq_idx - 1) % len(cycle)]
+      next_jq: Jieqi = cycle[(jq_idx + 1) % len(cycle)]
 
-  def test_solar_side_disagreements_are_exactly_derived(self) -> None:
-    expected: set[date] = affected_solar_days()
-    measured_ganzhi: set[date] = set()
-    measured_via_lunar: set[date] = set()
+      inside: datetime = window_start + (moment - window_start) / 2
+      if inside >= cel_first: # else both queries fall off the table edge (小寒 1901)
+        assert CEL.prev_jie(inside).jieqi == prev_jq, (year, jq)
+        assert CEL.next_jie(inside).jieqi == jq, (year, jq)
+      if inside < hko_last: # else both queries fall off the table edge (大雪 2100)
+        assert HKO.prev_jie(inside).jieqi == jq, (year, jq)
+        assert HKO.next_jie(inside).jieqi == next_jq, (year, jq)
 
-    day: date = HKO.to_date(HKO.get_min_supported_date(CalendarType.SOLAR))
-    last: date = HKO.to_date(HKO.get_max_supported_date(CalendarType.SOLAR))
-    while day <= last:
-      d: CalendarDate = solar(day)
-      if CEL.solar_to_ganzhi(d) != HKO.solar_to_ganzhi(d):
-        measured_ganzhi.add(day)
-      if CEL.lunar_to_ganzhi(CEL.solar_to_lunar(d)) != HKO.lunar_to_ganzhi(HKO.solar_to_lunar(d)):
-        measured_via_lunar.add(day)
-      day += timedelta(days=1)
+      before: datetime = window_start - timedelta(seconds=1)
+      if before >= cel_first and before >= hko_first:
+        assert CEL.prev_jie(before).jieqi == HKO.prev_jie(before).jieqi, (year, jq)
+        assert CEL.next_jie(before).jieqi == HKO.next_jie(before).jieqi, (year, jq)
+      after: datetime = moment + timedelta(seconds=1)
+      if after < cel_last and after < hko_last:
+        assert CEL.prev_jie(after).jieqi == HKO.prev_jie(after).jieqi, (year, jq)
+        assert CEL.next_jie(after).jieqi == HKO.next_jie(after).jieqi, (year, jq)
 
-    self.assertEqual(measured_ganzhi, expected)
-    self.assertEqual(measured_via_lunar, expected)
-    # Two moved 节, each shifting one ganzhi month: 30 and 31 days.
-    self.assertEqual(len(expected), 61)
 
-  def test_days_counts_disagrees_on_exactly_the_derived_years(self) -> None:
-    expected: set[int] = {year for year, _ in affected_ganzhi_months()}
-    measured: set[int] = {year for year in range(1901, 2100)
-                          if CEL.days_counts_in_ganzhi_year(year) != HKO.days_counts_in_ganzhi_year(year)}
-    self.assertEqual(measured, expected)
-    # A moved 节 makes one month longer and its neighbour shorter, so the year still adds up.
-    for year in expected:
-      self.assertEqual(sum(CEL.days_counts_in_ganzhi_year(year)),
-                       sum(HKO.days_counts_in_ganzhi_year(year)))
+def test_the_derivations_preconditions_hold() -> None:
+  '''
+  `affected_ganzhi_months` models a flipped 节 as moving the start of exactly one ganzhi
+  month.  That holds for every 节 except 立春, which is also the *end* of the previous
+  ganzhi year's twelfth month: a flipped 立春 would perturb `(Y - 1, 12)` too, and would
+  falsify the "yearly totals unchanged" check below, since the day gained and the day lost
+  would land in different ganzhi years.
 
-  def test_ganzhi_side_disagreements_stay_in_the_derived_months(self) -> None:
-    expected_months: set[tuple[int, int]] = affected_ganzhi_months()
-    measured_months: set[tuple[int, int]] = set()
-    measured_validity: set[tuple[int, int, int]] = set()
+  No shipped table flips 立春, so rather than carry untested branches for a configuration
+  that does not exist, the assumption is asserted here: if a re-baked table ever flips one,
+  this fails first and names what to generalise.  Layer (c) stays *sound* either way --
+  every test there compares a measured set against the derived one, so an unmodelled
+  divergence still turns the suite red.  What this guard protects is the diagnosis.
+  '''
+  assert Jieqi.立春 not in {jieqi_of(row) for row in flipped_jies()}, (
+    'a flipped 立春 also moves (Y - 1, 12): generalise `affected_ganzhi_months` and the '
+    'yearly-total assertion before deleting this guard')
 
-    for year in range(1901, 2100):
-      cel_counts: list[int] = CEL.days_counts_in_ganzhi_year(year)
-      hko_counts: list[int] = HKO.days_counts_in_ganzhi_year(year)
-      for month in range(1, 13):
-        for day in range(1, max(cel_counts[month - 1], hko_counts[month - 1]) + 1):
-          d: CalendarDate = CalendarDate(year, month, day, CalendarType.GANZHI)
-          cel_valid, hko_valid = CEL.is_valid_ganzhi_date(d), HKO.is_valid_ganzhi_date(d)
-          if cel_valid != hko_valid:
-            measured_validity.add((year, month, day))
-            continue
-          if not cel_valid:
-            continue
-          if (CEL.ganzhi_to_solar(d) != HKO.ganzhi_to_solar(d)
-              or CEL.ganzhi_to_lunar(d) != HKO.ganzhi_to_lunar(d)):
-            measured_months.add((year, month))
+  # The same reasoning at the window edge: the derived days are checked against a scan
+  # bounded by the supported solar range, so a flip in the final month would push the
+  # derived set past where that scan can see it.
+  last: date = HKO.to_date(HKO.get_max_supported_date(CalendarType.SOLAR))
+  assert max(affected_solar_days()) <= last
 
-    self.assertEqual(measured_months, expected_months)
-    # Validity can only differ where the month lengths do: the days in between the two.
-    expected_validity: set[tuple[int, int, int]] = set()
-    for year, _ in expected_months:
-      cel_counts = CEL.days_counts_in_ganzhi_year(year)
-      hko_counts = HKO.days_counts_in_ganzhi_year(year)
-      for month in range(1, 13):
-        lo, hi = sorted((cel_counts[month - 1], hko_counts[month - 1]))
-        expected_validity |= {(year, month, day) for day in range(lo + 1, hi + 1)}
-    self.assertEqual(measured_validity, expected_validity)
+
+# Layer (a): celestial's algo1 is the same HKO almanac data, so this is strict.
+
+def test_no_disagreement_anywhere() -> None:
+  day: date = HKO.to_date(HKO.get_min_supported_date(CalendarType.SOLAR))
+  last: date = HKO.to_date(HKO.get_max_supported_date(CalendarType.SOLAR))
+  while day <= last:
+    d: CalendarDate = solar(day)
+    assert CEL.solar_to_lunar(d) == HKO.solar_to_lunar(d), day
+    day += timedelta(days=1)
+
+
+def test_lunar_dates_round_trip_identically() -> None:
+  for year in range(1901, 2100):
+    for month in range(1, 14):
+      d: CalendarDate = CalendarDate(year, month, 1, CalendarType.LUNAR)
+      assert CEL.is_valid_lunar_date(d) == HKO.is_valid_lunar_date(d)
+      if CEL.is_valid_lunar_date(d):
+        assert CEL.lunar_to_solar(d) == HKO.lunar_to_solar(d)
+
+
+def test_bounds() -> None:
+  # celestial derives these from its tables, HKO hardcodes them; they must still agree,
+  # because the two backends cover the same physical window.
+  for date_type in CalendarType:
+    assert CEL.get_min_supported_date(date_type) == HKO.get_min_supported_date(date_type)
+    assert CEL.get_max_supported_date(date_type) == HKO.get_max_supported_date(date_type)
+
+
+# Layer (c): every expectation below is computed from the whitelist.
+
+def test_solar_side_disagreements_are_exactly_derived() -> None:
+  expected: set[date] = affected_solar_days()
+  measured_ganzhi: set[date] = set()
+  measured_via_lunar: set[date] = set()
+
+  day: date = HKO.to_date(HKO.get_min_supported_date(CalendarType.SOLAR))
+  last: date = HKO.to_date(HKO.get_max_supported_date(CalendarType.SOLAR))
+  while day <= last:
+    d: CalendarDate = solar(day)
+    if CEL.solar_to_ganzhi(d) != HKO.solar_to_ganzhi(d):
+      measured_ganzhi.add(day)
+    if CEL.lunar_to_ganzhi(CEL.solar_to_lunar(d)) != HKO.lunar_to_ganzhi(HKO.solar_to_lunar(d)):
+      measured_via_lunar.add(day)
+    day += timedelta(days=1)
+
+  assert measured_ganzhi == expected
+  assert measured_via_lunar == expected
+  # Two moved 节, each shifting one ganzhi month: 30 and 31 days.
+  assert len(expected) == 61
+
+
+def test_days_counts_disagrees_on_exactly_the_derived_years() -> None:
+  expected: set[int] = {year for year, _ in affected_ganzhi_months()}
+  measured: set[int] = {year for year in range(1901, 2100)
+                        if CEL.days_counts_in_ganzhi_year(year) != HKO.days_counts_in_ganzhi_year(year)}
+  assert measured == expected
+  # A moved 节 makes one month longer and its neighbour shorter, so the year still adds up.
+  for year in expected:
+    assert sum(CEL.days_counts_in_ganzhi_year(year)) == \
+           sum(HKO.days_counts_in_ganzhi_year(year))
+
+
+def test_ganzhi_side_disagreements_stay_in_the_derived_months() -> None:
+  expected_months: set[tuple[int, int]] = affected_ganzhi_months()
+  measured_months: set[tuple[int, int]] = set()
+  measured_validity: set[tuple[int, int, int]] = set()
+
+  for year in range(1901, 2100):
+    cel_counts: list[int] = CEL.days_counts_in_ganzhi_year(year)
+    hko_counts: list[int] = HKO.days_counts_in_ganzhi_year(year)
+    for month in range(1, 13):
+      for day in range(1, max(cel_counts[month - 1], hko_counts[month - 1]) + 1):
+        d: CalendarDate = CalendarDate(year, month, day, CalendarType.GANZHI)
+        cel_valid, hko_valid = CEL.is_valid_ganzhi_date(d), HKO.is_valid_ganzhi_date(d)
+        if cel_valid != hko_valid:
+          measured_validity.add((year, month, day))
+          continue
+        if not cel_valid:
+          continue
+        if (CEL.ganzhi_to_solar(d) != HKO.ganzhi_to_solar(d)
+            or CEL.ganzhi_to_lunar(d) != HKO.ganzhi_to_lunar(d)):
+          measured_months.add((year, month))
+
+  assert measured_months == expected_months
+  # Validity can only differ where the month lengths do: the days in between the two.
+  expected_validity: set[tuple[int, int, int]] = set()
+  for year, _ in expected_months:
+    cel_counts = CEL.days_counts_in_ganzhi_year(year)
+    hko_counts = HKO.days_counts_in_ganzhi_year(year)
+    for month in range(1, 13):
+      lo, hi = sorted((cel_counts[month - 1], hko_counts[month - 1]))
+      expected_validity |= {(year, month, day) for day in range(lo + 1, hi + 1)}
+  assert measured_validity == expected_validity

--- a/tests/calendar/test_celestial_tables.py
+++ b/tests/calendar/test_celestial_tables.py
@@ -31,14 +31,18 @@ from celestial_parity_data import (
 
 DATA_DIR: Final[Path] = Path(__file__).parents[2] / 'src' / 'calendar' / 'celestial_data' / 'data'
 
+
 JIEQI_TABLE_PATH: Final[Path] = DATA_DIR / 'jieqi_moments.txt'
 ALGO1_TABLE_PATH: Final[Path] = DATA_DIR / 'lunar_years_algo1.txt'
 ALGO2_TABLE_PATH: Final[Path] = DATA_DIR / 'lunar_years_algo2.txt'
 
+
 FIXTURE_DIR: Final[Path] = Path(__file__).parent / 'celestial_fixtures'
+
 
 JIEQI_LIST: Final[list[Jieqi]] = list(Jieqi)
 SEXAGENARY_CYCLE: Final[list[Ganzhi]] = Ganzhi.list_sexagenary_cycle()
+
 
 # SCHEMA.md's closed provenance namespace, restated here as the assertable form of it.
 _COMMON_HEADER_KEYS: Final[frozenset[str]] = frozenset({
@@ -51,6 +55,7 @@ LUNAR_HEADER_KEYS: Final[frozenset[str]] = _COMMON_HEADER_KEYS | {'algo'}
 
 # ---------------------------------------------------------------------------
 # Minimal independent table reader (SCHEMA.md; header continuation lines are folded away)
+
 
 def _read_table(path: Path) -> tuple[dict[str, str], list[list[str]]]:
   header: dict[str, str] = {}
@@ -78,6 +83,7 @@ class _JieqiRow(NamedTuple):
   name:   str
   moment: datetime
 
+
 def _parse_jieqi_rows(raw_rows: list[list[str]]) -> list[_JieqiRow]:
   return [
     _JieqiRow(
@@ -98,6 +104,7 @@ class _LunarRow(NamedTuple):
   days_counts:      tuple[int, ...]
   ganzhi:           str
 
+
 def _parse_lunar_rows(raw_rows: list[list[str]]) -> list[_LunarRow]:
   return [
     _LunarRow(
@@ -116,6 +123,7 @@ def _load_jieqi_table() -> tuple[dict[str, str], list[list[str]], list[_JieqiRow
   header, raw_rows = _read_table(JIEQI_TABLE_PATH)
   return header, raw_rows, _parse_jieqi_rows(raw_rows)
 
+
 def _load_lunar_table(path: Path) -> tuple[dict[str, str], list[_LunarRow]]:
   header, raw_rows = _read_table(path)
   return header, _parse_lunar_rows(raw_rows)
@@ -130,6 +138,7 @@ def _load_lunar_table(path: Path) -> tuple[dict[str, str], list[_LunarRow]]:
 #
 # The contract is stated in three independent places -- this file, the generator, and the
 # loader's regex -- so nothing but a test can keep them from drifting apart.
+
 
 def test_shipped_tables() -> None:
   for path, expected in ((JIEQI_TABLE_PATH, JIEQI_HEADER_KEYS),
@@ -150,6 +159,7 @@ def test_fixtures() -> None:
 
 
 # The jieqi table itself: row count, ordering, jq_idx <-> name, the 小寒/大寒 January note.
+
 
 def test_header_and_row_count() -> None:
   header, raw_rows, _ = _load_jieqi_table()
@@ -180,6 +190,7 @@ def test_row_sequence_and_names() -> None:
 # The divergences must be exactly the frozen whitelist in `celestial_parity_data.py`
 # -- the entry count itself is asserted, so a new unexplained divergence turns this red.
 
+
 def test_whitelist_self_consistency() -> None:
   assert len(JIEQI_DATE_DIVERGENCES) == 7
   assert len({ (d.year, d.jq_idx) for d in JIEQI_DATE_DIVERGENCES }) == 7 # No duplicate keys.
@@ -191,8 +202,7 @@ def test_whitelist_self_consistency() -> None:
     assert abs((divergence.celestial_moment.date() - divergence.hko_date).days) == 1
   # The only two 节 (month boundaries) are 1917 大雪 and 1927 白露 -- the entries that
   # propagate into the ganzhi-calendar methods.
-  assert { (d.year, d.name) for d in JIEQI_DATE_DIVERGENCES if d.is_jie } == \
-         { (1917, '大雪'), (1927, '白露') }
+  assert { (d.year, d.name) for d in JIEQI_DATE_DIVERGENCES if d.is_jie } == { (1917, '大雪'), (1927, '白露') }
 
 
 def test_dates_vs_hko() -> None:
@@ -217,6 +227,7 @@ def test_dates_vs_hko() -> None:
 
 # ---------------------------------------------------------------------------
 # The lunar tables themselves: row count, bitmask <-> days_counts round-trip, ganzhi formula.
+
 
 def _check_shape(path: Path) -> list[_LunarRow]:
   header, rows = _load_lunar_table(path)
@@ -259,6 +270,7 @@ def test_algo2_shape() -> None:
 # (`first_solar_date` / `leap_month` / `days_counts` / `ganzhi`).
 # algo1 is HKO-lineage and must match 199/199; algo2 diverges on exactly the six
 # whitelisted years (`ALGO2_DIVERGENT_YEARS`).
+
 
 def _hko_differences(rows: list[_LunarRow]) -> dict[int, list[str]]:
   '''Field-level differences against hko_data, keyed by lunar year (empty means a match).'''
@@ -311,6 +323,7 @@ def test_ganzhi_matches_hko() -> None:
 # The documentary algo1 x algo2 diff: since algo1 matches HKO 199/199, algo2's
 # differences from HKO are exactly its differences from algo1 -- the same six years
 # as celestial `src/test/lunar/diff_test.cpp`.
+
 
 def test_divergent_years() -> None:
   _, algo1_rows = _load_lunar_table(ALGO1_TABLE_PATH)

--- a/tests/calendar/test_celestial_tables.py
+++ b/tests/calendar/test_celestial_tables.py
@@ -13,8 +13,6 @@
 # 2033 issue agree by construction); the truth side is covered by celestial's own
 # HKO x DE441 dual-axis validation (0.525 min).
 
-import unittest
-
 from datetime import date, datetime
 from pathlib import Path
 from typing import Final, NamedTuple
@@ -124,225 +122,207 @@ def _load_lunar_table(path: Path) -> tuple[dict[str, str], list[_LunarRow]]:
 
 
 # ---------------------------------------------------------------------------
+# Header keys are closed: SCHEMA.md declares the provenance namespace closed, and a column
+# name must never take a key of its own: `# leap_month: 1..12, or 0 when the year has no
+# leap month.` reads to every parser here and in `loader` as a provenance key whose value
+# happens to be a sentence.  Prose about a column belongs on continuation lines under
+# `columns`.
+#
+# The contract is stated in three independent places -- this file, the generator, and the
+# loader's regex -- so nothing but a test can keep them from drifting apart.
 
-class TestHeaderKeysAreClosed(unittest.TestCase):
-  '''
-  SCHEMA.md declares the provenance namespace closed, and a column name must never take a
-  key of its own: `# leap_month: 1..12, or 0 when the year has no leap month.` reads to every
-  parser here and in `loader` as a provenance key whose value happens to be a sentence.
-  Prose about a column belongs on continuation lines under `columns`.
-
-  The contract is stated in three independent places -- this file, the generator, and the
-  loader's regex -- so nothing but a test can keep them from drifting apart.
-  '''
-
-  def test_shipped_tables(self) -> None:
-    for path, expected in ((JIEQI_TABLE_PATH, JIEQI_HEADER_KEYS),
-                           (ALGO1_TABLE_PATH, LUNAR_HEADER_KEYS),
-                           (ALGO2_TABLE_PATH, LUNAR_HEADER_KEYS)):
-      with self.subTest(table=path.name):
-        header, _ = _read_table(path)
-        self.assertEqual(frozenset(header), expected)
-
-  def test_fixtures(self) -> None:
-    # The fixtures carry one key more and are otherwise the same format, which is the whole
-    # point of them: a loader that passes on a fixture is reading the shipped layout.
-    for name, expected in (('jieqi_moments.txt', JIEQI_HEADER_KEYS),
-                           ('lunar_years_algo1.txt', LUNAR_HEADER_KEYS),
-                           ('lunar_years_algo2.txt', LUNAR_HEADER_KEYS)):
-      with self.subTest(fixture=name):
-        header, _ = _read_table(FIXTURE_DIR / name)
-        self.assertEqual(frozenset(header), expected | {'fixture'})
+def test_shipped_tables() -> None:
+  for path, expected in ((JIEQI_TABLE_PATH, JIEQI_HEADER_KEYS),
+                         (ALGO1_TABLE_PATH, LUNAR_HEADER_KEYS),
+                         (ALGO2_TABLE_PATH, LUNAR_HEADER_KEYS)):
+    header, _ = _read_table(path)
+    assert frozenset(header) == expected, path.name
 
 
-class TestJieqiTableShape(unittest.TestCase):
-  '''The jieqi table itself: row count, ordering, jq_idx <-> name, the 小寒/大寒 January note.'''
-
-  def test_header_and_row_count(self) -> None:
-    header, raw_rows, _ = _load_jieqi_table()
-    self.assertEqual(header['columns'], 'year jq_idx name date time')
-    self.assertEqual(header['rows'], '4800') # 200 years x 24 jieqis, exact.
-    self.assertEqual(len(raw_rows), 4800)
-    self.assertEqual(header['schema_version'], '1')
-    self.assertEqual(header['celestial_version'], '0.4.0')
-    self.assertEqual(header['timescale'].split(',')[0], 'UTC+08:00')
-    self.assertEqual(header['rounding'].split(' ')[0], 'truncate')
-
-  def test_row_sequence_and_names(self) -> None:
-    _, raw_rows, rows = _load_jieqi_table()
-    for i, (fields, row) in enumerate(zip(raw_rows, rows)):
-      self.assertEqual(fields[1], f'{i % 24:02d}') # jq_idx is zero-padded.
-      self.assertEqual(row.year, 1901 + i // 24)   # Rows ascend by (year, jq_idx).
-      self.assertEqual(row.jq_idx, i % 24)
-      self.assertEqual(row.name, JIEQI_LIST[row.jq_idx].value)
-      self.assertEqual(row.moment.microsecond, 0)  # Truncated to whole seconds.
-      if row.jq_idx in (22, 23): # 小寒/大寒 of year Y fall in January of Y (SCHEMA.md note).
-        self.assertEqual((row.moment.year, row.moment.month), (row.year, 1))
-      else:
-        self.assertEqual(row.moment.year, row.year)
+def test_fixtures() -> None:
+  # The fixtures carry one key more and are otherwise the same format, which is the whole
+  # point of them: a loader that passes on a fixture is reading the shipped layout.
+  for name, expected in (('jieqi_moments.txt', JIEQI_HEADER_KEYS),
+                         ('lunar_years_algo1.txt', LUNAR_HEADER_KEYS),
+                         ('lunar_years_algo2.txt', LUNAR_HEADER_KEYS)):
+    header, _ = _read_table(FIXTURE_DIR / name)
+    assert frozenset(header) == expected | {'fixture'}, name
 
 
-class TestJieqiDateParity(unittest.TestCase):
-  '''
-  Layer b: the table's jieqi DATES vs hko_data, over the whole window (200 x 24 = 4800).
-  The divergences must be exactly the frozen whitelist in `celestial_parity_data.py`
-  -- the entry count itself is asserted, so a new unexplained divergence turns this red.
-  '''
+# The jieqi table itself: row count, ordering, jq_idx <-> name, the 小寒/大寒 January note.
 
-  def test_whitelist_self_consistency(self) -> None:
-    self.assertEqual(len(JIEQI_DATE_DIVERGENCES), 7)
-    self.assertEqual(len({ (d.year, d.jq_idx) for d in JIEQI_DATE_DIVERGENCES }), 7) # No duplicate keys.
-    for divergence in JIEQI_DATE_DIVERGENCES:
-      self.assertEqual(divergence.name, JIEQI_LIST[divergence.jq_idx].value)
-      self.assertEqual(divergence.is_jie, divergence.jq_idx % 2 == 0)
-      self.assertEqual(divergence.celestial_moment.microsecond, 0)
-      # Every entry is a midnight-adjacent date flip, never more than one day.
-      self.assertEqual(abs((divergence.celestial_moment.date() - divergence.hko_date).days), 1)
-    # The only two 节 (month boundaries) are 1917 大雪 and 1927 白露 -- the entries that
-    # propagate into the ganzhi-calendar methods.
-    self.assertEqual(
-      { (d.year, d.name) for d in JIEQI_DATE_DIVERGENCES if d.is_jie },
-      { (1917, '大雪'), (1927, '白露') },
-    )
+def test_header_and_row_count() -> None:
+  header, raw_rows, _ = _load_jieqi_table()
+  assert header['columns'] == 'year jq_idx name date time'
+  assert header['rows'] == '4800' # 200 years x 24 jieqis, exact.
+  assert len(raw_rows) == 4800
+  assert header['schema_version'] == '1'
+  assert header['celestial_version'] == '0.4.0'
+  assert header['timescale'].split(',')[0] == 'UTC+08:00'
+  assert header['rounding'].split(' ')[0] == 'truncate'
 
-  def test_dates_vs_hko(self) -> None:
-    hko_jieqi: hko_data.DecodedJieqiDates = hko_data.DecodedJieqiDates()
-    _, _, rows = _load_jieqi_table()
 
-    divergences: dict[tuple[int, int], tuple[datetime, date]] = {}
-    for row in rows:
-      hko_date: date = hko_jieqi.get(row.year, JIEQI_LIST[row.jq_idx])
-      if row.moment.date() != hko_date:
-        divergences[(row.year, row.jq_idx)] = (row.moment, hko_date)
+def test_row_sequence_and_names() -> None:
+  _, raw_rows, rows = _load_jieqi_table()
+  for i, (fields, row) in enumerate(zip(raw_rows, rows)):
+    assert fields[1] == f'{i % 24:02d}' # jq_idx is zero-padded.
+    assert row.year == 1901 + i // 24   # Rows ascend by (year, jq_idx).
+    assert row.jq_idx == i % 24
+    assert row.name == JIEQI_LIST[row.jq_idx].value
+    assert row.moment.microsecond == 0  # Truncated to whole seconds.
+    if row.jq_idx in (22, 23): # 小寒/大寒 of year Y fall in January of Y (SCHEMA.md note).
+      assert (row.moment.year, row.moment.month) == (row.year, 1)
+    else:
+      assert row.moment.year == row.year
 
-    # The divergence keys are exactly the whitelist keys -- no more, no fewer.
-    self.assertEqual(
-      set(divergences),
-      { (d.year, d.jq_idx) for d in JIEQI_DATE_DIVERGENCES },
-    )
 
-    # ...and each divergence carries exactly the whitelisted values on both sides.
-    for divergence in JIEQI_DATE_DIVERGENCES:
-      moment, hko_date = divergences[(divergence.year, divergence.jq_idx)]
-      self.assertEqual(moment, divergence.celestial_moment)
-      self.assertEqual(hko_date, divergence.hko_date)
+# Layer b: the table's jieqi DATES vs hko_data, over the whole window (200 x 24 = 4800).
+# The divergences must be exactly the frozen whitelist in `celestial_parity_data.py`
+# -- the entry count itself is asserted, so a new unexplained divergence turns this red.
+
+def test_whitelist_self_consistency() -> None:
+  assert len(JIEQI_DATE_DIVERGENCES) == 7
+  assert len({ (d.year, d.jq_idx) for d in JIEQI_DATE_DIVERGENCES }) == 7 # No duplicate keys.
+  for divergence in JIEQI_DATE_DIVERGENCES:
+    assert divergence.name == JIEQI_LIST[divergence.jq_idx].value
+    assert divergence.is_jie == (divergence.jq_idx % 2 == 0)
+    assert divergence.celestial_moment.microsecond == 0
+    # Every entry is a midnight-adjacent date flip, never more than one day.
+    assert abs((divergence.celestial_moment.date() - divergence.hko_date).days) == 1
+  # The only two 节 (month boundaries) are 1917 大雪 and 1927 白露 -- the entries that
+  # propagate into the ganzhi-calendar methods.
+  assert { (d.year, d.name) for d in JIEQI_DATE_DIVERGENCES if d.is_jie } == \
+         { (1917, '大雪'), (1927, '白露') }
+
+
+def test_dates_vs_hko() -> None:
+  hko_jieqi: hko_data.DecodedJieqiDates = hko_data.DecodedJieqiDates()
+  _, _, rows = _load_jieqi_table()
+
+  divergences: dict[tuple[int, int], tuple[datetime, date]] = {}
+  for row in rows:
+    hko_date: date = hko_jieqi.get(row.year, JIEQI_LIST[row.jq_idx])
+    if row.moment.date() != hko_date:
+      divergences[(row.year, row.jq_idx)] = (row.moment, hko_date)
+
+  # The divergence keys are exactly the whitelist keys -- no more, no fewer.
+  assert set(divergences) == { (d.year, d.jq_idx) for d in JIEQI_DATE_DIVERGENCES }
+
+  # ...and each divergence carries exactly the whitelisted values on both sides.
+  for divergence in JIEQI_DATE_DIVERGENCES:
+    moment, hko_date = divergences[(divergence.year, divergence.jq_idx)]
+    assert moment == divergence.celestial_moment
+    assert hko_date == divergence.hko_date
 
 
 # ---------------------------------------------------------------------------
+# The lunar tables themselves: row count, bitmask <-> days_counts round-trip, ganzhi formula.
 
-class TestLunarTableShape(unittest.TestCase):
-  '''The lunar tables themselves: row count, bitmask <-> days_counts round-trip, ganzhi formula.'''
+def _check_shape(path: Path) -> list[_LunarRow]:
+  header, rows = _load_lunar_table(path)
+  assert header['columns'] == 'lunar_year first_solar_date leap_month month_len_bits days_counts ganzhi'
+  assert header['rows'] == '199' # 1901..2099, BOTH algos clamped to this window.
+  assert header['year_range'].split(' ')[0] == '1901..2099'
+  assert len(rows) == 199
 
-  def _check_shape(self, path: Path) -> list[_LunarRow]:
-    header, rows = _load_lunar_table(path)
-    self.assertEqual(header['columns'], 'lunar_year first_solar_date leap_month month_len_bits days_counts ganzhi')
-    self.assertEqual(header['rows'], '199') # 1901..2099, BOTH algos clamped to this window.
-    self.assertEqual(header['year_range'].split(' ')[0], '1901..2099')
-    self.assertEqual(len(rows), 199)
+  for i, row in enumerate(rows):
+    assert row.lunar_year == 1901 + i # Ascending, contiguous.
+    assert 0 <= row.leap_month <= 12
+    assert len(row.days_counts) == (12 if row.leap_month == 0 else 13)
 
-    for i, row in enumerate(rows):
-      self.assertEqual(row.lunar_year, 1901 + i) # Ascending, contiguous.
-      self.assertTrue(0 <= row.leap_month <= 12)
-      self.assertEqual(len(row.days_counts), 12 if row.leap_month == 0 else 13)
+    # The bitmask must round-trip through days_counts, with no stray high bits.
+    assert row.month_len_bits >> len(row.days_counts) == 0
+    reencoded: int = 0
+    for bit, count in enumerate(row.days_counts):
+      assert count in (29, 30)
+      reencoded |= (1 << bit) if count == 30 else 0
+    assert reencoded == row.month_len_bits
 
-      # The bitmask must round-trip through days_counts, with no stray high bits.
-      self.assertEqual(row.month_len_bits >> len(row.days_counts), 0)
-      reencoded: int = 0
-      for bit, count in enumerate(row.days_counts):
-        self.assertIn(count, (29, 30))
-        reencoded |= (1 << bit) if count == 30 else 0
-      self.assertEqual(reencoded, row.month_len_bits)
+    # The ganzhi column follows the (lunar_year - 4) mod 60 formula.
+    assert row.ganzhi == str(SEXAGENARY_CYCLE[(row.lunar_year - 4) % 60])
 
-      # The ganzhi column follows the (lunar_year - 4) mod 60 formula.
-      self.assertEqual(row.ganzhi, str(SEXAGENARY_CYCLE[(row.lunar_year - 4) % 60]))
-
-      # Lunar new year falls in January/February of the same Gregorian year.
-      self.assertEqual(row.first_solar_date.year, row.lunar_year)
-      self.assertIn(row.first_solar_date.month, (1, 2))
-    return rows
-
-  def test_algo1_shape(self) -> None:
-    self._check_shape(ALGO1_TABLE_PATH)
-
-  def test_algo2_shape(self) -> None:
-    self._check_shape(ALGO2_TABLE_PATH)
+    # Lunar new year falls in January/February of the same Gregorian year.
+    assert row.first_solar_date.year == row.lunar_year
+    assert row.first_solar_date.month in (1, 2)
+  return rows
 
 
-class TestLunarParity(unittest.TestCase):
-  '''
-  Layer a: the lunar tables vs hko_data, field by field
-  (`first_solar_date` / `leap_month` / `days_counts` / `ganzhi`).
-  algo1 is HKO-lineage and must match 199/199; algo2 diverges on exactly the six
-  whitelisted years (`ALGO2_DIVERGENT_YEARS`).
-  '''
-
-  def _hko_differences(self, rows: list[_LunarRow]) -> dict[int, list[str]]:
-    '''Field-level differences against hko_data, keyed by lunar year (empty means a match).'''
-    hko_lunar: hko_data.DecodedLunarYears = hko_data.DecodedLunarYears()
-    differences: dict[int, list[str]] = {}
-    for row in rows:
-      hko: hko_data.LunarYearInfo = hko_lunar.get(row.lunar_year)
-      diffs: list[str] = []
-      if row.first_solar_date != hko['first_solar_day']:
-        diffs.append(f'first_solar_date {row.first_solar_date} vs HKO {hko["first_solar_day"]}')
-      # hko_data spells "no leap month" as None; the table uses 0. Normalise when comparing.
-      if (row.leap_month if row.leap_month != 0 else None) != hko['leap_month']:
-        diffs.append(f'leap_month {row.leap_month} vs HKO {hko["leap_month"]}')
-      if list(row.days_counts) != hko['days_counts']:
-        diffs.append(f'days_counts {list(row.days_counts)} vs HKO {hko["days_counts"]}')
-      if row.ganzhi != str(hko['ganzhi']):
-        diffs.append(f'ganzhi {row.ganzhi} vs HKO {hko["ganzhi"]}')
-      if diffs:
-        differences[row.lunar_year] = diffs
-    return differences
-
-  def test_algo1_matches_hko_strictly(self) -> None:
-    _, rows = _load_lunar_table(ALGO1_TABLE_PATH)
-    self.assertEqual(len(rows), 199)
-    # 199/199: any field-level difference in any year fails the test, with details.
-    self.assertEqual(self._hko_differences(rows), {})
-
-  def test_algo2_diverges_exactly_on_whitelist_years(self) -> None:
-    _, rows = _load_lunar_table(ALGO2_TABLE_PATH)
-    self.assertEqual(len(rows), 199)
-    differences: dict[int, list[str]] = self._hko_differences(rows)
-    self.assertEqual(sorted(differences), list(ALGO2_DIVERGENT_YEARS))
-    self.assertEqual(len(differences), 6)
-
-  def test_ganzhi_matches_hko(self) -> None:
-    hko_lunar: hko_data.DecodedLunarYears = hko_data.DecodedLunarYears()
-    for path in (ALGO1_TABLE_PATH, ALGO2_TABLE_PATH):
-      _, rows = _load_lunar_table(path)
-      mismatches: list[str] = [
-        f'{row.lunar_year}: {row.ganzhi} vs HKO {hko_lunar.get(row.lunar_year)["ganzhi"]}'
-        for row in rows
-        if row.ganzhi != str(hko_lunar.get(row.lunar_year)['ganzhi'])
-      ]
-      self.assertEqual(mismatches, []) # 199/199 for both tables.
+def test_algo1_shape() -> None:
+  _check_shape(ALGO1_TABLE_PATH)
 
 
-class TestAlgo1Algo2MutualDiff(unittest.TestCase):
-  '''
-  The documentary algo1 x algo2 diff: since algo1 matches HKO 199/199, algo2's
-  differences from HKO are exactly its differences from algo1 -- the same six years
-  as celestial `src/test/lunar/diff_test.cpp`.
-  '''
-
-  def test_divergent_years(self) -> None:
-    _, algo1_rows = _load_lunar_table(ALGO1_TABLE_PATH)
-    _, algo2_rows = _load_lunar_table(ALGO2_TABLE_PATH)
-    self.assertEqual([r.lunar_year for r in algo1_rows], [r.lunar_year for r in algo2_rows])
-
-    divergent_years: list[int] = []
-    for algo1_row, algo2_row in zip(algo1_rows, algo2_rows):
-      # The ganzhi column derives from the lunar year alone, so it never diverges.
-      self.assertEqual(algo1_row.ganzhi, algo2_row.ganzhi)
-      if (algo1_row.first_solar_date, algo1_row.leap_month, algo1_row.month_len_bits, algo1_row.days_counts) != \
-         (algo2_row.first_solar_date, algo2_row.leap_month, algo2_row.month_len_bits, algo2_row.days_counts):
-        divergent_years.append(algo1_row.lunar_year)
-
-    self.assertEqual(divergent_years, list(ALGO2_DIVERGENT_YEARS))
+def test_algo2_shape() -> None:
+  _check_shape(ALGO2_TABLE_PATH)
 
 
-if __name__ == '__main__':
-  unittest.main()
+# Layer a: the lunar tables vs hko_data, field by field
+# (`first_solar_date` / `leap_month` / `days_counts` / `ganzhi`).
+# algo1 is HKO-lineage and must match 199/199; algo2 diverges on exactly the six
+# whitelisted years (`ALGO2_DIVERGENT_YEARS`).
+
+def _hko_differences(rows: list[_LunarRow]) -> dict[int, list[str]]:
+  '''Field-level differences against hko_data, keyed by lunar year (empty means a match).'''
+  hko_lunar: hko_data.DecodedLunarYears = hko_data.DecodedLunarYears()
+  differences: dict[int, list[str]] = {}
+  for row in rows:
+    hko: hko_data.LunarYearInfo = hko_lunar.get(row.lunar_year)
+    diffs: list[str] = []
+    if row.first_solar_date != hko['first_solar_day']:
+      diffs.append(f'first_solar_date {row.first_solar_date} vs HKO {hko["first_solar_day"]}')
+    # hko_data spells "no leap month" as None; the table uses 0. Normalise when comparing.
+    if (row.leap_month if row.leap_month != 0 else None) != hko['leap_month']:
+      diffs.append(f'leap_month {row.leap_month} vs HKO {hko["leap_month"]}')
+    if list(row.days_counts) != hko['days_counts']:
+      diffs.append(f'days_counts {list(row.days_counts)} vs HKO {hko["days_counts"]}')
+    if row.ganzhi != str(hko['ganzhi']):
+      diffs.append(f'ganzhi {row.ganzhi} vs HKO {hko["ganzhi"]}')
+    if diffs:
+      differences[row.lunar_year] = diffs
+  return differences
+
+
+def test_algo1_matches_hko_strictly() -> None:
+  _, rows = _load_lunar_table(ALGO1_TABLE_PATH)
+  assert len(rows) == 199
+  # 199/199: any field-level difference in any year fails the test, with details.
+  assert _hko_differences(rows) == {}
+
+
+def test_algo2_diverges_exactly_on_whitelist_years() -> None:
+  _, rows = _load_lunar_table(ALGO2_TABLE_PATH)
+  assert len(rows) == 199
+  differences: dict[int, list[str]] = _hko_differences(rows)
+  assert sorted(differences) == list(ALGO2_DIVERGENT_YEARS)
+  assert len(differences) == 6
+
+
+def test_ganzhi_matches_hko() -> None:
+  hko_lunar: hko_data.DecodedLunarYears = hko_data.DecodedLunarYears()
+  for path in (ALGO1_TABLE_PATH, ALGO2_TABLE_PATH):
+    _, rows = _load_lunar_table(path)
+    mismatches: list[str] = [
+      f'{row.lunar_year}: {row.ganzhi} vs HKO {hko_lunar.get(row.lunar_year)["ganzhi"]}'
+      for row in rows
+      if row.ganzhi != str(hko_lunar.get(row.lunar_year)['ganzhi'])
+    ]
+    assert mismatches == [] # 199/199 for both tables.
+
+
+# The documentary algo1 x algo2 diff: since algo1 matches HKO 199/199, algo2's
+# differences from HKO are exactly its differences from algo1 -- the same six years
+# as celestial `src/test/lunar/diff_test.cpp`.
+
+def test_divergent_years() -> None:
+  _, algo1_rows = _load_lunar_table(ALGO1_TABLE_PATH)
+  _, algo2_rows = _load_lunar_table(ALGO2_TABLE_PATH)
+  assert [r.lunar_year for r in algo1_rows] == [r.lunar_year for r in algo2_rows]
+
+  divergent_years: list[int] = []
+  for algo1_row, algo2_row in zip(algo1_rows, algo2_rows):
+    # The ganzhi column derives from the lunar year alone, so it never diverges.
+    assert algo1_row.ganzhi == algo2_row.ganzhi
+    if (algo1_row.first_solar_date, algo1_row.leap_month, algo1_row.month_len_bits, algo1_row.days_counts) != \
+       (algo2_row.first_solar_date, algo2_row.leap_month, algo2_row.month_len_bits, algo2_row.days_counts):
+      divergent_years.append(algo1_row.lunar_year)
+
+  assert divergent_years == list(ALGO2_DIVERGENT_YEARS)

--- a/tests/calendar/test_celestial_utils.py
+++ b/tests/calendar/test_celestial_utils.py
@@ -217,11 +217,9 @@ def test_exactly_on_a_jie_belongs_to_it() -> None:
 
 def test_jie_across_year_boundaries() -> None:
   # Before 小寒 of its own year, the previous Jie is last year's 大雪.
-  assert ALGO1.prev_jie(datetime(2024, 1, 1)) == \
-         (Jieqi.大雪, ALGO1.jieqi_moment(2023, Jieqi.大雪))
+  assert ALGO1.prev_jie(datetime(2024, 1, 1)) == (Jieqi.大雪, ALGO1.jieqi_moment(2023, Jieqi.大雪))
   # On or after 大雪, the next Jie is next year's 小寒.
-  assert ALGO1.next_jie(datetime(2024, 12, 20)) == \
-         (Jieqi.小寒, ALGO1.jieqi_moment(2025, Jieqi.小寒))
+  assert ALGO1.next_jie(datetime(2024, 12, 20)) == (Jieqi.小寒, ALGO1.jieqi_moment(2025, Jieqi.小寒))
 
 
 def test_prev_and_next_bracket_every_jie() -> None:

--- a/tests/calendar/test_celestial_utils.py
+++ b/tests/calendar/test_celestial_utils.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2026 Ningqi Wang (0xf3cd) <https://github.com/0xf3cd>
 # test_celestial_utils.py
 
-import unittest
+import pytest
 
 from datetime import date, datetime, timedelta
 
@@ -27,232 +27,243 @@ def ganzhi(year: int, month: int, day: int) -> CalendarDate:
   return CalendarDate(year, month, day, CalendarType.GANZHI)
 
 
-class TestProtocolConformance(unittest.TestCase):
-  def test_conforms(self) -> None:
-    for utils in (ALGO1, ALGO2):
-      self.assertIsInstance(utils, CalendarUtilsProtocol)
-
-  def test_the_two_algos_are_separate_objects(self) -> None:
-    # A shared mutable switch plus `lru_cache` would let a switch return results computed
-    # under the previous algorithm; separate instances make that impossible.
-    self.assertIsNot(ALGO1, ALGO2)
+def test_conforms() -> None:
+  for utils in (ALGO1, ALGO2):
+    assert isinstance(utils, CalendarUtilsProtocol)
 
 
-class TestSupportedRange(unittest.TestCase):
-  def test_derived_bounds(self) -> None:
-    # Derived from the tables, not hardcoded: the solar bounds are the anchor and the
-    # other four are conversions of them.
-    self.assertEqual(ALGO1.get_min_supported_date(CalendarType.SOLAR), solar(1901, 2, 19))
-    self.assertEqual(ALGO1.get_max_supported_date(CalendarType.SOLAR), solar(2099, 12, 31))
-    self.assertEqual(ALGO1.get_min_supported_date(CalendarType.LUNAR), lunar(1901, 1, 1))
-    self.assertEqual(ALGO1.get_max_supported_date(CalendarType.LUNAR), lunar(2099, 12, 20))
-    self.assertEqual(ALGO1.get_min_supported_date(CalendarType.GANZHI), ganzhi(1901, 1, 16))
-    self.assertEqual(ALGO1.get_max_supported_date(CalendarType.GANZHI), ganzhi(2099, 11, 25))
-
-  def test_the_three_bounds_are_one_physical_day(self) -> None:
-    # This is why per-date-type ranges would be wrong: they are the same day, spelled three
-    # ways.  A conversion of either bound must stay inside the window on all three axes.
-    for bound in (ALGO1.get_min_supported_date, ALGO1.get_max_supported_date):
-      day: date = ALGO1.to_date(bound(CalendarType.SOLAR))
-      self.assertEqual(ALGO1.to_date(bound(CalendarType.LUNAR)), day)
-      self.assertEqual(ALGO1.to_date(bound(CalendarType.GANZHI)), day)
+def test_the_two_algos_are_separate_objects() -> None:
+  # A shared mutable switch plus `lru_cache` would let a switch return results computed
+  # under the previous algorithm; separate instances make that impossible.
+  assert ALGO1 is not ALGO2
 
 
-class TestValidity(unittest.TestCase):
-  def test_solar(self) -> None:
-    self.assertTrue(ALGO1.is_valid_solar_date(solar(2024, 2, 4)))
-    self.assertFalse(ALGO1.is_valid_solar_date(lunar(2024, 2, 4))) # Wrong date type.
-    self.assertFalse(ALGO1.is_valid_solar_date(solar(1901, 2, 18))) # One day before min.
-    self.assertFalse(ALGO1.is_valid_solar_date(solar(2100, 1, 1))) # Past max.
-    self.assertFalse(ALGO1.is_valid_solar_date(solar(2023, 2, 29))) # Not a leap year.
-    self.assertTrue(ALGO1.is_valid_solar_date(solar(2024, 2, 29))) # A leap year.
-    self.assertFalse(ALGO1.is_valid_solar_date(solar(2024, 13, 1))) # No such month.
-
-  def test_lunar(self) -> None:
-    self.assertTrue(ALGO1.is_valid_lunar_date(lunar(2024, 1, 1)))
-    self.assertFalse(ALGO1.is_valid_lunar_date(solar(2024, 1, 1))) # Wrong date type.
-    self.assertFalse(ALGO1.is_valid_lunar_date(lunar(1900, 12, 1))) # Before min.
-    self.assertFalse(ALGO1.is_valid_lunar_date(lunar(2099, 12, 21))) # Past max.
-    self.assertFalse(ALGO1.is_valid_lunar_date(lunar(2024, 13, 1))) # 2024 has 12 lunar months.
-    self.assertTrue(ALGO1.is_valid_lunar_date(lunar(2023, 13, 1))) # 2023 is a leap lunar year.
-    self.assertFalse(ALGO1.is_valid_lunar_date(lunar(2024, 1, 0)))
-    self.assertFalse(ALGO1.is_valid_lunar_date(lunar(2024, 1, 31)))
-
-  def test_ganzhi(self) -> None:
-    self.assertTrue(ALGO1.is_valid_ganzhi_date(ganzhi(2024, 1, 1)))
-    self.assertFalse(ALGO1.is_valid_ganzhi_date(solar(2024, 1, 1))) # Wrong date type.
-    self.assertFalse(ALGO1.is_valid_ganzhi_date(ganzhi(1901, 1, 15))) # Before min.
-    self.assertFalse(ALGO1.is_valid_ganzhi_date(ganzhi(2099, 11, 26))) # Past max.
-    self.assertFalse(ALGO1.is_valid_ganzhi_date(ganzhi(2024, 13, 1))) # 12 ganzhi months only.
-    self.assertFalse(ALGO1.is_valid_ganzhi_date(ganzhi(2024, 1, 0)))
-    self.assertFalse(ALGO1.is_valid_ganzhi_date(ganzhi(2024, 1, 33)))
-
-  def test_dispatch(self) -> None:
-    self.assertTrue(ALGO1.is_valid(solar(2024, 2, 4)))
-    self.assertTrue(ALGO1.is_valid(lunar(2024, 1, 1)))
-    self.assertTrue(ALGO1.is_valid(ganzhi(2024, 1, 1)))
-    self.assertFalse(ALGO1.is_valid(solar(2100, 1, 1)))
+def test_derived_bounds() -> None:
+  # Derived from the tables, not hardcoded: the solar bounds are the anchor and the
+  # other four are conversions of them.
+  assert ALGO1.get_min_supported_date(CalendarType.SOLAR) == solar(1901, 2, 19)
+  assert ALGO1.get_max_supported_date(CalendarType.SOLAR) == solar(2099, 12, 31)
+  assert ALGO1.get_min_supported_date(CalendarType.LUNAR) == lunar(1901, 1, 1)
+  assert ALGO1.get_max_supported_date(CalendarType.LUNAR) == lunar(2099, 12, 20)
+  assert ALGO1.get_min_supported_date(CalendarType.GANZHI) == ganzhi(1901, 1, 16)
+  assert ALGO1.get_max_supported_date(CalendarType.GANZHI) == ganzhi(2099, 11, 25)
 
 
-class TestConversions(unittest.TestCase):
-  def test_ganzhi_month_lengths(self) -> None:
-    counts: list[int] = ALGO1.days_counts_in_ganzhi_year(2024)
-    self.assertEqual(len(counts), 12)
-    # A ganzhi year runs 立春 to 立春, so the months must add up to exactly that span.
-    span: int = (ALGO1.jieqi_date(2025, Jieqi.立春) - ALGO1.jieqi_date(2024, Jieqi.立春)).days
-    self.assertEqual(sum(counts), span)
-
-  def test_ganzhi_month_lengths_cannot_poison_the_cache(self) -> None:
-    '''
-    The lengths come from a cache, so handing back the cached list itself would let one
-    caller's in-place edit corrupt every later answer.  Worse, it would not stay contained:
-    `is_valid_ganzhi_date` caches verdicts computed from these lengths, so the wrong answers
-    would outlive the edit and no `cache_clear` would bring them back.
-    '''
-    counts: list[int] = ALGO1.days_counts_in_ganzhi_year(2000)
-    self.assertIsNot(counts, ALGO1.days_counts_in_ganzhi_year(2000))
-
-    counts[0] = 999
-    self.assertEqual(ALGO1.days_counts_in_ganzhi_year(2000)[0], 30)
-    self.assertTrue(ALGO1.is_valid_ganzhi_date(ganzhi(2000, 1, 29)))
-
-  def test_round_trips(self) -> None:
-    # Every day of a leap lunar year and of a plain one, both ways round.
-    for year in (2023, 2024):
-      day: date = date(year, 1, 1)
-      while day.year == year:
-        d: CalendarDate = solar(day.year, day.month, day.day)
-        self.assertEqual(ALGO1.lunar_to_solar(ALGO1.solar_to_lunar(d)), d)
-        self.assertEqual(ALGO1.ganzhi_to_solar(ALGO1.solar_to_ganzhi(d)), d)
-        self.assertEqual(ALGO1.ganzhi_to_lunar(ALGO1.solar_to_ganzhi(d)), ALGO1.solar_to_lunar(d))
-        self.assertEqual(ALGO1.lunar_to_ganzhi(ALGO1.solar_to_lunar(d)), ALGO1.solar_to_ganzhi(d))
-        day += timedelta(days=1)
-
-  def test_dates_before_the_year_boundaries(self) -> None:
-    # A solar date before 立春 belongs to the previous ganzhi year; before the lunar new
-    # year, to the previous lunar year.  Both are the `-= 1` branches.
-    self.assertEqual(ALGO1.solar_to_ganzhi(solar(2024, 1, 1)).year, 2023)
-    self.assertEqual(ALGO1.solar_to_lunar(solar(2024, 1, 1)).year, 2023)
-    self.assertEqual(ALGO1.solar_to_ganzhi(solar(2024, 2, 5)).year, 2024)
-
-  def test_to_family(self) -> None:
-    day: date = date(2024, 2, 4)
-    self.assertEqual(ALGO1.to_solar(day), solar(2024, 2, 4))
-    self.assertEqual(ALGO1.to_date(day), day)
-    self.assertEqual(ALGO1.to_lunar(day), ALGO1.solar_to_lunar(solar(2024, 2, 4)))
-    self.assertEqual(ALGO1.to_ganzhi(day), ALGO1.solar_to_ganzhi(solar(2024, 2, 4)))
-
-    # Each `to_*` is the identity on its own type, and converts from the other two.
-    for d in (solar(2024, 2, 4), lunar(2023, 13, 25), ganzhi(2024, 1, 1)):
-      self.assertEqual(ALGO1.to_solar(d).date_type, CalendarType.SOLAR)
-      self.assertEqual(ALGO1.to_lunar(d).date_type, CalendarType.LUNAR)
-      self.assertEqual(ALGO1.to_ganzhi(d).date_type, CalendarType.GANZHI)
-      self.assertEqual(ALGO1.to_date(d), date(2024, 2, 4))
+def test_the_three_bounds_are_one_physical_day() -> None:
+  # This is why per-date-type ranges would be wrong: they are the same day, spelled three
+  # ways.  A conversion of either bound must stay inside the window on all three axes.
+  for bound in (ALGO1.get_min_supported_date, ALGO1.get_max_supported_date):
+    day: date = ALGO1.to_date(bound(CalendarType.SOLAR))
+    assert ALGO1.to_date(bound(CalendarType.LUNAR)) == day
+    assert ALGO1.to_date(bound(CalendarType.GANZHI)) == day
 
 
-class TestJieqi(unittest.TestCase):
-  def test_real_moments_not_placeholders(self) -> None:
-    # The whole point of this backend: HKO can only say 00:00:00.
-    self.assertEqual(ALGO1.jieqi_moment(2024, Jieqi.立春), datetime(2024, 2, 4, 16, 27, 6))
-    self.assertEqual(ALGO1.jieqi_moment(2000, Jieqi.立春), datetime(2000, 2, 4, 20, 40, 23))
-    self.assertNotEqual(ALGO1.jieqi_moment(2024, Jieqi.立春).time(), datetime.min.time())
-
-  def test_date_is_the_moment_truncated(self) -> None:
-    for year in (1901, 1979, 2024, 2100):
-      for jq in Jieqi.as_list():
-        self.assertEqual(ALGO1.jieqi_date(year, jq), ALGO1.jieqi_moment(year, jq).date())
-
-  def test_out_of_range_year(self) -> None:
-    with self.assertRaises(AssertionError):
-      ALGO1.jieqi_moment(2101, Jieqi.立春)
-    with self.assertRaises(AssertionError):
-      ALGO1.jieqi_moment(1900, Jieqi.立春)
-    with self.assertRaises(AssertionError):
-      ALGO1.jieqi_moment('2024', Jieqi.立春)
-    with self.assertRaises(AssertionError):
-      ALGO1.jieqi_moment(2024, '立春')
-
-  def test_supported_jie_boundaries(self) -> None:
-    first, last = ALGO1.supported_jie_boundaries()
-    self.assertEqual(first, ALGO1.jieqi_moment(1901, Jieqi.小寒))
-    self.assertEqual(last, ALGO1.jieqi_moment(2100, Jieqi.大雪))
-
-  def test_jie_range_is_enforced(self) -> None:
-    first, last = ALGO1.supported_jie_boundaries()
-    for fn in (ALGO1.prev_jie, ALGO1.next_jie):
-      with self.assertRaises(ValueError):
-        fn(first - timedelta(seconds=1))
-      with self.assertRaises(ValueError):
-        fn(last) # The upper bound is exclusive.
-      with self.assertRaises(AssertionError):
-        fn(date(2024, 2, 4)) # A date is not a datetime.
-
-  def test_exactly_on_a_jie_belongs_to_it(self) -> None:
-    '''
-    The `>=` convention.  #72's golden cases are all comfortably away from a boundary, so
-    this hole is not covered by them -- and with real moments it is now reachable.
-    '''
-    moment: datetime = ALGO1.jieqi_moment(2024, Jieqi.立春)
-
-    self.assertEqual(ALGO1.prev_jie(moment), (Jieqi.立春, moment))
-    self.assertEqual(ALGO1.next_jie(moment), (Jieqi.惊蛰, ALGO1.jieqi_moment(2024, Jieqi.惊蛰)))
-
-    # One second earlier, the previous Jie is still 小寒 and the next one is 立春 itself.
-    self.assertEqual(ALGO1.prev_jie(moment - timedelta(seconds=1)).jieqi, Jieqi.小寒)
-    self.assertEqual(ALGO1.next_jie(moment - timedelta(seconds=1)), (Jieqi.立春, moment))
-
-    # One second later, both have moved past 立春.
-    self.assertEqual(ALGO1.prev_jie(moment + timedelta(seconds=1)), (Jieqi.立春, moment))
-    self.assertEqual(ALGO1.next_jie(moment + timedelta(seconds=1)).jieqi, Jieqi.惊蛰)
-
-  def test_jie_across_year_boundaries(self) -> None:
-    # Before 小寒 of its own year, the previous Jie is last year's 大雪.
-    self.assertEqual(ALGO1.prev_jie(datetime(2024, 1, 1)),
-                     (Jieqi.大雪, ALGO1.jieqi_moment(2023, Jieqi.大雪)))
-    # On or after 大雪, the next Jie is next year's 小寒.
-    self.assertEqual(ALGO1.next_jie(datetime(2024, 12, 20)),
-                     (Jieqi.小寒, ALGO1.jieqi_moment(2025, Jieqi.小寒)))
-
-  def test_prev_and_next_bracket_every_jie(self) -> None:
-    # Walking the whole window: `prev_jie` and `next_jie` must always be adjacent 节.
-    first, last = ALGO1.supported_jie_boundaries()
-    moment: datetime = first
-    seen: int = 0
-    while moment < last:
-      self.assertEqual(ALGO1.prev_jie(moment).moment, moment)
-      nxt = ALGO1.next_jie(moment)
-      self.assertGreater(nxt.moment, moment)
-      self.assertEqual(ALGO1.prev_jie(nxt.moment - timedelta(seconds=1)).moment, moment)
-      moment = nxt.moment
-      seen += 1
-    # 12 节 per year over 1901..2100, minus 大雪 2100 itself (the bound is exclusive).
-    self.assertEqual(seen, len(range(1901, 2101)) * 12 - 1)
+def test_solar() -> None:
+  assert ALGO1.is_valid_solar_date(solar(2024, 2, 4))
+  assert not ALGO1.is_valid_solar_date(lunar(2024, 2, 4)) # Wrong date type.
+  assert not ALGO1.is_valid_solar_date(solar(1901, 2, 18)) # One day before min.
+  assert not ALGO1.is_valid_solar_date(solar(2100, 1, 1)) # Past max.
+  assert not ALGO1.is_valid_solar_date(solar(2023, 2, 29)) # Not a leap year.
+  assert ALGO1.is_valid_solar_date(solar(2024, 2, 29)) # A leap year.
+  assert not ALGO1.is_valid_solar_date(solar(2024, 13, 1)) # No such month.
 
 
-class TestDualLunarAlgorithms(unittest.TestCase):
-  def test_divergence_is_exactly_the_known_years(self) -> None:
-    '''
-    Scanned over the whole window rather than over month starts: 1915's difference is in
-    the length of its *last* month, so no month start inside 1915 moves -- it surfaces as
-    lunar 1916 starting a day later.
-    '''
-    diverging_days: list[date] = []
-    diverging_years: set[int] = set()
-    day: date = ALGO1.to_date(ALGO1.get_min_supported_date(CalendarType.SOLAR))
-    last: date = ALGO1.to_date(ALGO1.get_max_supported_date(CalendarType.SOLAR))
-    while day <= last:
+def test_lunar() -> None:
+  assert ALGO1.is_valid_lunar_date(lunar(2024, 1, 1))
+  assert not ALGO1.is_valid_lunar_date(solar(2024, 1, 1)) # Wrong date type.
+  assert not ALGO1.is_valid_lunar_date(lunar(1900, 12, 1)) # Before min.
+  assert not ALGO1.is_valid_lunar_date(lunar(2099, 12, 21)) # Past max.
+  assert not ALGO1.is_valid_lunar_date(lunar(2024, 13, 1)) # 2024 has 12 lunar months.
+  assert ALGO1.is_valid_lunar_date(lunar(2023, 13, 1)) # 2023 is a leap lunar year.
+  assert not ALGO1.is_valid_lunar_date(lunar(2024, 1, 0))
+  assert not ALGO1.is_valid_lunar_date(lunar(2024, 1, 31))
+
+
+def test_ganzhi() -> None:
+  assert ALGO1.is_valid_ganzhi_date(ganzhi(2024, 1, 1))
+  assert not ALGO1.is_valid_ganzhi_date(solar(2024, 1, 1)) # Wrong date type.
+  assert not ALGO1.is_valid_ganzhi_date(ganzhi(1901, 1, 15)) # Before min.
+  assert not ALGO1.is_valid_ganzhi_date(ganzhi(2099, 11, 26)) # Past max.
+  assert not ALGO1.is_valid_ganzhi_date(ganzhi(2024, 13, 1)) # 12 ganzhi months only.
+  assert not ALGO1.is_valid_ganzhi_date(ganzhi(2024, 1, 0))
+  assert not ALGO1.is_valid_ganzhi_date(ganzhi(2024, 1, 33))
+
+
+def test_dispatch() -> None:
+  assert ALGO1.is_valid(solar(2024, 2, 4))
+  assert ALGO1.is_valid(lunar(2024, 1, 1))
+  assert ALGO1.is_valid(ganzhi(2024, 1, 1))
+  assert not ALGO1.is_valid(solar(2100, 1, 1))
+
+
+def test_ganzhi_month_lengths() -> None:
+  counts: list[int] = ALGO1.days_counts_in_ganzhi_year(2024)
+  assert len(counts) == 12
+  # A ganzhi year runs 立春 to 立春, so the months must add up to exactly that span.
+  span: int = (ALGO1.jieqi_date(2025, Jieqi.立春) - ALGO1.jieqi_date(2024, Jieqi.立春)).days
+  assert sum(counts) == span
+
+
+def test_ganzhi_month_lengths_cannot_poison_the_cache() -> None:
+  '''
+  The lengths come from a cache, so handing back the cached list itself would let one
+  caller's in-place edit corrupt every later answer.  Worse, it would not stay contained:
+  `is_valid_ganzhi_date` caches verdicts computed from these lengths, so the wrong answers
+  would outlive the edit and no `cache_clear` would bring them back.
+  '''
+  counts: list[int] = ALGO1.days_counts_in_ganzhi_year(2000)
+  assert counts is not ALGO1.days_counts_in_ganzhi_year(2000)
+
+  counts[0] = 999
+  assert ALGO1.days_counts_in_ganzhi_year(2000)[0] == 30
+  assert ALGO1.is_valid_ganzhi_date(ganzhi(2000, 1, 29))
+
+
+def test_round_trips() -> None:
+  # Every day of a leap lunar year and of a plain one, both ways round.
+  for year in (2023, 2024):
+    day: date = date(year, 1, 1)
+    while day.year == year:
       d: CalendarDate = solar(day.year, day.month, day.day)
-      algo1_lunar, algo2_lunar = ALGO1.solar_to_lunar(d), ALGO2.solar_to_lunar(d)
-      if algo1_lunar != algo2_lunar:
-        diverging_days.append(day)
-        diverging_years |= {algo1_lunar.year, algo2_lunar.year}
+      assert ALGO1.lunar_to_solar(ALGO1.solar_to_lunar(d)) == d
+      assert ALGO1.ganzhi_to_solar(ALGO1.solar_to_ganzhi(d)) == d
+      assert ALGO1.ganzhi_to_lunar(ALGO1.solar_to_ganzhi(d)) == ALGO1.solar_to_lunar(d)
+      assert ALGO1.lunar_to_ganzhi(ALGO1.solar_to_lunar(d)) == ALGO1.solar_to_ganzhi(d)
       day += timedelta(days=1)
 
-    self.assertEqual(tuple(sorted(diverging_years)), ALGO2_DIVERGENT_YEARS)
-    # Each divergence is one lunar month shifted by a day, so it spans exactly 30 days.
-    self.assertEqual(len(diverging_days), 150)
 
-  def test_the_jieqi_surface_is_shared(self) -> None:
-    # Only the lunar tables differ; everything jieqi-derived is identical.
-    self.assertEqual(ALGO1.jieqi_moment(2024, Jieqi.立春), ALGO2.jieqi_moment(2024, Jieqi.立春))
-    self.assertEqual(ALGO1.days_counts_in_ganzhi_year(2024), ALGO2.days_counts_in_ganzhi_year(2024))
+def test_dates_before_the_year_boundaries() -> None:
+  # A solar date before 立春 belongs to the previous ganzhi year; before the lunar new
+  # year, to the previous lunar year.  Both are the `-= 1` branches.
+  assert ALGO1.solar_to_ganzhi(solar(2024, 1, 1)).year == 2023
+  assert ALGO1.solar_to_lunar(solar(2024, 1, 1)).year == 2023
+  assert ALGO1.solar_to_ganzhi(solar(2024, 2, 5)).year == 2024
+
+
+def test_to_family() -> None:
+  day: date = date(2024, 2, 4)
+  assert ALGO1.to_solar(day) == solar(2024, 2, 4)
+  assert ALGO1.to_date(day) == day
+  assert ALGO1.to_lunar(day) == ALGO1.solar_to_lunar(solar(2024, 2, 4))
+  assert ALGO1.to_ganzhi(day) == ALGO1.solar_to_ganzhi(solar(2024, 2, 4))
+
+  # Each `to_*` is the identity on its own type, and converts from the other two.
+  for d in (solar(2024, 2, 4), lunar(2023, 13, 25), ganzhi(2024, 1, 1)):
+    assert ALGO1.to_solar(d).date_type == CalendarType.SOLAR
+    assert ALGO1.to_lunar(d).date_type == CalendarType.LUNAR
+    assert ALGO1.to_ganzhi(d).date_type == CalendarType.GANZHI
+    assert ALGO1.to_date(d) == date(2024, 2, 4)
+
+
+def test_real_moments_not_placeholders() -> None:
+  # The whole point of this backend: HKO can only say 00:00:00.
+  assert ALGO1.jieqi_moment(2024, Jieqi.立春) == datetime(2024, 2, 4, 16, 27, 6)
+  assert ALGO1.jieqi_moment(2000, Jieqi.立春) == datetime(2000, 2, 4, 20, 40, 23)
+  assert ALGO1.jieqi_moment(2024, Jieqi.立春).time() != datetime.min.time()
+
+
+def test_date_is_the_moment_truncated() -> None:
+  for year in (1901, 1979, 2024, 2100):
+    for jq in Jieqi.as_list():
+      assert ALGO1.jieqi_date(year, jq) == ALGO1.jieqi_moment(year, jq).date()
+
+
+def test_out_of_range_year() -> None:
+  with pytest.raises(AssertionError):
+    ALGO1.jieqi_moment(2101, Jieqi.立春)
+  with pytest.raises(AssertionError):
+    ALGO1.jieqi_moment(1900, Jieqi.立春)
+  with pytest.raises(AssertionError):
+    ALGO1.jieqi_moment('2024', Jieqi.立春)
+  with pytest.raises(AssertionError):
+    ALGO1.jieqi_moment(2024, '立春')
+
+
+def test_supported_jie_boundaries() -> None:
+  first, last = ALGO1.supported_jie_boundaries()
+  assert first == ALGO1.jieqi_moment(1901, Jieqi.小寒)
+  assert last == ALGO1.jieqi_moment(2100, Jieqi.大雪)
+
+
+def test_jie_range_is_enforced() -> None:
+  first, last = ALGO1.supported_jie_boundaries()
+  for fn in (ALGO1.prev_jie, ALGO1.next_jie):
+    with pytest.raises(ValueError):
+      fn(first - timedelta(seconds=1))
+    with pytest.raises(ValueError):
+      fn(last) # The upper bound is exclusive.
+    with pytest.raises(AssertionError):
+      fn(date(2024, 2, 4)) # A date is not a datetime.
+
+
+def test_exactly_on_a_jie_belongs_to_it() -> None:
+  '''
+  The `>=` convention.  #72's golden cases are all comfortably away from a boundary, so
+  this hole is not covered by them -- and with real moments it is now reachable.
+  '''
+  moment: datetime = ALGO1.jieqi_moment(2024, Jieqi.立春)
+
+  assert ALGO1.prev_jie(moment) == (Jieqi.立春, moment)
+  assert ALGO1.next_jie(moment) == (Jieqi.惊蛰, ALGO1.jieqi_moment(2024, Jieqi.惊蛰))
+
+  # One second earlier, the previous Jie is still 小寒 and the next one is 立春 itself.
+  assert ALGO1.prev_jie(moment - timedelta(seconds=1)).jieqi == Jieqi.小寒
+  assert ALGO1.next_jie(moment - timedelta(seconds=1)) == (Jieqi.立春, moment)
+
+  # One second later, both have moved past 立春.
+  assert ALGO1.prev_jie(moment + timedelta(seconds=1)) == (Jieqi.立春, moment)
+  assert ALGO1.next_jie(moment + timedelta(seconds=1)).jieqi == Jieqi.惊蛰
+
+
+def test_jie_across_year_boundaries() -> None:
+  # Before 小寒 of its own year, the previous Jie is last year's 大雪.
+  assert ALGO1.prev_jie(datetime(2024, 1, 1)) == \
+         (Jieqi.大雪, ALGO1.jieqi_moment(2023, Jieqi.大雪))
+  # On or after 大雪, the next Jie is next year's 小寒.
+  assert ALGO1.next_jie(datetime(2024, 12, 20)) == \
+         (Jieqi.小寒, ALGO1.jieqi_moment(2025, Jieqi.小寒))
+
+
+def test_prev_and_next_bracket_every_jie() -> None:
+  # Walking the whole window: `prev_jie` and `next_jie` must always be adjacent 节.
+  first, last = ALGO1.supported_jie_boundaries()
+  moment: datetime = first
+  seen: int = 0
+  while moment < last:
+    assert ALGO1.prev_jie(moment).moment == moment
+    nxt = ALGO1.next_jie(moment)
+    assert nxt.moment > moment
+    assert ALGO1.prev_jie(nxt.moment - timedelta(seconds=1)).moment == moment
+    moment = nxt.moment
+    seen += 1
+  # 12 节 per year over 1901..2100, minus 大雪 2100 itself (the bound is exclusive).
+  assert seen == len(range(1901, 2101)) * 12 - 1
+
+
+def test_divergence_is_exactly_the_known_years() -> None:
+  '''
+  Scanned over the whole window rather than over month starts: 1915's difference is in
+  the length of its *last* month, so no month start inside 1915 moves -- it surfaces as
+  lunar 1916 starting a day later.
+  '''
+  diverging_days: list[date] = []
+  diverging_years: set[int] = set()
+  day: date = ALGO1.to_date(ALGO1.get_min_supported_date(CalendarType.SOLAR))
+  last: date = ALGO1.to_date(ALGO1.get_max_supported_date(CalendarType.SOLAR))
+  while day <= last:
+    d: CalendarDate = solar(day.year, day.month, day.day)
+    algo1_lunar, algo2_lunar = ALGO1.solar_to_lunar(d), ALGO2.solar_to_lunar(d)
+    if algo1_lunar != algo2_lunar:
+      diverging_days.append(day)
+      diverging_years |= {algo1_lunar.year, algo2_lunar.year}
+    day += timedelta(days=1)
+
+  assert tuple(sorted(diverging_years)) == ALGO2_DIVERGENT_YEARS
+  # Each divergence is one lunar month shifted by a day, so it spans exactly 30 days.
+  assert len(diverging_days) == 150
+
+
+def test_the_jieqi_surface_is_shared() -> None:
+  # Only the lunar tables differ; everything jieqi-derived is identical.
+  assert ALGO1.jieqi_moment(2024, Jieqi.立春) == ALGO2.jieqi_moment(2024, Jieqi.立春)
+  assert ALGO1.days_counts_in_ganzhi_year(2024) == ALGO2.days_counts_in_ganzhi_year(2024)

--- a/tests/calendar/test_dates.py
+++ b/tests/calendar/test_dates.py
@@ -1,9 +1,10 @@
 # Copyright (C) 2024 Ningqi Wang (0xf3cd) <https://github.com/0xf3cd>
 # test_dates.py
 
-import unittest
 import random
 import copy
+
+import pytest
 
 from datetime import date, timedelta
 from itertools import product
@@ -11,271 +12,287 @@ from itertools import product
 from src.calendar import CalendarType, CalendarDate
 
 
-class TestCalendarType(unittest.TestCase):
-  def test_calendar_type(self) -> None:
-    self.assertIs(CalendarType.SOLAR, CalendarType.公历)
-    self.assertIs(CalendarType.LUNAR, CalendarType.农历)
-    self.assertIs(CalendarType.GANZHI, CalendarType.干支历)
-    self.assertEqual(len(CalendarType), 3)
+def test_calendar_type() -> None:
+  assert CalendarType.SOLAR is CalendarType.公历
+  assert CalendarType.LUNAR is CalendarType.农历
+  assert CalendarType.GANZHI is CalendarType.干支历
+  assert len(CalendarType) == 3
 
 
-class TestCalendarDate(unittest.TestCase):
-  def test_solar_date(self) -> None:
-    sd = CalendarDate(2024, 1, 1, CalendarType.SOLAR)
-    self.assertEqual(sd.year, 2024)
-    self.assertEqual(sd.month, 1)
-    self.assertEqual(sd.day, 1)
-    self.assertEqual(sd.date_type, CalendarType.SOLAR)
+def test_solar_date() -> None:
+  sd = CalendarDate(2024, 1, 1, CalendarType.SOLAR)
+  assert sd.year == 2024
+  assert sd.month == 1
+  assert sd.day == 1
+  assert sd.date_type == CalendarType.SOLAR
 
-    self.assertEqual(sd, CalendarDate(2024, 1, 1, CalendarType.SOLAR))
-    self.assertEqual(sd, sd)
+  assert sd == CalendarDate(2024, 1, 1, CalendarType.SOLAR)
+  assert sd == sd # noqa: PLR0124 # reflexivity is the behavior under test
 
-    self.assertNotEqual(sd, CalendarDate(2023, 1, 1, CalendarType.SOLAR))
-    self.assertNotEqual(sd, CalendarDate(2024, 2, 1, CalendarType.SOLAR))
-    self.assertNotEqual(sd, CalendarDate(2024, 1, 30, CalendarType.SOLAR))
-    self.assertNotEqual(sd, CalendarDate(2024, 1, 1, CalendarType.LUNAR))
-    self.assertNotEqual(sd, CalendarDate(2024, 1, 1, CalendarType.GANZHI))
+  assert sd != CalendarDate(2023, 1, 1, CalendarType.SOLAR)
+  assert sd != CalendarDate(2024, 2, 1, CalendarType.SOLAR)
+  assert sd != CalendarDate(2024, 1, 30, CalendarType.SOLAR)
+  assert sd != CalendarDate(2024, 1, 1, CalendarType.LUNAR)
+  assert sd != CalendarDate(2024, 1, 1, CalendarType.GANZHI)
 
-    self.assertNotEqual(sd, date(2024, 1, 1))
-    self.assertNotEqual(sd, '2024-01-01')
+  assert sd != date(2024, 1, 1)
+  assert sd != '2024-01-01'
 
-    with self.assertRaises(AssertionError):
-      CalendarDate('2024', 1, 1, CalendarType.SOLAR) # type: ignore
-    with self.assertRaises(AssertionError):
-      CalendarDate(2024, '1', 1, CalendarType.SOLAR) # type: ignore
-    with self.assertRaises(AssertionError):
-      CalendarDate(2024, 1, '1', CalendarType.SOLAR) # type: ignore
-    with self.assertRaises(AssertionError):
-      CalendarDate(2024, 1, 1, 'SOLAR') # type: ignore
-    with self.assertRaises(TypeError):
-      CalendarDate(2024, 1, 1) # type: ignore # Missing argument.
+  with pytest.raises(AssertionError):
+    CalendarDate('2024', 1, 1, CalendarType.SOLAR) # type: ignore
+  with pytest.raises(AssertionError):
+    CalendarDate(2024, '1', 1, CalendarType.SOLAR) # type: ignore
+  with pytest.raises(AssertionError):
+    CalendarDate(2024, 1, '1', CalendarType.SOLAR) # type: ignore
+  with pytest.raises(AssertionError):
+    CalendarDate(2024, 1, 1, 'SOLAR') # type: ignore
+  with pytest.raises(TypeError):
+    CalendarDate(2024, 1, 1) # type: ignore # Missing argument.
 
-    # Create invalid dates, no exception is expected to be raised, since `CalendarType` is just a thin wrapper.
-    CalendarDate(2024, 13, 1, CalendarType.SOLAR) # Invalid month.
-    CalendarDate(2024, 0, 1, CalendarType.SOLAR) # Invalid month.
-    CalendarDate(2024, 1, 0, CalendarType.SOLAR) # Invalid day.
-    CalendarDate(2024, 1, 32, CalendarType.SOLAR) # Invalid day.
+  # Create invalid dates, no exception is expected to be raised, since `CalendarType` is just a thin wrapper.
+  CalendarDate(2024, 13, 1, CalendarType.SOLAR) # Invalid month.
+  CalendarDate(2024, 0, 1, CalendarType.SOLAR) # Invalid month.
+  CalendarDate(2024, 1, 0, CalendarType.SOLAR) # Invalid day.
+  CalendarDate(2024, 1, 32, CalendarType.SOLAR) # Invalid day.
 
-  def test_lunar_date(self) -> None:
-    ld = CalendarDate(2024, 1, 1, CalendarType.LUNAR)
-    self.assertEqual(ld.year, 2024)
-    self.assertEqual(ld.month, 1)
-    self.assertEqual(ld.day, 1)
-    self.assertEqual(ld.date_type, CalendarType.LUNAR)
 
-    self.assertEqual(ld, CalendarDate(2024, 1, 1, CalendarType.LUNAR))
-    self.assertEqual(ld, ld)
+def test_lunar_date() -> None:
+  ld = CalendarDate(2024, 1, 1, CalendarType.LUNAR)
+  assert ld.year == 2024
+  assert ld.month == 1
+  assert ld.day == 1
+  assert ld.date_type == CalendarType.LUNAR
 
-    self.assertNotEqual(ld, CalendarDate(2023, 1, 1, CalendarType.LUNAR))
-    self.assertNotEqual(ld, CalendarDate(2024, 2, 1, CalendarType.LUNAR))
-    self.assertNotEqual(ld, CalendarDate(2024, 1, 30, CalendarType.LUNAR))
-    self.assertNotEqual(ld, CalendarDate(2024, 13, 29, CalendarType.LUNAR)) # Notice that there can be 13 lunar months in a lunar year.
-    self.assertNotEqual(ld, CalendarDate(2024, 1, 1, CalendarType.SOLAR))
-    self.assertNotEqual(ld, CalendarDate(2024, 1, 1, CalendarType.GANZHI))
+  assert ld == CalendarDate(2024, 1, 1, CalendarType.LUNAR)
+  assert ld == ld # noqa: PLR0124 # reflexivity is the behavior under test
 
-    self.assertNotEqual(ld, date(2024, 1, 1))
-    self.assertNotEqual(ld, '2024-01-01')
+  assert ld != CalendarDate(2023, 1, 1, CalendarType.LUNAR)
+  assert ld != CalendarDate(2024, 2, 1, CalendarType.LUNAR)
+  assert ld != CalendarDate(2024, 1, 30, CalendarType.LUNAR)
+  assert ld != CalendarDate(2024, 13, 29, CalendarType.LUNAR) # Notice that there can be 13 lunar months in a lunar year.
+  assert ld != CalendarDate(2024, 1, 1, CalendarType.SOLAR)
+  assert ld != CalendarDate(2024, 1, 1, CalendarType.GANZHI)
 
-    with self.assertRaises(AssertionError):
-      CalendarDate('2024', 1, 1, CalendarType.LUNAR) # type: ignore
-    with self.assertRaises(AssertionError):
-      CalendarDate(2024, '1', 1, CalendarType.LUNAR) # type: ignore
-    with self.assertRaises(AssertionError):
-      CalendarDate(2024, 1, '1', CalendarType.LUNAR) # type: ignore
-    with self.assertRaises(AssertionError):
-      CalendarDate(2024, 1, 1, 'LUNAR') # type: ignore
-    with self.assertRaises(TypeError):
-      CalendarDate(2024, 1, 1) # type: ignore # Missing argument.
+  assert ld != date(2024, 1, 1)
+  assert ld != '2024-01-01'
 
-    # Create invalid dates, no exception is expected to be raised, since `CalendarType` is just a thin wrapper.
-    CalendarDate(2024, 14, 1, CalendarType.LUNAR) # Invalid month.
-    CalendarDate(2024, 0, 1, CalendarType.LUNAR) # Invalid month.
-    CalendarDate(2024, 1, 31, CalendarType.LUNAR) # Invalid day.
-    CalendarDate(2024, 1, 0, CalendarType.LUNAR) # Invalid day.
+  with pytest.raises(AssertionError):
+    CalendarDate('2024', 1, 1, CalendarType.LUNAR) # type: ignore
+  with pytest.raises(AssertionError):
+    CalendarDate(2024, '1', 1, CalendarType.LUNAR) # type: ignore
+  with pytest.raises(AssertionError):
+    CalendarDate(2024, 1, '1', CalendarType.LUNAR) # type: ignore
+  with pytest.raises(AssertionError):
+    CalendarDate(2024, 1, 1, 'LUNAR') # type: ignore
+  with pytest.raises(TypeError):
+    CalendarDate(2024, 1, 1) # type: ignore # Missing argument.
 
-  def test_ganzhi_date(self) -> None:
-    gzd = CalendarDate(2024, 1, 1, CalendarType.GANZHI)
-    self.assertEqual(gzd.year, 2024)
-    self.assertEqual(gzd.month, 1)
-    self.assertEqual(gzd.day, 1)
-    self.assertEqual(gzd.date_type, CalendarType.GANZHI)
+  # Create invalid dates, no exception is expected to be raised, since `CalendarType` is just a thin wrapper.
+  CalendarDate(2024, 14, 1, CalendarType.LUNAR) # Invalid month.
+  CalendarDate(2024, 0, 1, CalendarType.LUNAR) # Invalid month.
+  CalendarDate(2024, 1, 31, CalendarType.LUNAR) # Invalid day.
+  CalendarDate(2024, 1, 0, CalendarType.LUNAR) # Invalid day.
 
-    self.assertEqual(gzd, CalendarDate(2024, 1, 1, CalendarType.GANZHI))
-    self.assertEqual(gzd, gzd)
 
-    self.assertNotEqual(gzd, CalendarDate(2023, 1, 1, CalendarType.GANZHI))
-    self.assertNotEqual(gzd, CalendarDate(2024, 2, 1, CalendarType.GANZHI))
-    self.assertNotEqual(gzd, CalendarDate(2024, 1, 30, CalendarType.GANZHI))
-    self.assertNotEqual(gzd, CalendarDate(2024, 1, 1, CalendarType.LUNAR))
-    self.assertNotEqual(gzd, CalendarDate(2024, 1, 1, CalendarType.SOLAR))
+def test_ganzhi_date() -> None:
+  gzd = CalendarDate(2024, 1, 1, CalendarType.GANZHI)
+  assert gzd.year == 2024
+  assert gzd.month == 1
+  assert gzd.day == 1
+  assert gzd.date_type == CalendarType.GANZHI
 
-    self.assertNotEqual(gzd, date(2024, 1, 1))
-    self.assertNotEqual(gzd, '2024-01-01')
+  assert gzd == CalendarDate(2024, 1, 1, CalendarType.GANZHI)
+  assert gzd == gzd # noqa: PLR0124 # reflexivity is the behavior under test
 
-    with self.assertRaises(AssertionError):
-      CalendarDate('2024', 1, 1, CalendarType.GANZHI) # type: ignore
-    with self.assertRaises(AssertionError):
-      CalendarDate(2024, '1', 1, CalendarType.GANZHI) # type: ignore
-    with self.assertRaises(AssertionError):
-      CalendarDate(2024, 1, '1', CalendarType.GANZHI) # type: ignore
-    with self.assertRaises(AssertionError):
-      CalendarDate(2024, 1, 1, 'GANZHI') # type: ignore
-    with self.assertRaises(TypeError):
-      CalendarDate(2024, 1, 1) # type: ignore # Missing argument.
+  assert gzd != CalendarDate(2023, 1, 1, CalendarType.GANZHI)
+  assert gzd != CalendarDate(2024, 2, 1, CalendarType.GANZHI)
+  assert gzd != CalendarDate(2024, 1, 30, CalendarType.GANZHI)
+  assert gzd != CalendarDate(2024, 1, 1, CalendarType.LUNAR)
+  assert gzd != CalendarDate(2024, 1, 1, CalendarType.SOLAR)
 
-    # Create invalid dates, no exception is expected to be raised, since `CalendarType` is just a thin wrapper.
-    CalendarDate(2024, 13, 1, CalendarType.GANZHI) # Invalid month.
-    CalendarDate(2024, 0, 1, CalendarType.GANZHI) # Invalid month.
-    CalendarDate(2024, 1, 32, CalendarType.GANZHI) # Invalid day.
-    CalendarDate(2024, 1, 0, CalendarType.GANZHI) # Invalid day.
+  assert gzd != date(2024, 1, 1)
+  assert gzd != '2024-01-01'
 
-  def test_date_cmp_operators(self) -> None:
-    # Use solar dates to test date operators.
-    random_date_list: list[date] = []
-    for _ in range(256):
-      random_date_list.append(date(random.randint(1, 9999), random.randint(1, 12), random.randint(1, 28)))
+  with pytest.raises(AssertionError):
+    CalendarDate('2024', 1, 1, CalendarType.GANZHI) # type: ignore
+  with pytest.raises(AssertionError):
+    CalendarDate(2024, '1', 1, CalendarType.GANZHI) # type: ignore
+  with pytest.raises(AssertionError):
+    CalendarDate(2024, 1, '1', CalendarType.GANZHI) # type: ignore
+  with pytest.raises(AssertionError):
+    CalendarDate(2024, 1, 1, 'GANZHI') # type: ignore
+  with pytest.raises(TypeError):
+    CalendarDate(2024, 1, 1) # type: ignore # Missing argument.
 
-    for date1, date2 in product(random_date_list, random_date_list):
-      c_date1: CalendarDate = CalendarDate(date1.year, date1.month, date1.day, CalendarType.SOLAR)
-      c_date2: CalendarDate = CalendarDate(date2.year, date2.month, date2.day, CalendarType.SOLAR)
-      
-      if date1 < date2:
-        self.assertTrue(c_date1 < c_date2)
-      if date1 <= date2:
-        self.assertTrue(c_date1 <= c_date2)
-      if date1 > date2:
-        self.assertTrue(c_date1 > c_date2)
-      if date1 >= date2:
-        self.assertTrue(c_date1 >= c_date2)
-      if date1 == date2:
-        self.assertTrue(c_date1 == c_date2)
-      if date1 != date2:
-        self.assertTrue(c_date1 != c_date2)
+  # Create invalid dates, no exception is expected to be raised, since `CalendarType` is just a thin wrapper.
+  CalendarDate(2024, 13, 1, CalendarType.GANZHI) # Invalid month.
+  CalendarDate(2024, 0, 1, CalendarType.GANZHI) # Invalid month.
+  CalendarDate(2024, 1, 32, CalendarType.GANZHI) # Invalid day.
+  CalendarDate(2024, 1, 0, CalendarType.GANZHI) # Invalid day.
 
-    cur_date: date = date(
-      random.randint(1, 9999),
-      random.randint(1, 12),
-      random.randint(1, 28)
-    )
-    for _ in range(512):
-      next_date: date = cur_date + timedelta(days=1)
-      c_date1 = CalendarDate(cur_date.year, cur_date.month, cur_date.day, CalendarType.SOLAR)
-      c_date2 = CalendarDate(next_date.year, next_date.month, next_date.day, CalendarType.SOLAR)
 
-      self.assertTrue(c_date1 < c_date2)
-      self.assertTrue(c_date1 <= c_date2)
-      self.assertFalse(c_date1 > c_date2)
-      self.assertFalse(c_date1 >= c_date2)
-      self.assertFalse(c_date1 == c_date2)
-      self.assertTrue(c_date1 != c_date2)
+def test_date_cmp_operators() -> None:
+  # Use solar dates to test date operators.
+  random_date_list: list[date] = []
+  for _ in range(256):
+    random_date_list.append(date(random.randint(1, 9999), random.randint(1, 12), random.randint(1, 28)))
 
-      self.assertTrue(c_date1 >= c_date1) # noqa: PLR0124 # reflexivity is the behavior under test
-      self.assertTrue(c_date1 <= c_date1) # noqa: PLR0124 # reflexivity is the behavior under test
-      self.assertFalse(c_date1 > c_date1) # noqa: PLR0124 # reflexivity is the behavior under test
-      self.assertFalse(c_date1 < c_date1) # noqa: PLR0124 # reflexivity is the behavior under test
-      self.assertTrue(c_date1 == c_date1) # noqa: PLR0124 # reflexivity is the behavior under test
-      self.assertFalse(c_date1 != c_date1) # noqa: PLR0124 # reflexivity is the behavior under test
+  for date1, date2 in product(random_date_list, random_date_list):
+    c_date1: CalendarDate = CalendarDate(date1.year, date1.month, date1.day, CalendarType.SOLAR)
+    c_date2: CalendarDate = CalendarDate(date2.year, date2.month, date2.day, CalendarType.SOLAR)
 
-      cur_date = next_date
+    if date1 < date2:
+      assert c_date1 < c_date2
+    if date1 <= date2:
+      assert c_date1 <= c_date2
+    if date1 > date2:
+      assert c_date1 > c_date2
+    if date1 >= date2:
+      assert c_date1 >= c_date2
+    if date1 == date2:
+      assert c_date1 == c_date2
+    if date1 != date2:
+      assert c_date1 != c_date2
 
-  def test_date_cmp_operators_negative(self) -> None:
-    # As expected, only the dates of the same `CalendarType` can be compared.
-    calendar_dates: list[CalendarDate] = [
-      CalendarDate(2024, 1, 1, CalendarType.SOLAR),
-      CalendarDate(2024, 1, 1, CalendarType.LUNAR),
-      CalendarDate(2024, 1, 1, CalendarType.GANZHI),
-    ]
+  cur_date: date = date(
+    random.randint(1, 9999),
+    random.randint(1, 12),
+    random.randint(1, 28)
+  )
+  for _ in range(512):
+    next_date: date = cur_date + timedelta(days=1)
+    c_date1 = CalendarDate(cur_date.year, cur_date.month, cur_date.day, CalendarType.SOLAR)
+    c_date2 = CalendarDate(next_date.year, next_date.month, next_date.day, CalendarType.SOLAR)
 
-    for d1, d2 in product(calendar_dates, calendar_dates):
-      bool1: bool = d1 == d2
-      bool2: bool = d1 != d2
-      
-      # Either bool1 or bool2 is True.
-      self.assertTrue(bool1 or bool2)
-      self.assertFalse(bool1 and bool2)
+    assert c_date1 < c_date2
+    assert c_date1 <= c_date2
+    assert not c_date1 > c_date2
+    assert not c_date1 >= c_date2
+    assert not c_date1 == c_date2 # noqa: SIM201 # `==` itself is the operator under test
+    assert c_date1 != c_date2
 
-      self.assertEqual(d1 == d2, d2 == d1)
-      self.assertEqual(d1 != d2, d2 != d1)
+    assert c_date1 >= c_date1 # noqa: PLR0124 # reflexivity is the behavior under test
+    assert c_date1 <= c_date1 # noqa: PLR0124 # reflexivity is the behavior under test
+    assert not c_date1 > c_date1 # noqa: PLR0124 # reflexivity is the behavior under test
+    assert not c_date1 < c_date1 # noqa: PLR0124 # reflexivity is the behavior under test
+    assert c_date1 == c_date1 # noqa: PLR0124 # reflexivity is the behavior under test
+    assert not c_date1 != c_date1 # noqa: PLR0124, SIM202 # reflexivity is the behavior under test
 
-      # Following subtests need `d1` to be of the same `CalendarType` as `d2`.
-      if d1.date_type == d2.date_type:
-        continue
+    cur_date = next_date
 
-      self.assertRaises(TypeError, lambda : d1 < d2)
-      self.assertRaises(TypeError, lambda : d1 <= d2)
-      self.assertRaises(TypeError, lambda : d1 > d2)
-      self.assertRaises(TypeError, lambda : d1 >= d2)
 
-    for d1, dt in zip(calendar_dates, [date(2024, 1, 1)] * 3):
-      # `==`/`!=` against a foreign type follow Python's convention (False/True, both
-      # directions, no raise); ordering against one still raises.
-      self.assertFalse(d1 == dt)
-      self.assertTrue(d1 != dt)
-      self.assertFalse(dt == d1)
-      self.assertTrue(dt != d1)
+def test_date_cmp_operators_negative() -> None:
+  # As expected, only the dates of the same `CalendarType` can be compared.
+  calendar_dates: list[CalendarDate] = [
+    CalendarDate(2024, 1, 1, CalendarType.SOLAR),
+    CalendarDate(2024, 1, 1, CalendarType.LUNAR),
+    CalendarDate(2024, 1, 1, CalendarType.GANZHI),
+  ]
 
-      self.assertRaises(TypeError, lambda : d1 < dt)
-      self.assertRaises(TypeError, lambda : d1 <= dt)
-      self.assertRaises(TypeError, lambda : d1 > dt)
-      self.assertRaises(TypeError, lambda : d1 >= dt)
+  for d1, d2 in product(calendar_dates, calendar_dates):
+    bool1: bool = d1 == d2
+    bool2: bool = d1 != d2
 
-      self.assertRaises(TypeError, lambda : dt < d1)
-      self.assertRaises(TypeError, lambda : dt <= d1)
-      self.assertRaises(TypeError, lambda : dt > d1)
-      self.assertRaises(TypeError, lambda : dt >= d1)
+    # Either bool1 or bool2 is True.
+    assert bool1 or bool2
+    assert not (bool1 and bool2)
 
-  def test_str_repr(self) -> None:
-    random_date_list: list[CalendarDate] = []
-    for _ in range(256):
-      random_date_list.append(
-        CalendarDate(
-          random.randint(1902, 2099),
-          random.randint(1, 12),
-          random.randint(1, 28),
-          random.choice(list(CalendarType))
-        )
+    assert (d1 == d2) == (d2 == d1)
+    assert (d1 != d2) == (d2 != d1)
+
+    # Following subtests need `d1` to be of the same `CalendarType` as `d2`.
+    if d1.date_type == d2.date_type:
+      continue
+
+    with pytest.raises(TypeError):
+      d1 < d2 # noqa: B015 # the raising comparison is the behavior under test
+    with pytest.raises(TypeError):
+      d1 <= d2 # noqa: B015 # the raising comparison is the behavior under test
+    with pytest.raises(TypeError):
+      d1 > d2 # noqa: B015 # the raising comparison is the behavior under test
+    with pytest.raises(TypeError):
+      d1 >= d2 # noqa: B015 # the raising comparison is the behavior under test
+
+  for d1, dt in zip(calendar_dates, [date(2024, 1, 1)] * 3):
+    # `==`/`!=` against a foreign type follow Python's convention (False/True, both
+    # directions, no raise); ordering against one still raises.
+    assert not d1 == dt # noqa: SIM201 # `==` itself is the operator under test
+    assert d1 != dt
+    assert not dt == d1 # noqa: SIM201 # `==` itself is the operator under test
+    assert dt != d1
+
+    with pytest.raises(TypeError):
+      d1 < dt # noqa: B015 # the raising comparison is the behavior under test
+    with pytest.raises(TypeError):
+      d1 <= dt # noqa: B015 # the raising comparison is the behavior under test
+    with pytest.raises(TypeError):
+      d1 > dt # noqa: B015 # the raising comparison is the behavior under test
+    with pytest.raises(TypeError):
+      d1 >= dt # noqa: B015 # the raising comparison is the behavior under test
+
+    with pytest.raises(TypeError):
+      dt < d1 # noqa: B015 # the raising comparison is the behavior under test
+    with pytest.raises(TypeError):
+      dt <= d1 # noqa: B015 # the raising comparison is the behavior under test
+    with pytest.raises(TypeError):
+      dt > d1 # noqa: B015 # the raising comparison is the behavior under test
+    with pytest.raises(TypeError):
+      dt >= d1 # noqa: B015 # the raising comparison is the behavior under test
+
+
+def test_str_repr() -> None:
+  random_date_list: list[CalendarDate] = []
+  for _ in range(256):
+    random_date_list.append(
+      CalendarDate(
+        random.randint(1902, 2099),
+        random.randint(1, 12),
+        random.randint(1, 28),
+        random.choice(list(CalendarType))
       )
+    )
 
-    for d in random_date_list:
-      self.assertEqual(str(d), d.__str__())
-      self.assertEqual(repr(d), d.__repr__())
-      self.assertEqual(str(d), str(d))
-      self.assertEqual(repr(d), repr(d))
-    
-    for d1, d2 in product(random_date_list, random_date_list):
-      if d1 == d2:
-        self.assertEqual(str(d1), str(d2))
-        self.assertEqual(repr(d1), repr(d2))
-      if d1 != d2:
-        self.assertNotEqual(str(d1), str(d2))
-        self.assertNotEqual(repr(d1), repr(d2))    
+  for d in random_date_list:
+    assert str(d) == d.__str__()
+    assert repr(d) == d.__repr__()
+    assert str(d) == str(d) # noqa: PLR0124 # determinism across calls is the behavior under test
+    assert repr(d) == repr(d) # noqa: PLR0124 # determinism across calls is the behavior under test
 
-  def test_malicious_writes(self) -> None:
-    with self.subTest('Write to properties'):
-      d = CalendarDate(2000, 1, 1, CalendarType.SOLAR)
-      with self.assertRaises(AttributeError):
-        d.year = 1999 # type: ignore
-      with self.assertRaises(AttributeError):
-        d.month = 2 # type: ignore
-      with self.assertRaises(AttributeError):
-        d.day = 10 # type: ignore
-      with self.assertRaises(AttributeError):
-        d.date_type = CalendarType.LUNAR # type: ignore
+  for d1, d2 in product(random_date_list, random_date_list):
+    if d1 == d2:
+      assert str(d1) == str(d2)
+      assert repr(d1) == repr(d2)
+    if d1 != d2:
+      assert str(d1) != str(d2)
+      assert repr(d1) != repr(d2)
 
-    with self.subTest('Write to underlying instance variables'):
-      # A frozen dataclass rejects writes to any attribute -- even brand-new private names.
-      d = CalendarDate(2000, 1, 1, CalendarType.SOLAR)
-      with self.assertRaises(AttributeError):
-        d._year = 1999 # type: ignore
-    
-  def test_copy(self) -> None:
-    d = CalendarDate(2000, 1, 1, CalendarType.SOLAR)
-    for method, d_copy in [('shallow', copy.copy(d)), ('deep', copy.deepcopy(d))]:
-      with self.subTest(f'Test {method} copy'):
-        self.assertEqual(d, d_copy)
-        self.assertEqual(d_copy, d)
-        self.assertIsNot(d, d_copy)
-        # Copies can no longer be mutated into inequality (frozen dataclass), so
-        # distinctness is shown against freshly constructed different dates instead.
-        self.assertNotEqual(d_copy, CalendarDate(2001, 1, 1, CalendarType.SOLAR))
-        self.assertNotEqual(d_copy, CalendarDate(2000, 1, 1, CalendarType.LUNAR))
+
+def test_malicious_writes() -> None:
+  # Write to properties.
+  d = CalendarDate(2000, 1, 1, CalendarType.SOLAR)
+  with pytest.raises(AttributeError):
+    d.year = 1999 # type: ignore
+  with pytest.raises(AttributeError):
+    d.month = 2 # type: ignore
+  with pytest.raises(AttributeError):
+    d.day = 10 # type: ignore
+  with pytest.raises(AttributeError):
+    d.date_type = CalendarType.LUNAR # type: ignore
+
+  # Write to underlying instance variables.
+  # A frozen dataclass rejects writes to any attribute -- even brand-new private names.
+  d = CalendarDate(2000, 1, 1, CalendarType.SOLAR)
+  with pytest.raises(AttributeError):
+    d._year = 1999 # type: ignore
+
+
+def test_copy() -> None:
+  d = CalendarDate(2000, 1, 1, CalendarType.SOLAR)
+  for method, d_copy in [('shallow', copy.copy(d)), ('deep', copy.deepcopy(d))]:
+    assert d == d_copy
+    assert d_copy == d
+    assert d is not d_copy
+    # Copies can no longer be mutated into inequality (frozen dataclass), so
+    # distinctness is shown against freshly constructed different dates instead.
+    assert d_copy != CalendarDate(2001, 1, 1, CalendarType.SOLAR)
+    assert d_copy != CalendarDate(2000, 1, 1, CalendarType.LUNAR)

--- a/tests/calendar/test_dates.py
+++ b/tests/calendar/test_dates.py
@@ -3,6 +3,7 @@
 
 import random
 import copy
+import operator
 
 import pytest
 
@@ -200,18 +201,13 @@ def test_date_cmp_operators_negative() -> None:
     assert (d1 == d2) == (d2 == d1)
     assert (d1 != d2) == (d2 != d1)
 
-    # Following subtests need `d1` to be of the same `CalendarType` as `d2`.
+    # Comparing dates of different `CalendarType`s must raise.
     if d1.date_type == d2.date_type:
       continue
 
-    with pytest.raises(TypeError):
-      d1 < d2 # noqa: B015 # the raising comparison is the behavior under test
-    with pytest.raises(TypeError):
-      d1 <= d2 # noqa: B015 # the raising comparison is the behavior under test
-    with pytest.raises(TypeError):
-      d1 > d2 # noqa: B015 # the raising comparison is the behavior under test
-    with pytest.raises(TypeError):
-      d1 >= d2 # noqa: B015 # the raising comparison is the behavior under test
+    for op in (operator.lt, operator.le, operator.gt, operator.ge):
+      with pytest.raises(TypeError):
+        op(d1, d2)
 
   for d1, dt in zip(calendar_dates, [date(2024, 1, 1)] * 3):
     # `==`/`!=` against a foreign type follow Python's convention (False/True, both
@@ -221,23 +217,13 @@ def test_date_cmp_operators_negative() -> None:
     assert not dt == d1 # noqa: SIM201 # `==` itself is the operator under test
     assert dt != d1
 
-    with pytest.raises(TypeError):
-      d1 < dt # noqa: B015 # the raising comparison is the behavior under test
-    with pytest.raises(TypeError):
-      d1 <= dt # noqa: B015 # the raising comparison is the behavior under test
-    with pytest.raises(TypeError):
-      d1 > dt # noqa: B015 # the raising comparison is the behavior under test
-    with pytest.raises(TypeError):
-      d1 >= dt # noqa: B015 # the raising comparison is the behavior under test
+    for op in (operator.lt, operator.le, operator.gt, operator.ge):
+      with pytest.raises(TypeError):
+        op(d1, dt)
 
-    with pytest.raises(TypeError):
-      dt < d1 # noqa: B015 # the raising comparison is the behavior under test
-    with pytest.raises(TypeError):
-      dt <= d1 # noqa: B015 # the raising comparison is the behavior under test
-    with pytest.raises(TypeError):
-      dt > d1 # noqa: B015 # the raising comparison is the behavior under test
-    with pytest.raises(TypeError):
-      dt >= d1 # noqa: B015 # the raising comparison is the behavior under test
+    for op in (operator.lt, operator.le, operator.gt, operator.ge):
+      with pytest.raises(TypeError):
+        op(dt, d1)
 
 
 def test_str_repr() -> None:

--- a/tests/calendar/test_hko_data.py
+++ b/tests/calendar/test_hko_data.py
@@ -7,7 +7,6 @@ import hashlib
 import tempfile
 
 import pytest
-import unittest
 
 from pathlib import Path
 from datetime import date, timedelta
@@ -17,372 +16,385 @@ from src.calendar.hko_data import encoder
 from src.defines import Jieqi, Ganzhi
 
 
-@pytest.mark.hkodata
-class TestHkoData(unittest.TestCase):
-  def test_traditional_chinese_jieqi(self) -> None:
-    self.assertEqual(len(hko_data.jieqi_list_in_traditional_chinese), 24)
-
-  def test_traditional_chinese_month(self) -> None:
-    self.assertEqual(len(hko_data.twelve_months_in_traditional_chinese), 12)
-  
-  def test_int_bytes_conversion(self) -> None:
-    self.assertEqual(hko_data.int_to_bytes(0x12345678, 4), b'\x12\x34\x56\x78')
-    self.assertEqual(hko_data.bytes_to_int(b'\x12\x34\x56\x78'), 0x12345678)
-
-    for _ in range(512):
-      i: int = random.randint(0, 0xffffffff)
-      i_bytes: bytes = hko_data.int_to_bytes(i, 4)
-      self.assertEqual(i, hko_data.bytes_to_int(i_bytes))
-
-  def test_date_bytes_conversion(self) -> None:
-    self.assertEqual(hko_data.date_to_bytes(date(2000, 1, 1)), hko_data.date_to_bytes(date(2000, 1, 1)))
-    self.assertNotEqual(hko_data.date_to_bytes(date(2000, 1, 1)), hko_data.date_to_bytes(date(2000, 1, 2)))
-    self.assertEqual(hko_data.bytes_to_date(b'\x00\x01\x01\x01'), date(1, 1, 1))
-    self.assertEqual(hko_data.bytes_to_date(hko_data.date_to_bytes(date(2024, 2, 25))), date(2024, 2, 25))
-
-    dt: date = date(
-      year=random.randint(1600, 2500),
-      month=random.randint(1, 12),
-      day=random.randint(1, 28), # Not using 29, 30, or 31 here, to avoid invalid day (e.g. 2024-2-31)
-    )
-    for _ in range(512):
-      dt = dt + timedelta(days=random.randint(1, 3))
-      dt_bytes: bytes = hko_data.date_to_bytes(dt)
-      self.assertEqual(dt, hko_data.bytes_to_date(dt_bytes))
-      self.assertEqual(len(dt_bytes), 4, msg=f'expect the length of dt_bytes to be 4, but got {len(dt_bytes)}')
-      self.assertEqual(hko_data.bytes_to_int(dt_bytes[0:2]), dt.year)
-      self.assertEqual(hko_data.bytes_to_int(dt_bytes[2:3]), dt.month)
-      self.assertEqual(hko_data.bytes_to_int(dt_bytes[3:4]), dt.day)
-
-    with self.assertRaises(ValueError):
-      hko_data.date_to_bytes(date(2024, 64, 1))
-    with self.assertRaises(ValueError):
-      hko_data.date_to_bytes(date(2024, 12, 32))
-    with self.assertRaises(ValueError):
-      hko_data.bytes_to_date(b'\x00\x01\x00\x00')
-    with self.assertRaises(AssertionError):
-      hko_data.bytes_to_date(b'\x00\x00\x00\x00\x00\x01\x00\x00')
-    with self.assertRaises(AssertionError):
-      hko_data.bytes_to_date(b'\x00\x00')
-    with self.assertRaises(AssertionError):
-      hko_data.bytes_to_date(b'\x00\x00' * 10)
-
-  def test_decode_jieqi(self) -> None:
-    decoded_jieqi: hko_data.DecodedJieqiDates = hko_data.DecodedJieqiDates()
-
-    # In our expectation, the data between gregorian year 1901 and 2100 (edges included) is valid.
-    for year in range(1901, 2100 + 1):
-      self.assertTrue(year in decoded_jieqi.supported_year_range())
-
-    for year in decoded_jieqi.supported_year_range():
-      self.assertEqual(len(decoded_jieqi[year]), 24)
-
-    self.assertEqual(min(decoded_jieqi.supported_year_range()), hko_data.START_YEAR)
-    self.assertEqual(max(decoded_jieqi.supported_year_range()), hko_data.END_YEAR)
-
-    for year in decoded_jieqi.supported_year_range():
-      jieqi_dates_dict: hko_data.JieqiDates = decoded_jieqi[year]
-      self.assertEqual(len(jieqi_dates_dict), 24)
-      self.assertEqual(set(jieqi_dates_dict.keys()), set(Jieqi))
-
-    for year in decoded_jieqi.supported_year_range():
-      for jieqi in Jieqi:
-        self.assertEqual(decoded_jieqi.get(year, jieqi), decoded_jieqi[year][jieqi])
-    
-    self.assertEqual(decoded_jieqi[1964][Jieqi.寒露], date(1964, 10, 8))
-    self.assertEqual(decoded_jieqi[1997][Jieqi.小寒], date(1997, 1, 5))
-    self.assertEqual(decoded_jieqi[2024][Jieqi.立春], date(2024, 2, 4))
-
-    self.assertEqual(decoded_jieqi.get(1964, Jieqi.寒露), date(1964, 10, 8))
-    self.assertEqual(decoded_jieqi.get(1997, Jieqi.小寒), date(1997, 1, 5))
-    self.assertEqual(decoded_jieqi.get(2024, Jieqi.立春), date(2024, 2, 4))
-
-    another_decoded_jieqi: hko_data.DecodedJieqiDates = hko_data.DecodedJieqiDates()
-    self.assertListEqual(list(decoded_jieqi.supported_year_range()), list(another_decoded_jieqi.supported_year_range()))
-
-    for year in decoded_jieqi.supported_year_range():
-      for jieqi in Jieqi:
-        self.assertEqual(decoded_jieqi.get(year, jieqi), another_decoded_jieqi.get(year, jieqi))
-    
-  def test_decode_jieqi_getitem_negative(self) -> None:
-    decoded_jieqi: hko_data.DecodedJieqiDates = hko_data.DecodedJieqiDates()
-    with self.assertRaises(AssertionError):
-      decoded_jieqi[1000]
-    with self.assertRaises(AssertionError):
-      decoded_jieqi[min(decoded_jieqi.supported_year_range()) - 1]
-    with self.assertRaises(AssertionError):
-      decoded_jieqi[max(decoded_jieqi.supported_year_range()) + 1]
-    with self.assertRaises(AssertionError):
-      decoded_jieqi['2024'] # type: ignore
-    with self.assertRaises(AssertionError):
-      decoded_jieqi[Jieqi.芒种] # type: ignore
-    with self.assertRaises(AssertionError):
-      decoded_jieqi[:] # type: ignore
-    with self.assertRaises(AssertionError):
-      decoded_jieqi[date(2024, 1, 1)] # type: ignore
-
-    data1 = decoded_jieqi[2024]
-    data2 = decoded_jieqi[2024]
-    self.assertEqual(data1, data2)
-    self.assertIsNot(data1, data2)
-
-    data2[Jieqi.惊蛰] = date(1999, 1, 1)
-    data3 = decoded_jieqi[2024]
-    self.assertEqual(data1, data3)
-    self.assertNotEqual(data1, data2)
-    self.assertNotEqual(data2, data3)
-
-  def test_decode_jieqi_get_negative(self) -> None:
-    decoded_jieqi: hko_data.DecodedJieqiDates = hko_data.DecodedJieqiDates()
-    with self.assertRaises(TypeError):
-      decoded_jieqi.get(2024)
-    with self.assertRaises(TypeError):
-      decoded_jieqi.get(Jieqi.春分)
-    with self.assertRaises(AssertionError):
-      decoded_jieqi.get('1000', Jieqi.寒露)
-    with self.assertRaises(AssertionError):
-      decoded_jieqi.get(1000, Jieqi.寒露)
-    with self.assertRaises(AssertionError):
-      decoded_jieqi.get(min(decoded_jieqi.supported_year_range()) - 1, Jieqi.寒露)
-    with self.assertRaises(AssertionError):
-      decoded_jieqi.get(max(decoded_jieqi.supported_year_range()) + 1, Jieqi.寒露)
-
-    self.assertEqual(decoded_jieqi.get(2024, Jieqi.立春), decoded_jieqi.get(2024, Jieqi.立春))
-    self.assertIs(decoded_jieqi.get(2024, Jieqi.立春), decoded_jieqi.get(2024, Jieqi.立春), msg='should be the same object since it is cached')
-
-    lichun_2024_date = decoded_jieqi.get(2024, Jieqi.立春)
-    lichun_2024_date_ = decoded_jieqi.get(2024, Jieqi.立春)
-    lichun_2024_date_ = date(9999, 9, 9)
-    self.assertNotEqual(lichun_2024_date, lichun_2024_date_)
-    self.assertEqual(lichun_2024_date, decoded_jieqi.get(2024, Jieqi.立春))
-
-    jieqi_dates_in_2024 = decoded_jieqi[2024]
-    self.assertEqual(jieqi_dates_in_2024[Jieqi.立春], lichun_2024_date)
-
-    jieqi_dates_in_2024[Jieqi.立春] = date(1996, 2, 4)
-    self.assertNotEqual(jieqi_dates_in_2024[Jieqi.立春], lichun_2024_date)
-    self.assertEqual(decoded_jieqi.get(2024, Jieqi.立春), lichun_2024_date)
-
-  def test_decode_lunar_year(self) -> None:
-    decoded_lunardate: hko_data.DecodedLunarYears = hko_data.DecodedLunarYears()
-
-    # In our expectation, the lunar years in [1901, 2099] (edges included) are supported.
-    for year in range(1901, 2099 + 1):
-      self.assertTrue(year in decoded_lunardate.supported_year_range())
-
-    for year in decoded_lunardate.supported_year_range():
-      info1 = decoded_lunardate[year]
-      info2 = decoded_lunardate.get(year)
-      self.assertIsNot(info1, info2)
-      self.assertEqual(set(info1.keys()), set(info2.keys()))
-
-      self.assertEqual(info1['first_solar_day'], info2['first_solar_day'])
-      self.assertEqual(info1['leap'], info2['leap'])
-      self.assertEqual(info1['leap_month'], info2['leap_month'])
-      self.assertEqual(info1['days_counts'], info2['days_counts'])
-      self.assertEqual(info1['ganzhi'], info2['ganzhi'])
-
-      if info1['leap']:
-        self.assertNotEqual(info1['leap_month'], 0)
-        self.assertEqual(len(info1['days_counts']), 13)
-      else:
-        self.assertIsNone(info1['leap_month'])
-        self.assertEqual(len(info1['days_counts']), 12)
-
-    expected_days_counts_2000: list[int] = [30, 30, 29, 29, 30, 29, 29, 30, 29, 30, 30, 29]
-    self.assertEqual(decoded_lunardate[2000]['first_solar_day'], date(2000, 2, 5))
-    self.assertFalse(decoded_lunardate[2000]['leap'])
-    self.assertIsNone(decoded_lunardate[2000]['leap_month'])
-    self.assertListEqual(decoded_lunardate[2000]['days_counts'], expected_days_counts_2000)
-    self.assertEqual(decoded_lunardate[2000]['ganzhi'], Ganzhi.from_str('庚辰'))
-
-    expected_days_counts_2001: list[int] = [30, 30, 29, 30, 29, 30, 29, 29, 30, 29, 30, 29, 30]
-    self.assertEqual(decoded_lunardate[2001]['first_solar_day'], date(2001, 1, 24))
-    self.assertTrue(decoded_lunardate[2001]['leap'])
-    self.assertEqual(decoded_lunardate[2001]['leap_month'], 4)
-    self.assertListEqual(decoded_lunardate[2001]['days_counts'], expected_days_counts_2001)
-    self.assertEqual(decoded_lunardate[2001]['ganzhi'], Ganzhi.from_str('辛巳'))
-
-    expected_days_counts_2024: list[int] = [29, 30, 29, 29, 30, 29, 30, 30, 29, 30, 30, 29]
-    self.assertEqual(decoded_lunardate[2024]['first_solar_day'], date(2024, 2, 10))
-    self.assertFalse(decoded_lunardate[2024]['leap'])
-    self.assertIsNone(decoded_lunardate[2024]['leap_month'])
-    self.assertListEqual(decoded_lunardate[2024]['days_counts'], expected_days_counts_2024)
-    self.assertEqual(decoded_lunardate[2024]['ganzhi'], Ganzhi.from_str('甲辰'))
-
-    # 1924 is a year of "甲子" ganzhi.
-    self.assertEqual(decoded_lunardate[1924]['ganzhi'], Ganzhi.from_str('甲子'))
-    sexagenary_cycle = Ganzhi.list_sexagenary_cycle()
-    for year in decoded_lunardate.supported_year_range():
-      diff: int = year - 1924
-      expected_ganzhi: Ganzhi = sexagenary_cycle[diff % len(sexagenary_cycle)]
-      self.assertEqual(decoded_lunardate[year]['ganzhi'], expected_ganzhi)
-
-  def test_decode_lunar_year_get_returns_a_copy(self) -> None:
-    '''
-    `get` leverages a cache, so it must hand back a rebuilt record: mutating what a caller
-    received must not corrupt later answers (issue #92).
-    '''
-    decoded_lunardate: hko_data.DecodedLunarYears = hko_data.DecodedLunarYears()
-    info: hko_data.LunarYearInfo = decoded_lunardate.get(2000)
-    self.assertIsNot(info, decoded_lunardate.get(2000))
-    self.assertIsNot(info['days_counts'], decoded_lunardate.get(2000)['days_counts'])
-
-    original_days_counts: list[int] = list(info['days_counts'])
-    info['days_counts'][0] = 999
-    info['leap_month'] = 7
-    self.assertEqual(decoded_lunardate.get(2000)['days_counts'], original_days_counts)
-    self.assertIsNone(decoded_lunardate.get(2000)['leap_month'])
-
-  def test_decode_lunar_year_negative(self) -> None:
-    decoded_lunardate: hko_data.DecodedLunarYears = hko_data.DecodedLunarYears()
-    with self.assertRaises(AssertionError):
-      decoded_lunardate.get(min(decoded_lunardate.supported_year_range()) - 1)
-    with self.assertRaises(AssertionError):
-      decoded_lunardate[min(decoded_lunardate.supported_year_range()) - 1]
-    with self.assertRaises(AssertionError):
-      decoded_lunardate.get(max(decoded_lunardate.supported_year_range()) + 1)
-    with self.assertRaises(AssertionError):
-      decoded_lunardate[max(decoded_lunardate.supported_year_range()) + 1]
-    with self.assertRaises(AssertionError):
-      decoded_lunardate.get('a') # type: ignore
-    with self.assertRaises(AssertionError):
-      decoded_lunardate.get('1984') # type: ignore
-    with self.assertRaises(AssertionError):
-      decoded_lunardate.get(date(year=1984, month=1, day=1)) # type: ignore
-    
-    temp = decoded_lunardate[2024]
-    temp['days_counts'].append(29)
-    temp['ganzhi'] = Ganzhi.from_str('甲子')
-
-    new_2024_info = decoded_lunardate[2024]
-    self.assertIsNot(new_2024_info, temp)
-    self.assertNotEqual(new_2024_info['days_counts'], temp['days_counts'])
-    self.assertNotEqual(new_2024_info['ganzhi'], temp['ganzhi'])
-
-    expected_days_counts_2024: list[int] = [29, 30, 29, 29, 30, 29, 30, 30, 29, 30, 30, 29]
-    self.assertEqual(new_2024_info['first_solar_day'], date(2024, 2, 10))
-    self.assertFalse(new_2024_info['leap'])
-    self.assertIsNone(new_2024_info['leap_month'])
-    self.assertListEqual(new_2024_info['days_counts'], expected_days_counts_2024)
-    self.assertEqual(new_2024_info['ganzhi'], Ganzhi.from_str('甲辰'))
-
-  def test_file_existence(self) -> None:
-    '''The data files should exist and be readable.'''
-    data_path: Path = hko_data.get_data_base_path()
-    self.assertTrue(data_path.exists() and data_path.is_dir())
-
-    txt_paths: dict[int, Path] = hko_data.common.get_raw_txt_file_paths()
-    for path in txt_paths.values():
-      self.assertTrue(path.exists() and path.is_file())
-      with open(path, 'r', encoding='utf-8') as f:
-        self.assertTrue(f.read() != '')
-
-    self.assertTrue(hko_data.common.raw_data_ready())
-
-  def test_raw_data_ready(self) -> None:
-    self.assertTrue(hko_data.common.raw_data_ready())
-
-    # Do something bad in between.
-
-    temp_dir: Path = Path(tempfile.mkdtemp())
-    data_path: Path = hko_data.common.get_data_base_path()
-    self.assertTrue(temp_dir.exists() and temp_dir.is_dir())
-    self.assertTrue(data_path.exists() and data_path.is_dir())
-
-    # Copy the data folder to the temporary folder.
-    shutil.copytree(data_path, temp_dir / 'data')
-
-    try:
-      shutil.move(data_path, temp_dir / 'data2')
-      self.assertFalse(hko_data.common.raw_data_ready())
-
-      # Create a file called "data" (not a folder).
-      with open(data_path, 'w') as f:
-        f.write('I am not a folder!!!')
-      self.assertFalse(hko_data.common.raw_data_ready())
-
-      # Remove the fake "data" file.
-      data_path.unlink()
-      self.assertFalse(data_path.exists())
-
-      # Copy the original data folder back.
-      shutil.copytree(temp_dir / 'data', data_path)
-      self.assertTrue(hko_data.common.raw_data_ready())
-
-      all_txt_paths: dict[int, Path] = hko_data.common.get_raw_txt_file_paths()
-      random.choice(list(all_txt_paths.values())).unlink()
-      self.assertFalse(hko_data.common.raw_data_ready())
-
-    finally:
-      # Finally restore the original data folder.
-      # Also ensure the data is ready again after the above malicious operations.
-      shutil.copytree(temp_dir / 'data', data_path, dirs_exist_ok=True)
-      self.assertTrue(hko_data.common.raw_data_ready())
-
-      shutil.rmtree(temp_dir)
-
-  @pytest.mark.slow
-  def test_do_encode(self) -> None:
-    self.assertTrue(hko_data.common.encoded_data_ready())
-
-    # Do something bad in between.
-
-    temp_dir: Path = Path(tempfile.mkdtemp())
-    jieqi_path: Path = hko_data.common.get_jieqi_encoded_data_path()
-    lunardate_path: Path = hko_data.common.get_lunardate_encoded_data_path()
-    self.assertTrue(temp_dir.exists() and temp_dir.is_dir())
-    self.assertTrue(jieqi_path.exists() and jieqi_path.is_file())
-    self.assertTrue(lunardate_path.exists() and lunardate_path.is_file())
-
-    # Copy the data folder to the temporary folder.
-    data_path: Path = hko_data.common.get_data_base_path()
-    shutil.copytree(data_path, temp_dir / 'data')
-
-    try:
-      # Copy the encoded binary files to the temporary folder.
-      shutil.move(jieqi_path, temp_dir / 'jieqi.bin')
-      self.assertFalse(hko_data.common.encoded_data_ready())
-      shutil.move(lunardate_path, temp_dir / 'lunardate.bin')
-      self.assertFalse(hko_data.common.encoded_data_ready())
-
-      # Ensure the encoded binary files are gone.
-      self.assertFalse(jieqi_path.exists())
-      self.assertFalse(lunardate_path.exists())
-
-      # The decoder only reads the committed data files; it never re-encodes them.
-      with self.assertRaises(RuntimeError):
-        hko_data.DecodedJieqiDates()
-      with self.assertRaises(RuntimeError):
-        hko_data.DecodedLunarYears()
-
-      # Encode them again, with the offline encoder tool.
-      encoder.do_encode()
-      self.assertIsNotNone(hko_data.DecodedJieqiDates())
-      self.assertTrue(hko_data.common.encoded_data_ready())
-
-      lunardate_path.unlink()
-      self.assertFalse(hko_data.common.encoded_data_ready())
-
-      # Encode them again, with the offline encoder tool.
-      encoder.do_encode()
-      self.assertIsNotNone(hko_data.DecodedLunarYears())
-      self.assertTrue(hko_data.common.encoded_data_ready())
-
-      # Ensure the new encoded binary files are the same as the old ones.
-      prev_jieqi_md5: str = hashlib.md5((temp_dir / 'jieqi.bin').read_bytes()).hexdigest()
-      prev_lunardate_md5: str = hashlib.md5((temp_dir / 'lunardate.bin').read_bytes()).hexdigest()
-
-      new_jieqi_md5: str = hashlib.md5(jieqi_path.read_bytes()).hexdigest()
-      new_lunardate_md5: str = hashlib.md5(lunardate_path.read_bytes()).hexdigest()
-
-      self.assertEqual(prev_jieqi_md5, new_jieqi_md5)
-      self.assertEqual(prev_lunardate_md5, new_lunardate_md5)
-
-    finally:
-      # Finally restore the original data folder.
-      # Also ensure the data is ready again after the above malicious operations.
-      shutil.copytree(temp_dir / 'data', data_path, dirs_exist_ok=True)
-      self.assertTrue(hko_data.common.raw_data_ready())
-
-      shutil.rmtree(temp_dir)
+pytestmark = pytest.mark.hkodata
+
+
+def test_traditional_chinese_jieqi() -> None:
+  assert len(hko_data.jieqi_list_in_traditional_chinese) == 24
+
+
+def test_traditional_chinese_month() -> None:
+  assert len(hko_data.twelve_months_in_traditional_chinese) == 12
+
+
+def test_int_bytes_conversion() -> None:
+  assert hko_data.int_to_bytes(0x12345678, 4) == b'\x12\x34\x56\x78'
+  assert hko_data.bytes_to_int(b'\x12\x34\x56\x78') == 0x12345678
+
+  for _ in range(512):
+    i: int = random.randint(0, 0xffffffff)
+    i_bytes: bytes = hko_data.int_to_bytes(i, 4)
+    assert i == hko_data.bytes_to_int(i_bytes)
+
+
+def test_date_bytes_conversion() -> None:
+  assert hko_data.date_to_bytes(date(2000, 1, 1)) == hko_data.date_to_bytes(date(2000, 1, 1))
+  assert hko_data.date_to_bytes(date(2000, 1, 1)) != hko_data.date_to_bytes(date(2000, 1, 2))
+  assert hko_data.bytes_to_date(b'\x00\x01\x01\x01') == date(1, 1, 1)
+  assert hko_data.bytes_to_date(hko_data.date_to_bytes(date(2024, 2, 25))) == date(2024, 2, 25)
+
+  dt: date = date(
+    year=random.randint(1600, 2500),
+    month=random.randint(1, 12),
+    day=random.randint(1, 28), # Not using 29, 30, or 31 here, to avoid invalid day (e.g. 2024-2-31)
+  )
+  for _ in range(512):
+    dt = dt + timedelta(days=random.randint(1, 3))
+    dt_bytes: bytes = hko_data.date_to_bytes(dt)
+    assert dt == hko_data.bytes_to_date(dt_bytes)
+    assert len(dt_bytes) == 4, f'expect the length of dt_bytes to be 4, but got {len(dt_bytes)}'
+    assert hko_data.bytes_to_int(dt_bytes[0:2]) == dt.year
+    assert hko_data.bytes_to_int(dt_bytes[2:3]) == dt.month
+    assert hko_data.bytes_to_int(dt_bytes[3:4]) == dt.day
+
+  with pytest.raises(ValueError):
+    hko_data.date_to_bytes(date(2024, 64, 1))
+  with pytest.raises(ValueError):
+    hko_data.date_to_bytes(date(2024, 12, 32))
+  with pytest.raises(ValueError):
+    hko_data.bytes_to_date(b'\x00\x01\x00\x00')
+  with pytest.raises(AssertionError):
+    hko_data.bytes_to_date(b'\x00\x00\x00\x00\x00\x01\x00\x00')
+  with pytest.raises(AssertionError):
+    hko_data.bytes_to_date(b'\x00\x00')
+  with pytest.raises(AssertionError):
+    hko_data.bytes_to_date(b'\x00\x00' * 10)
+
+
+def test_decode_jieqi() -> None:
+  decoded_jieqi: hko_data.DecodedJieqiDates = hko_data.DecodedJieqiDates()
+
+  # In our expectation, the data between gregorian year 1901 and 2100 (edges included) is valid.
+  for year in range(1901, 2100 + 1):
+    assert year in decoded_jieqi.supported_year_range()
+
+  for year in decoded_jieqi.supported_year_range():
+    assert len(decoded_jieqi[year]) == 24
+
+  assert min(decoded_jieqi.supported_year_range()) == hko_data.START_YEAR
+  assert max(decoded_jieqi.supported_year_range()) == hko_data.END_YEAR
+
+  for year in decoded_jieqi.supported_year_range():
+    jieqi_dates_dict: hko_data.JieqiDates = decoded_jieqi[year]
+    assert len(jieqi_dates_dict) == 24
+    assert set(jieqi_dates_dict.keys()) == set(Jieqi)
+
+  for year in decoded_jieqi.supported_year_range():
+    for jieqi in Jieqi:
+      assert decoded_jieqi.get(year, jieqi) == decoded_jieqi[year][jieqi]
+
+  assert decoded_jieqi[1964][Jieqi.寒露] == date(1964, 10, 8)
+  assert decoded_jieqi[1997][Jieqi.小寒] == date(1997, 1, 5)
+  assert decoded_jieqi[2024][Jieqi.立春] == date(2024, 2, 4)
+
+  assert decoded_jieqi.get(1964, Jieqi.寒露) == date(1964, 10, 8)
+  assert decoded_jieqi.get(1997, Jieqi.小寒) == date(1997, 1, 5)
+  assert decoded_jieqi.get(2024, Jieqi.立春) == date(2024, 2, 4)
+
+  another_decoded_jieqi: hko_data.DecodedJieqiDates = hko_data.DecodedJieqiDates()
+  assert list(decoded_jieqi.supported_year_range()) == list(another_decoded_jieqi.supported_year_range())
+
+  for year in decoded_jieqi.supported_year_range():
+    for jieqi in Jieqi:
+      assert decoded_jieqi.get(year, jieqi) == another_decoded_jieqi.get(year, jieqi)
+
+
+def test_decode_jieqi_getitem_negative() -> None:
+  decoded_jieqi: hko_data.DecodedJieqiDates = hko_data.DecodedJieqiDates()
+  with pytest.raises(AssertionError):
+    decoded_jieqi[1000]
+  with pytest.raises(AssertionError):
+    decoded_jieqi[min(decoded_jieqi.supported_year_range()) - 1]
+  with pytest.raises(AssertionError):
+    decoded_jieqi[max(decoded_jieqi.supported_year_range()) + 1]
+  with pytest.raises(AssertionError):
+    decoded_jieqi['2024'] # type: ignore
+  with pytest.raises(AssertionError):
+    decoded_jieqi[Jieqi.芒种] # type: ignore
+  with pytest.raises(AssertionError):
+    decoded_jieqi[:] # type: ignore
+  with pytest.raises(AssertionError):
+    decoded_jieqi[date(2024, 1, 1)] # type: ignore
+
+  data1 = decoded_jieqi[2024]
+  data2 = decoded_jieqi[2024]
+  assert data1 == data2
+  assert data1 is not data2
+
+  data2[Jieqi.惊蛰] = date(1999, 1, 1)
+  data3 = decoded_jieqi[2024]
+  assert data1 == data3
+  assert data1 != data2
+  assert data2 != data3
+
+
+def test_decode_jieqi_get_negative() -> None:
+  decoded_jieqi: hko_data.DecodedJieqiDates = hko_data.DecodedJieqiDates()
+  with pytest.raises(TypeError):
+    decoded_jieqi.get(2024)
+  with pytest.raises(TypeError):
+    decoded_jieqi.get(Jieqi.春分)
+  with pytest.raises(AssertionError):
+    decoded_jieqi.get('1000', Jieqi.寒露)
+  with pytest.raises(AssertionError):
+    decoded_jieqi.get(1000, Jieqi.寒露)
+  with pytest.raises(AssertionError):
+    decoded_jieqi.get(min(decoded_jieqi.supported_year_range()) - 1, Jieqi.寒露)
+  with pytest.raises(AssertionError):
+    decoded_jieqi.get(max(decoded_jieqi.supported_year_range()) + 1, Jieqi.寒露)
+
+  assert decoded_jieqi.get(2024, Jieqi.立春) == decoded_jieqi.get(2024, Jieqi.立春)
+  assert decoded_jieqi.get(2024, Jieqi.立春) is decoded_jieqi.get(2024, Jieqi.立春), 'should be the same object since it is cached'
+
+  lichun_2024_date = decoded_jieqi.get(2024, Jieqi.立春)
+  lichun_2024_date_ = decoded_jieqi.get(2024, Jieqi.立春)
+  lichun_2024_date_ = date(9999, 9, 9)
+  assert lichun_2024_date != lichun_2024_date_
+  assert lichun_2024_date == decoded_jieqi.get(2024, Jieqi.立春)
+
+  jieqi_dates_in_2024 = decoded_jieqi[2024]
+  assert jieqi_dates_in_2024[Jieqi.立春] == lichun_2024_date
+
+  jieqi_dates_in_2024[Jieqi.立春] = date(1996, 2, 4)
+  assert jieqi_dates_in_2024[Jieqi.立春] != lichun_2024_date
+  assert decoded_jieqi.get(2024, Jieqi.立春) == lichun_2024_date
+
+
+def test_decode_lunar_year() -> None:
+  decoded_lunardate: hko_data.DecodedLunarYears = hko_data.DecodedLunarYears()
+
+  # In our expectation, the lunar years in [1901, 2099] (edges included) are supported.
+  for year in range(1901, 2099 + 1):
+    assert year in decoded_lunardate.supported_year_range()
+
+  for year in decoded_lunardate.supported_year_range():
+    info1 = decoded_lunardate[year]
+    info2 = decoded_lunardate.get(year)
+    assert info1 is not info2
+    assert set(info1.keys()) == set(info2.keys())
+
+    assert info1['first_solar_day'] == info2['first_solar_day']
+    assert info1['leap'] == info2['leap']
+    assert info1['leap_month'] == info2['leap_month']
+    assert info1['days_counts'] == info2['days_counts']
+    assert info1['ganzhi'] == info2['ganzhi']
+
+    if info1['leap']:
+      assert info1['leap_month'] != 0
+      assert len(info1['days_counts']) == 13
+    else:
+      assert info1['leap_month'] is None
+      assert len(info1['days_counts']) == 12
+
+  expected_days_counts_2000: list[int] = [30, 30, 29, 29, 30, 29, 29, 30, 29, 30, 30, 29]
+  assert decoded_lunardate[2000]['first_solar_day'] == date(2000, 2, 5)
+  assert not decoded_lunardate[2000]['leap']
+  assert decoded_lunardate[2000]['leap_month'] is None
+  assert decoded_lunardate[2000]['days_counts'] == expected_days_counts_2000
+  assert decoded_lunardate[2000]['ganzhi'] == Ganzhi.from_str('庚辰')
+
+  expected_days_counts_2001: list[int] = [30, 30, 29, 30, 29, 30, 29, 29, 30, 29, 30, 29, 30]
+  assert decoded_lunardate[2001]['first_solar_day'] == date(2001, 1, 24)
+  assert decoded_lunardate[2001]['leap']
+  assert decoded_lunardate[2001]['leap_month'] == 4
+  assert decoded_lunardate[2001]['days_counts'] == expected_days_counts_2001
+  assert decoded_lunardate[2001]['ganzhi'] == Ganzhi.from_str('辛巳')
+
+  expected_days_counts_2024: list[int] = [29, 30, 29, 29, 30, 29, 30, 30, 29, 30, 30, 29]
+  assert decoded_lunardate[2024]['first_solar_day'] == date(2024, 2, 10)
+  assert not decoded_lunardate[2024]['leap']
+  assert decoded_lunardate[2024]['leap_month'] is None
+  assert decoded_lunardate[2024]['days_counts'] == expected_days_counts_2024
+  assert decoded_lunardate[2024]['ganzhi'] == Ganzhi.from_str('甲辰')
+
+  # 1924 is a year of "甲子" ganzhi.
+  assert decoded_lunardate[1924]['ganzhi'] == Ganzhi.from_str('甲子')
+  sexagenary_cycle = Ganzhi.list_sexagenary_cycle()
+  for year in decoded_lunardate.supported_year_range():
+    diff: int = year - 1924
+    expected_ganzhi: Ganzhi = sexagenary_cycle[diff % len(sexagenary_cycle)]
+    assert decoded_lunardate[year]['ganzhi'] == expected_ganzhi
+
+
+def test_decode_lunar_year_get_returns_a_copy() -> None:
+  '''
+  `get` leverages a cache, so it must hand back a rebuilt record: mutating what a caller
+  received must not corrupt later answers (issue #92).
+  '''
+  decoded_lunardate: hko_data.DecodedLunarYears = hko_data.DecodedLunarYears()
+  info: hko_data.LunarYearInfo = decoded_lunardate.get(2000)
+  assert info is not decoded_lunardate.get(2000)
+  assert info['days_counts'] is not decoded_lunardate.get(2000)['days_counts']
+
+  original_days_counts: list[int] = list(info['days_counts'])
+  info['days_counts'][0] = 999
+  info['leap_month'] = 7
+  assert decoded_lunardate.get(2000)['days_counts'] == original_days_counts
+  assert decoded_lunardate.get(2000)['leap_month'] is None
+
+
+def test_decode_lunar_year_negative() -> None:
+  decoded_lunardate: hko_data.DecodedLunarYears = hko_data.DecodedLunarYears()
+  with pytest.raises(AssertionError):
+    decoded_lunardate.get(min(decoded_lunardate.supported_year_range()) - 1)
+  with pytest.raises(AssertionError):
+    decoded_lunardate[min(decoded_lunardate.supported_year_range()) - 1]
+  with pytest.raises(AssertionError):
+    decoded_lunardate.get(max(decoded_lunardate.supported_year_range()) + 1)
+  with pytest.raises(AssertionError):
+    decoded_lunardate[max(decoded_lunardate.supported_year_range()) + 1]
+  with pytest.raises(AssertionError):
+    decoded_lunardate.get('a') # type: ignore
+  with pytest.raises(AssertionError):
+    decoded_lunardate.get('1984') # type: ignore
+  with pytest.raises(AssertionError):
+    decoded_lunardate.get(date(year=1984, month=1, day=1)) # type: ignore
+
+  temp = decoded_lunardate[2024]
+  temp['days_counts'].append(29)
+  temp['ganzhi'] = Ganzhi.from_str('甲子')
+
+  new_2024_info = decoded_lunardate[2024]
+  assert new_2024_info is not temp
+  assert new_2024_info['days_counts'] != temp['days_counts']
+  assert new_2024_info['ganzhi'] != temp['ganzhi']
+
+  expected_days_counts_2024: list[int] = [29, 30, 29, 29, 30, 29, 30, 30, 29, 30, 30, 29]
+  assert new_2024_info['first_solar_day'] == date(2024, 2, 10)
+  assert not new_2024_info['leap']
+  assert new_2024_info['leap_month'] is None
+  assert new_2024_info['days_counts'] == expected_days_counts_2024
+  assert new_2024_info['ganzhi'] == Ganzhi.from_str('甲辰')
+
+
+def test_file_existence() -> None:
+  '''The data files should exist and be readable.'''
+  data_path: Path = hko_data.get_data_base_path()
+  assert data_path.exists() and data_path.is_dir()
+
+  txt_paths: dict[int, Path] = hko_data.common.get_raw_txt_file_paths()
+  for path in txt_paths.values():
+    assert path.exists() and path.is_file()
+    with open(path, 'r', encoding='utf-8') as f:
+      assert f.read() != ''
+
+  assert hko_data.common.raw_data_ready()
+
+
+def test_raw_data_ready() -> None:
+  assert hko_data.common.raw_data_ready()
+
+  # Do something bad in between.
+
+  temp_dir: Path = Path(tempfile.mkdtemp())
+  data_path: Path = hko_data.common.get_data_base_path()
+  assert temp_dir.exists() and temp_dir.is_dir()
+  assert data_path.exists() and data_path.is_dir()
+
+  # Copy the data folder to the temporary folder.
+  shutil.copytree(data_path, temp_dir / 'data')
+
+  try:
+    shutil.move(data_path, temp_dir / 'data2')
+    assert not hko_data.common.raw_data_ready()
+
+    # Create a file called "data" (not a folder).
+    with open(data_path, 'w') as f:
+      f.write('I am not a folder!!!')
+    assert not hko_data.common.raw_data_ready()
+
+    # Remove the fake "data" file.
+    data_path.unlink()
+    assert not data_path.exists()
+
+    # Copy the original data folder back.
+    shutil.copytree(temp_dir / 'data', data_path)
+    assert hko_data.common.raw_data_ready()
+
+    all_txt_paths: dict[int, Path] = hko_data.common.get_raw_txt_file_paths()
+    random.choice(list(all_txt_paths.values())).unlink()
+    assert not hko_data.common.raw_data_ready()
+
+  finally:
+    # Finally restore the original data folder.
+    # Also ensure the data is ready again after the above malicious operations.
+    shutil.copytree(temp_dir / 'data', data_path, dirs_exist_ok=True)
+    assert hko_data.common.raw_data_ready()
+
+    shutil.rmtree(temp_dir)
+
+
+@pytest.mark.slow
+def test_do_encode() -> None:
+  assert hko_data.common.encoded_data_ready()
+
+  # Do something bad in between.
+
+  temp_dir: Path = Path(tempfile.mkdtemp())
+  jieqi_path: Path = hko_data.common.get_jieqi_encoded_data_path()
+  lunardate_path: Path = hko_data.common.get_lunardate_encoded_data_path()
+  assert temp_dir.exists() and temp_dir.is_dir()
+  assert jieqi_path.exists() and jieqi_path.is_file()
+  assert lunardate_path.exists() and lunardate_path.is_file()
+
+  # Copy the data folder to the temporary folder.
+  data_path: Path = hko_data.common.get_data_base_path()
+  shutil.copytree(data_path, temp_dir / 'data')
+
+  try:
+    # Copy the encoded binary files to the temporary folder.
+    shutil.move(jieqi_path, temp_dir / 'jieqi.bin')
+    assert not hko_data.common.encoded_data_ready()
+    shutil.move(lunardate_path, temp_dir / 'lunardate.bin')
+    assert not hko_data.common.encoded_data_ready()
+
+    # Ensure the encoded binary files are gone.
+    assert not jieqi_path.exists()
+    assert not lunardate_path.exists()
+
+    # The decoder only reads the committed data files; it never re-encodes them.
+    with pytest.raises(RuntimeError):
+      hko_data.DecodedJieqiDates()
+    with pytest.raises(RuntimeError):
+      hko_data.DecodedLunarYears()
+
+    # Encode them again, with the offline encoder tool.
+    encoder.do_encode()
+    assert hko_data.DecodedJieqiDates() is not None
+    assert hko_data.common.encoded_data_ready()
+
+    lunardate_path.unlink()
+    assert not hko_data.common.encoded_data_ready()
+
+    # Encode them again, with the offline encoder tool.
+    encoder.do_encode()
+    assert hko_data.DecodedLunarYears() is not None
+    assert hko_data.common.encoded_data_ready()
+
+    # Ensure the new encoded binary files are the same as the old ones.
+    prev_jieqi_md5: str = hashlib.md5((temp_dir / 'jieqi.bin').read_bytes()).hexdigest()
+    prev_lunardate_md5: str = hashlib.md5((temp_dir / 'lunardate.bin').read_bytes()).hexdigest()
+
+    new_jieqi_md5: str = hashlib.md5(jieqi_path.read_bytes()).hexdigest()
+    new_lunardate_md5: str = hashlib.md5(lunardate_path.read_bytes()).hexdigest()
+
+    assert prev_jieqi_md5 == new_jieqi_md5
+    assert prev_lunardate_md5 == new_lunardate_md5
+
+  finally:
+    # Finally restore the original data folder.
+    # Also ensure the data is ready again after the above malicious operations.
+    shutil.copytree(temp_dir / 'data', data_path, dirs_exist_ok=True)
+    assert hko_data.common.raw_data_ready()
+
+    shutil.rmtree(temp_dir)

--- a/tests/calendar/test_hko_data.py
+++ b/tests/calendar/test_hko_data.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2024 Ningqi Wang (0xf3cd) <https://github.com/0xf3cd>
-# test_hkodata.py
+# test_hko_data.py
 
 import random
 import shutil

--- a/tests/calendar/test_hko_data_utils.py
+++ b/tests/calendar/test_hko_data_utils.py
@@ -4,650 +4,660 @@
 import random
 import itertools
 import pytest
-import unittest
 
 from datetime import date, datetime, timedelta
 from typing import Any
 
-from src.calendar import CalendarType, CalendarDate, hko_data_utils, CalendarUtilsProtocol
+from src.calendar import CalendarType, CalendarDate, hko_data_utils
 from src.calendar.hko_data import DecodedLunarYears, DecodedJieqiDates
 from src.defines import Jieqi
 
-class TestHkoDataCalendarUtils(unittest.TestCase):
-  def test_conformance(self) -> None:
-    # hko_data_utils is a module...
-    # Making sure all required methods are implemented.
-    self.assertIsInstance(hko_data_utils, CalendarUtilsProtocol)
-
-  @pytest.mark.slow
-  def test_is_valid_solar_date(self) -> None:
-    d: date = date(1902, 1, 1)
-    while d < date(2099, 1, 1):
-      solar_date: CalendarDate = CalendarDate(d.year, d.month, d.day, CalendarType.SOLAR)
-      self.assertTrue(hko_data_utils.is_valid_solar_date(solar_date))
-      self.assertFalse(hko_data_utils.is_valid_lunar_date(solar_date))
-      self.assertFalse(hko_data_utils.is_valid_ganzhi_date(solar_date))
-      d = d + timedelta(days=1)
-
-    self.assertFalse(hko_data_utils.is_valid_solar_date(CalendarDate(2024, 1, 1, CalendarType.LUNAR)))
-    self.assertFalse(hko_data_utils.is_valid_solar_date(CalendarDate(2024, 1, 1, CalendarType.GANZHI)))
-    self.assertFalse(hko_data_utils.is_valid_solar_date(CalendarDate(9999, 2, 29, CalendarType.SOLAR))) # Out of supported range.
-    self.assertFalse(hko_data_utils.is_valid_solar_date(CalendarDate(2023, 2, 29, CalendarType.SOLAR)))
-    self.assertFalse(hko_data_utils.is_valid_solar_date(CalendarDate(2023, 13, 29, CalendarType.SOLAR)))
-    self.assertFalse(hko_data_utils.is_valid_solar_date(CalendarDate(1900, 2, 29, CalendarType.SOLAR)))
-    self.assertFalse(hko_data_utils.is_valid_solar_date(CalendarDate(2024, 2, 30, CalendarType.SOLAR)))
-    self.assertFalse(hko_data_utils.is_valid_solar_date(CalendarDate(2024, 4, 31, CalendarType.SOLAR)))
-    self.assertFalse(hko_data_utils.is_valid_solar_date(CalendarDate(2023, 0, 29, CalendarType.SOLAR)))
-    self.assertFalse(hko_data_utils.is_valid_solar_date(CalendarDate(2023, 1, 32, CalendarType.SOLAR)))
-    self.assertFalse(hko_data_utils.is_valid_solar_date(CalendarDate(0, 1, 15, CalendarType.SOLAR)))
-
-  @pytest.mark.slow
-  def test_is_valid_lunar_date(self) -> None:
-    lunar_years_db: DecodedLunarYears = DecodedLunarYears()
-    min_year: int = hko_data_utils.get_min_supported_date(CalendarType.LUNAR).year + 1
-    max_year: int = hko_data_utils.get_max_supported_date(CalendarType.LUNAR).year - 1
-
-    self.assertFalse(hko_data_utils.is_valid_lunar_date(CalendarDate(0, 1, 1, CalendarType.LUNAR))) # Out or supported range.
-    self.assertFalse(hko_data_utils.is_valid_lunar_date(CalendarDate(9999, 1, 1, CalendarType.LUNAR))) # Out of supported range.
-
-    for year in range(min_year, max_year + 1):
-      info = lunar_years_db[year]
-
-      for idx, count in enumerate(info['days_counts']):
-        month = idx + 1
-
-        for day in range(1, count + 1):
-          lunar_date: CalendarDate = CalendarDate(year, month, day, CalendarType.LUNAR)
-          self.assertFalse(hko_data_utils.is_valid_solar_date(lunar_date))
-          self.assertTrue(hko_data_utils.is_valid_lunar_date(lunar_date))
-          self.assertFalse(hko_data_utils.is_valid_ganzhi_date(lunar_date))
-
-        self.assertFalse(hko_data_utils.is_valid_lunar_date(CalendarDate(year, month, count + 1, CalendarType.LUNAR)))
-
-      self.assertFalse(hko_data_utils.is_valid_lunar_date(CalendarDate(year, len(info['days_counts']) + 1, 1, CalendarType.LUNAR)))
-
-  @pytest.mark.slow
-  def test_is_valid_ganzhi_date(self) -> None:
-    def __run_test_in_ganzhi_year(year: int) -> None:
-      days_counts: list[int] = hko_data_utils.days_counts_in_ganzhi_year(year)
-      for idx, count in enumerate(days_counts):
-        month: int = idx + 1
-        for day in range(1, count + 1):
-          ganzhi_date: CalendarDate = CalendarDate(year, month, day, CalendarType.GANZHI)
-          self.assertFalse(hko_data_utils.is_valid_solar_date(ganzhi_date))
-          self.assertFalse(hko_data_utils.is_valid_lunar_date(ganzhi_date))
-          self.assertTrue(hko_data_utils.is_valid_ganzhi_date(ganzhi_date))
-        self.assertFalse(hko_data_utils.is_valid_ganzhi_date(CalendarDate(year, month, count + 1, CalendarType.GANZHI)))
-      self.assertFalse(hko_data_utils.is_valid_ganzhi_date(CalendarDate(year, 0, 1, CalendarType.GANZHI)))
-      self.assertFalse(hko_data_utils.is_valid_ganzhi_date(CalendarDate(year, len(days_counts) + 1, 1, CalendarType.GANZHI)))
-
-    min_year: int = hko_data_utils.get_min_supported_date(CalendarType.LUNAR).year + 1
-    max_year: int = hko_data_utils.get_max_supported_date(CalendarType.LUNAR).year - 1
-    for year in range(min_year, max_year + 1):
-      __run_test_in_ganzhi_year(year)
-
-    self.assertFalse(hko_data_utils.is_valid_ganzhi_date(CalendarDate(0, 1, 1, CalendarType.GANZHI))) # Out or supported range.
-    self.assertFalse(hko_data_utils.is_valid_ganzhi_date(CalendarDate(9999, 1, 1, CalendarType.GANZHI))) # Out of supported range.
-
-  @pytest.mark.slow
-  def test_days_counts_in_ganzhi_year(self) -> None:
-    min_year: int = hko_data_utils.get_min_supported_date(CalendarType.GANZHI).year
-    max_year: int = hko_data_utils.get_max_supported_date(CalendarType.GANZHI).year
-
-    # Test negative cases first.
-    with self.assertRaises(AssertionError):
-      hko_data_utils.days_counts_in_ganzhi_year(-1)
-    with self.assertRaises(AssertionError):
-      hko_data_utils.days_counts_in_ganzhi_year(min_year - 1)
-    with self.assertRaises(AssertionError):
-      hko_data_utils.days_counts_in_ganzhi_year(max_year + 1)
-
-    # Test edge cases.
-    days_counts = hko_data_utils.days_counts_in_ganzhi_year(min_year)
-    for count in days_counts:
-      self.assertTrue(29 <= count <= 32) 
-    days_counts = hko_data_utils.days_counts_in_ganzhi_year(max_year)
-    for count in days_counts:
-      self.assertTrue(29 <= count <= 32) 
-
-    jieqi_dates_db: DecodedJieqiDates = DecodedJieqiDates()
-    month_starting_jieqis: list[Jieqi] = [ # List the jieqis that start new months in this ganzhi year.
-      Jieqi.立春, Jieqi.惊蛰, Jieqi.清明, Jieqi.立夏, Jieqi.芒种, Jieqi.小暑, 
-      Jieqi.立秋, Jieqi.白露, Jieqi.寒露, Jieqi.立冬, Jieqi.大雪, Jieqi.小寒,
-    ]
-    for year in range(min_year, max_year + 1):
-      dates: list[date] = []
-      # First 11 Jieqis will be in `year`, and the last Jieqi will be in `year + 1`.
-      for jq in month_starting_jieqis[:-1]:
-        dates.append(jieqi_dates_db.get(year, jq))
-      dates.append(jieqi_dates_db.get(year + 1, month_starting_jieqis[-1]))
-      dates.append(hko_data_utils.jieqi_dates_db.get(year + 1, Jieqi.立春)) # Start of the next ganzhi year.
-
-      days_counts = hko_data_utils.days_counts_in_ganzhi_year(year)
-      for idx, (start_date, next_start_date) in enumerate(itertools.pairwise(dates)):
-        days_in_this_month: int = days_counts[idx]
-        self.assertEqual(days_in_this_month, (next_start_date - start_date).days)
-
-  def test_days_counts_in_ganzhi_year_cannot_poison_the_cache(self) -> None:
-    '''
-    The lengths come from a cache, so handing back the cached list itself would let one
-    caller's in-place edit corrupt every later answer.  Worse, it would not stay contained:
-    `is_valid_ganzhi_date` caches verdicts computed from these lengths, so a wrong answer
-    cached during the poisoned window would outlive the edit (issue #92).
-    '''
-    counts: list[int] = hko_data_utils.days_counts_in_ganzhi_year(2000)
-    self.assertIsNot(counts, hko_data_utils.days_counts_in_ganzhi_year(2000))
-
-    # Poison, then FIRST-query a verdict computed from the lengths: month 1 of ganzhi
-    # year 2000 has 30 days, so day 31 must stay invalid even while the edit is live.
-    hko_data_utils.is_valid_ganzhi_date.cache_clear()
-    self.assertEqual(counts[0], 30)
-    counts[0] = 999
-    self.assertEqual(hko_data_utils.days_counts_in_ganzhi_year(2000)[0], 30)
-    self.assertFalse(hko_data_utils.is_valid_ganzhi_date(CalendarDate(2000, 1, 31, CalendarType.GANZHI)))
-
-  def test_is_valid(self) -> None:
-    for date_type in [CalendarType.SOLAR, CalendarType.LUNAR, CalendarType.GANZHI]:
-      min_date: CalendarDate = hko_data_utils.get_min_supported_date(date_type)
-      max_date: CalendarDate = hko_data_utils.get_max_supported_date(date_type)
-
-      self.assertTrue(hko_data_utils.is_valid(min_date))
-      self.assertTrue(hko_data_utils.is_valid(max_date))
-      self.assertFalse(hko_data_utils.is_valid(CalendarDate(0, 1, 1, date_type))) # Out or supported range.
-      self.assertFalse(hko_data_utils.is_valid(CalendarDate(9999, 1, 1, date_type))) # Out of supported range.
-
-    class __DuckTypeClass:
-      def __init__(self, anything: Any) -> None:
-        self.date_type = anything
-    self.assertFalse(hko_data_utils.is_valid(__DuckTypeClass(0))) # Test duck type.
-
-  @staticmethod
-  def __solar_date_gen(d: CalendarDate):
-    assert d.date_type == CalendarType.SOLAR
-    _d: date = date(d.year, d.month, d.day)
-    while True:
-      yield CalendarDate(_d.year, _d.month, _d.day, CalendarType.SOLAR)
-      _d = _d + timedelta(days=1)
-
-  @staticmethod
-  def __lunar_date_gen(d: CalendarDate):
-    assert d.date_type == CalendarType.LUNAR
-    _y, _m, _d = d.year, d.month, d.day
-    _lunar_year_db: DecodedLunarYears = DecodedLunarYears()
-    _year_data = _lunar_year_db.get(_y)
-    while True:
-      yield CalendarDate(_y, _m, _d, CalendarType.LUNAR)
-      _d += 1
-      if _d > _year_data['days_counts'][_m - 1]:
-        _d = 1
-        _m += 1
-        if _m > len(_year_data['days_counts']):
-          _m = 1
-          _y += 1
-          _year_data = _lunar_year_db.get(_y)
-
-  @staticmethod
-  def __ganzhi_date_gen(d: CalendarDate):
-    assert d.date_type == CalendarType.GANZHI
-    _y, _m, _d = d.year, d.month, d.day
-    _month_lengths: list[int] = hko_data_utils.days_counts_in_ganzhi_year(_y)
-    while True:
-      yield CalendarDate(_y, _m, _d, CalendarType.GANZHI)
-      _d += 1
-      if _d > _month_lengths[_m - 1]:
-        _d = 1
-        _m += 1
-        if _m > 12:
-          _m = 1
-          _y += 1
-          _month_lengths = hko_data_utils.days_counts_in_ganzhi_year(_y)
-  
-  @pytest.mark.slow
-  def test_lunar_to_solar(self) -> None:
-    min_lunar_date: CalendarDate = hko_data_utils.get_min_supported_date(CalendarType.LUNAR)
-    max_lunar_date: CalendarDate = hko_data_utils.get_max_supported_date(CalendarType.LUNAR)
-
-    self.assertEqual(hko_data_utils.lunar_to_solar(min_lunar_date),
-                     hko_data_utils.get_min_supported_date(CalendarType.SOLAR))
-    self.assertEqual(hko_data_utils.lunar_to_solar(max_lunar_date),
-                     hko_data_utils.get_max_supported_date(CalendarType.SOLAR))
-
-    solar_date_gen = self.__solar_date_gen(hko_data_utils.get_min_supported_date(CalendarType.SOLAR))
-    lunar_date_gen = self.__lunar_date_gen(hko_data_utils.get_min_supported_date(CalendarType.LUNAR))
-
-    while True:
-      solar_date = next(solar_date_gen)
-      lunar_date = next(lunar_date_gen)
-      self.assertEqual(solar_date, hko_data_utils.lunar_to_solar(lunar_date))
-
-      if lunar_date == max_lunar_date:
-        self.assertEqual(solar_date, hko_data_utils.get_max_supported_date(CalendarType.SOLAR))
-        break
-
-  @pytest.mark.slow
-  def test_solar_to_lunar(self) -> None:
-    min_solar_date: CalendarDate = hko_data_utils.get_min_supported_date(CalendarType.SOLAR)
-    max_solar_date: CalendarDate = hko_data_utils.get_max_supported_date(CalendarType.SOLAR)
-
-    self.assertEqual(hko_data_utils.solar_to_lunar(min_solar_date),
-                     hko_data_utils.get_min_supported_date(CalendarType.LUNAR))
-    self.assertEqual(hko_data_utils.solar_to_lunar(max_solar_date),
-                     hko_data_utils.get_max_supported_date(CalendarType.LUNAR))
-
-    solar_date_gen = self.__solar_date_gen(hko_data_utils.get_min_supported_date(CalendarType.SOLAR))
-    lunar_date_gen = self.__lunar_date_gen(hko_data_utils.get_min_supported_date(CalendarType.LUNAR))
-
-    while True:
-      solar_date = next(solar_date_gen)
-      lunar_date = next(lunar_date_gen)
-      self.assertEqual(lunar_date, hko_data_utils.solar_to_lunar(solar_date))
-
-      if solar_date == max_solar_date:
-        self.assertEqual(lunar_date, hko_data_utils.get_max_supported_date(CalendarType.LUNAR))
-        break
-
-  @pytest.mark.slow
-  def test_ganzhi_to_solar(self) -> None:
-    min_ganzhi_date: CalendarDate = hko_data_utils.get_min_supported_date(CalendarType.GANZHI)
-    max_ganzhi_date: CalendarDate = hko_data_utils.get_max_supported_date(CalendarType.GANZHI)
-
-    self.assertEqual(hko_data_utils.ganzhi_to_solar(min_ganzhi_date),
-                     hko_data_utils.get_min_supported_date(CalendarType.SOLAR))
-    self.assertEqual(hko_data_utils.ganzhi_to_solar(max_ganzhi_date),
-                     hko_data_utils.get_max_supported_date(CalendarType.SOLAR))
-    
-    solar_date_gen = self.__solar_date_gen(hko_data_utils.get_min_supported_date(CalendarType.SOLAR))
-    ganzhi_date_gen = self.__ganzhi_date_gen(hko_data_utils.get_min_supported_date(CalendarType.GANZHI))
-
-    while True:
-      solar_date = next(solar_date_gen)
-      ganzhi_date = next(ganzhi_date_gen)
-      self.assertEqual(solar_date, hko_data_utils.ganzhi_to_solar(ganzhi_date))
-
-      if ganzhi_date == max_ganzhi_date:
-        self.assertEqual(solar_date, hko_data_utils.get_max_supported_date(CalendarType.SOLAR))
-        break
-
-  @pytest.mark.slow
-  def test_solar_to_ganzhi(self) -> None:
-    min_solar_date: CalendarDate = hko_data_utils.get_min_supported_date(CalendarType.SOLAR)
-    max_solar_date: CalendarDate = hko_data_utils.get_max_supported_date(CalendarType.SOLAR)
-
-    self.assertEqual(hko_data_utils.solar_to_ganzhi(min_solar_date),
-                     hko_data_utils.get_min_supported_date(CalendarType.GANZHI))
-    self.assertEqual(hko_data_utils.solar_to_ganzhi(max_solar_date),
-                     hko_data_utils.get_max_supported_date(CalendarType.GANZHI))
-
-    solar_date_gen = self.__solar_date_gen(hko_data_utils.get_min_supported_date(CalendarType.SOLAR))
-    ganzhi_date_gen = self.__ganzhi_date_gen(hko_data_utils.get_min_supported_date(CalendarType.GANZHI))
-
-    while True:
-      solar_date = next(solar_date_gen)
-      ganzhi_date = next(ganzhi_date_gen)
-      self.assertEqual(ganzhi_date, hko_data_utils.solar_to_ganzhi(solar_date))
-
-      if solar_date == max_solar_date:
-        self.assertEqual(ganzhi_date, hko_data_utils.get_max_supported_date(CalendarType.GANZHI))
-        break
-
-  @pytest.mark.slow
-  def test_lunar_to_ganzhi(self) -> None:
-    min_lunar_date: CalendarDate = hko_data_utils.get_min_supported_date(CalendarType.LUNAR)
-    max_lunar_date: CalendarDate = hko_data_utils.get_max_supported_date(CalendarType.LUNAR)
-
-    self.assertEqual(hko_data_utils.lunar_to_ganzhi(min_lunar_date),
-                     hko_data_utils.get_min_supported_date(CalendarType.GANZHI))
-    self.assertEqual(hko_data_utils.lunar_to_ganzhi(max_lunar_date),
-                     hko_data_utils.get_max_supported_date(CalendarType.GANZHI))
-
-    lunar_date_gen = self.__lunar_date_gen(hko_data_utils.get_min_supported_date(CalendarType.LUNAR))
-    ganzhi_date_gen = self.__ganzhi_date_gen(hko_data_utils.get_min_supported_date(CalendarType.GANZHI))
-
-    while True:
-      lunar_date = next(lunar_date_gen)
-      ganzhi_date = next(ganzhi_date_gen)
-      self.assertEqual(ganzhi_date, hko_data_utils.lunar_to_ganzhi(lunar_date))
-
-      if lunar_date == max_lunar_date:
-        self.assertEqual(ganzhi_date, hko_data_utils.get_max_supported_date(CalendarType.GANZHI))
-        break
-
-  @pytest.mark.slow
-  def test_ganzhi_to_lunar(self) -> None:
-    min_ganzhi_date: CalendarDate = hko_data_utils.get_min_supported_date(CalendarType.GANZHI)
-    max_ganzhi_date: CalendarDate = hko_data_utils.get_max_supported_date(CalendarType.GANZHI)
-
-    self.assertEqual(hko_data_utils.ganzhi_to_lunar(min_ganzhi_date),
-                     hko_data_utils.get_min_supported_date(CalendarType.LUNAR))
-    self.assertEqual(hko_data_utils.ganzhi_to_lunar(max_ganzhi_date),
-                     hko_data_utils.get_max_supported_date(CalendarType.LUNAR))
-
-    ganzhi_date_gen = self.__ganzhi_date_gen(hko_data_utils.get_min_supported_date(CalendarType.GANZHI))
-    lunar_date_gen = self.__lunar_date_gen(hko_data_utils.get_min_supported_date(CalendarType.LUNAR))
-
-    while True:
-      ganzhi_date = next(ganzhi_date_gen)
-      lunar_date = next(lunar_date_gen)
-      self.assertEqual(lunar_date, hko_data_utils.ganzhi_to_lunar(ganzhi_date))
-
-      if ganzhi_date == max_ganzhi_date:
-        self.assertEqual(lunar_date, hko_data_utils.get_max_supported_date(CalendarType.LUNAR))
-        break
-
-  @pytest.mark.slow
-  def test_complex_date_conversions(self) -> None:
-    solar_date_gen = self.__solar_date_gen(hko_data_utils.get_min_supported_date(CalendarType.SOLAR))
-    lunar_date_gen = self.__lunar_date_gen(hko_data_utils.get_min_supported_date(CalendarType.LUNAR))
-    ganzhi_date_gen = self.__ganzhi_date_gen(hko_data_utils.get_min_supported_date(CalendarType.GANZHI))
-
-    for _ in range(4096):
-      solar_date = next(solar_date_gen)
-      lunar_date = next(lunar_date_gen)
-      ganzhi_date = next(ganzhi_date_gen)
-
-      with self.subTest('ganzhi'):
-        _solar_date = hko_data_utils.ganzhi_to_solar(ganzhi_date)
-        _lunar_date = hko_data_utils.ganzhi_to_lunar(ganzhi_date)
-
-        self.assertEqual(solar_date, _solar_date)
-        self.assertEqual(lunar_date, _lunar_date)
-        self.assertEqual(ganzhi_date, hko_data_utils.solar_to_ganzhi(_solar_date))
-        self.assertEqual(ganzhi_date, hko_data_utils.lunar_to_ganzhi(_lunar_date))
-
-      with self.subTest('solar'):
-        _lunar_date = hko_data_utils.solar_to_lunar(solar_date)
-        _ganzhi_date = hko_data_utils.solar_to_ganzhi(solar_date)
-
-        self.assertEqual(lunar_date, _lunar_date)
-        self.assertEqual(ganzhi_date, _ganzhi_date)
-        self.assertEqual(solar_date, hko_data_utils.lunar_to_solar(_lunar_date))
-        self.assertEqual(solar_date, hko_data_utils.ganzhi_to_solar(_ganzhi_date))
-
-      with self.subTest('lunar'):
-        _solar_date = hko_data_utils.lunar_to_solar(lunar_date)
-        _ganzhi_date = hko_data_utils.lunar_to_ganzhi(lunar_date)
-
-        self.assertEqual(solar_date, _solar_date)
-        self.assertEqual(ganzhi_date, _ganzhi_date)
-        self.assertEqual(lunar_date, hko_data_utils.solar_to_lunar(_solar_date))
-        self.assertEqual(lunar_date, hko_data_utils.ganzhi_to_lunar(_ganzhi_date))
-
-  def test_date_conversions_negative(self) -> None:
-    with self.subTest('ganzhi_to_lunar negative'):
-      with self.assertRaises(AssertionError):
-        hko_data_utils.ganzhi_to_lunar(CalendarDate(1, 1, 1, CalendarType.GANZHI))
-      with self.assertRaises(AssertionError):
-        hko_data_utils.ganzhi_to_lunar(CalendarDate(2024, 1, 1, CalendarType.SOLAR))
-
-    with self.subTest('lunar_to_ganzhi negative'):
-      with self.assertRaises(AssertionError):
-        hko_data_utils.lunar_to_ganzhi(CalendarDate(1, 1, 1, CalendarType.LUNAR))
-      with self.assertRaises(AssertionError):
-        hko_data_utils.lunar_to_ganzhi(CalendarDate(2024, 1, 1, CalendarType.SOLAR))
-
-    with self.subTest('solar_to_lunar negative'):
-      with self.assertRaises(AssertionError):
-        hko_data_utils.solar_to_lunar(CalendarDate(1, 1, 1, CalendarType.SOLAR))
-      with self.assertRaises(AssertionError):
-        hko_data_utils.solar_to_lunar(CalendarDate(2024, 1, 1, CalendarType.GANZHI))
-
-    with self.subTest('lunar_to_solar negative'):
-      with self.assertRaises(AssertionError):
-        hko_data_utils.lunar_to_solar(CalendarDate(1, 1, 1, CalendarType.LUNAR))
-      with self.assertRaises(AssertionError):
-        hko_data_utils.lunar_to_solar(CalendarDate(2024, 1, 1, CalendarType.GANZHI))
-
-    with self.subTest('solar_to_ganzhi negative'):
-      with self.assertRaises(AssertionError):
-        hko_data_utils.solar_to_ganzhi(CalendarDate(1, 1, 1, CalendarType.SOLAR))
-      with self.assertRaises(AssertionError):
-        hko_data_utils.solar_to_ganzhi(CalendarDate(2024, 1, 1, CalendarType.GANZHI))
-
-    with self.subTest('ganzhi_to_solar negative'):
-      with self.assertRaises(AssertionError):
-        hko_data_utils.ganzhi_to_solar(CalendarDate(1, 1, 1, CalendarType.GANZHI))
-      with self.assertRaises(AssertionError):
-        hko_data_utils.ganzhi_to_solar(CalendarDate(2024, 1, 1, CalendarType.SOLAR))
-
-  def test_to_solar(self) -> None:
-    with self.subTest('Positive cases'):
-      d: date = date(2023, 5, 8)
-      solar_date: CalendarDate = hko_data_utils.to_solar(d)
-      self.assertEqual(solar_date, CalendarDate(2023, 5, 8, CalendarType.SOLAR))
-      self.assertEqual(solar_date, hko_data_utils.to_solar(d))
-      self.assertEqual(solar_date, hko_data_utils.to_solar(solar_date))
-      self.assertEqual(solar_date, hko_data_utils.to_solar(hko_data_utils.solar_to_lunar(solar_date)))
-      self.assertEqual(solar_date, hko_data_utils.to_solar(hko_data_utils.solar_to_ganzhi(solar_date)))
-    
-    with self.subTest('Negative cases'):
-      with self.assertRaises(AssertionError):
-        hko_data_utils.to_solar(CalendarDate(9999, 1, 1, CalendarType.SOLAR)) # Invalid date
-      with self.assertRaises(AssertionError):
-        hko_data_utils.to_solar('2024-01-01') # Invalid type
-
-  def test_to_lunar(self) -> None:
-    with self.subTest('Positive cases'):
-      d: date = date(2023, 5, 8)
-      lunar_date: CalendarDate = hko_data_utils.to_lunar(d)
-      self.assertEqual(lunar_date, hko_data_utils.solar_to_lunar(CalendarDate(2023, 5, 8, CalendarType.SOLAR)))
-      self.assertEqual(lunar_date, hko_data_utils.to_lunar(d))
-      self.assertEqual(lunar_date, hko_data_utils.to_lunar(lunar_date))
-      self.assertEqual(lunar_date, hko_data_utils.to_lunar(hko_data_utils.lunar_to_solar(lunar_date)))
-      self.assertEqual(lunar_date, hko_data_utils.to_lunar(hko_data_utils.lunar_to_ganzhi(lunar_date)))
-    
-    with self.subTest('Negative cases'):
-      with self.assertRaises(AssertionError):
-        hko_data_utils.to_lunar(CalendarDate(9999, 1, 1, CalendarType.LUNAR)) # Invalid date
-      with self.assertRaises(AssertionError):
-        hko_data_utils.to_lunar('2024-01-01') # Invalid type
-
-  def test_to_ganzhi(self) -> None:
-    with self.subTest('Positive cases'):
-      d: date = date(2023, 5, 8)
-      ganzhi_date: CalendarDate = hko_data_utils.to_ganzhi(d)
-      self.assertEqual(ganzhi_date, hko_data_utils.solar_to_ganzhi(CalendarDate(2023, 5, 8, CalendarType.SOLAR)))
-      self.assertEqual(ganzhi_date, hko_data_utils.to_ganzhi(d))
-      self.assertEqual(ganzhi_date, hko_data_utils.to_ganzhi(ganzhi_date))
-      self.assertEqual(ganzhi_date, hko_data_utils.to_ganzhi(hko_data_utils.ganzhi_to_solar(ganzhi_date)))
-      self.assertEqual(ganzhi_date, hko_data_utils.to_ganzhi(hko_data_utils.ganzhi_to_lunar(ganzhi_date)))
-    
-    with self.subTest('Negative cases'):
-      with self.assertRaises(AssertionError):
-        hko_data_utils.to_ganzhi(CalendarDate(9999, 1, 1, CalendarType.GANZHI)) # Invalid date
-      with self.assertRaises(AssertionError):
-        hko_data_utils.to_ganzhi('2024-01-01') # Invalid type
-
-  def test_to_date(self) -> None:
-    d = date(2023, 5, 8)
-    self.assertEqual(hko_data_utils.to_date(d), d)
-
-    dt = datetime(2023, 5, 8, 1, 2, 3)
-    self.assertEqual(hko_data_utils.to_date(dt), d)
-
-    cd = CalendarDate(2000, 1, 1, CalendarType.SOLAR)
-    self.assertEqual(hko_data_utils.to_date(cd), date(2000, 1, 1))
-
-    cd = CalendarDate(1901, 1, 1, CalendarType.LUNAR)
-    self.assertEqual(hko_data_utils.to_date(cd), date(1901, 2, 19))
-
-    with self.subTest('Negative cases'):
-      with self.assertRaises(AssertionError):
-        hko_data_utils.to_date(CalendarDate(9999, 1, 1, CalendarType.GANZHI)) # Invalid date
-      with self.assertRaises(AssertionError):
-        hko_data_utils.to_date('2024-01-01') # Invalid type
-
-  def test_get_jieqi_date(self) -> None:
-    self.assertRaises(AssertionError, lambda: hko_data_utils.jieqi_date('2024', Jieqi.大寒))
-    self.assertRaises(AssertionError, lambda: hko_data_utils.jieqi_date(2024, '大寒'))
-    self.assertRaises(AssertionError, lambda: hko_data_utils.jieqi_date(9999, Jieqi.大寒)) # Out of supported solar year range.
-    self.assertRaises(AssertionError, lambda: hko_data_utils.jieqi_date(2101, Jieqi.小寒)) # Out of supported solar year range.
-    self.assertRaises(AssertionError, lambda: hko_data_utils.jieqi_date(0, Jieqi.大寒)) # Out of supported solar year range.
-    self.assertRaises(AssertionError, lambda: hko_data_utils.jieqi_date(1900, Jieqi.冬至)) # Out of supported solar year range.
-
-    self.assertEqual(hko_data_utils.jieqi_date(1901, Jieqi.小寒), date(1901, 1, 6))
-    self.assertEqual(hko_data_utils.jieqi_date(2100, Jieqi.冬至), date(2100, 12, 22))
-
-    self.assertEqual(hko_data_utils.jieqi_date(2024, Jieqi.大寒), date(2024, 1, 20))
-    self.assertEqual(hko_data_utils.jieqi_date(1997, Jieqi.小寒), date(1997, 1, 5))
-    self.assertEqual(hko_data_utils.jieqi_date(2000, Jieqi.立春), date(2000, 2, 4))
-    self.assertEqual(hko_data_utils.jieqi_date(2005, Jieqi.雨水), date(2005, 2, 18))
-
-    random_solar_year: int = random.randint(1901, 2100)
+
+@pytest.mark.slow
+def test_is_valid_solar_date() -> None:
+  d: date = date(1902, 1, 1)
+  while d < date(2099, 1, 1):
+    solar_date: CalendarDate = CalendarDate(d.year, d.month, d.day, CalendarType.SOLAR)
+    assert hko_data_utils.is_valid_solar_date(solar_date)
+    assert not hko_data_utils.is_valid_lunar_date(solar_date)
+    assert not hko_data_utils.is_valid_ganzhi_date(solar_date)
+    d = d + timedelta(days=1)
+
+  assert not hko_data_utils.is_valid_solar_date(CalendarDate(2024, 1, 1, CalendarType.LUNAR))
+  assert not hko_data_utils.is_valid_solar_date(CalendarDate(2024, 1, 1, CalendarType.GANZHI))
+  assert not hko_data_utils.is_valid_solar_date(CalendarDate(9999, 2, 29, CalendarType.SOLAR)) # Out of supported range.
+  assert not hko_data_utils.is_valid_solar_date(CalendarDate(2023, 2, 29, CalendarType.SOLAR))
+  assert not hko_data_utils.is_valid_solar_date(CalendarDate(2023, 13, 29, CalendarType.SOLAR))
+  assert not hko_data_utils.is_valid_solar_date(CalendarDate(1900, 2, 29, CalendarType.SOLAR))
+  assert not hko_data_utils.is_valid_solar_date(CalendarDate(2024, 2, 30, CalendarType.SOLAR))
+  assert not hko_data_utils.is_valid_solar_date(CalendarDate(2024, 4, 31, CalendarType.SOLAR))
+  assert not hko_data_utils.is_valid_solar_date(CalendarDate(2023, 0, 29, CalendarType.SOLAR))
+  assert not hko_data_utils.is_valid_solar_date(CalendarDate(2023, 1, 32, CalendarType.SOLAR))
+  assert not hko_data_utils.is_valid_solar_date(CalendarDate(0, 1, 15, CalendarType.SOLAR))
+
+
+@pytest.mark.slow
+def test_is_valid_lunar_date() -> None:
+  lunar_years_db: DecodedLunarYears = DecodedLunarYears()
+  min_year: int = hko_data_utils.get_min_supported_date(CalendarType.LUNAR).year + 1
+  max_year: int = hko_data_utils.get_max_supported_date(CalendarType.LUNAR).year - 1
+
+  assert not hko_data_utils.is_valid_lunar_date(CalendarDate(0, 1, 1, CalendarType.LUNAR)) # Out or supported range.
+  assert not hko_data_utils.is_valid_lunar_date(CalendarDate(9999, 1, 1, CalendarType.LUNAR)) # Out of supported range.
+
+  for year in range(min_year, max_year + 1):
+    info = lunar_years_db[year]
+
+    for idx, count in enumerate(info['days_counts']):
+      month = idx + 1
+
+      for day in range(1, count + 1):
+        lunar_date: CalendarDate = CalendarDate(year, month, day, CalendarType.LUNAR)
+        assert not hko_data_utils.is_valid_solar_date(lunar_date)
+        assert hko_data_utils.is_valid_lunar_date(lunar_date)
+        assert not hko_data_utils.is_valid_ganzhi_date(lunar_date)
+
+      assert not hko_data_utils.is_valid_lunar_date(CalendarDate(year, month, count + 1, CalendarType.LUNAR))
+
+    assert not hko_data_utils.is_valid_lunar_date(CalendarDate(year, len(info['days_counts']) + 1, 1, CalendarType.LUNAR))
+
+
+@pytest.mark.slow
+def test_is_valid_ganzhi_date() -> None:
+  def __run_test_in_ganzhi_year(year: int) -> None:
+    days_counts: list[int] = hko_data_utils.days_counts_in_ganzhi_year(year)
+    for idx, count in enumerate(days_counts):
+      month: int = idx + 1
+      for day in range(1, count + 1):
+        ganzhi_date: CalendarDate = CalendarDate(year, month, day, CalendarType.GANZHI)
+        assert not hko_data_utils.is_valid_solar_date(ganzhi_date)
+        assert not hko_data_utils.is_valid_lunar_date(ganzhi_date)
+        assert hko_data_utils.is_valid_ganzhi_date(ganzhi_date)
+      assert not hko_data_utils.is_valid_ganzhi_date(CalendarDate(year, month, count + 1, CalendarType.GANZHI))
+    assert not hko_data_utils.is_valid_ganzhi_date(CalendarDate(year, 0, 1, CalendarType.GANZHI))
+    assert not hko_data_utils.is_valid_ganzhi_date(CalendarDate(year, len(days_counts) + 1, 1, CalendarType.GANZHI))
+
+  min_year: int = hko_data_utils.get_min_supported_date(CalendarType.LUNAR).year + 1
+  max_year: int = hko_data_utils.get_max_supported_date(CalendarType.LUNAR).year - 1
+  for year in range(min_year, max_year + 1):
+    __run_test_in_ganzhi_year(year)
+
+  assert not hko_data_utils.is_valid_ganzhi_date(CalendarDate(0, 1, 1, CalendarType.GANZHI)) # Out or supported range.
+  assert not hko_data_utils.is_valid_ganzhi_date(CalendarDate(9999, 1, 1, CalendarType.GANZHI)) # Out of supported range.
+
+
+@pytest.mark.slow
+def test_days_counts_in_ganzhi_year() -> None:
+  min_year: int = hko_data_utils.get_min_supported_date(CalendarType.GANZHI).year
+  max_year: int = hko_data_utils.get_max_supported_date(CalendarType.GANZHI).year
+
+  # Test negative cases first.
+  with pytest.raises(AssertionError):
+    hko_data_utils.days_counts_in_ganzhi_year(-1)
+  with pytest.raises(AssertionError):
+    hko_data_utils.days_counts_in_ganzhi_year(min_year - 1)
+  with pytest.raises(AssertionError):
+    hko_data_utils.days_counts_in_ganzhi_year(max_year + 1)
+
+  # Test edge cases.
+  days_counts = hko_data_utils.days_counts_in_ganzhi_year(min_year)
+  for count in days_counts:
+    assert 29 <= count <= 32
+  days_counts = hko_data_utils.days_counts_in_ganzhi_year(max_year)
+  for count in days_counts:
+    assert 29 <= count <= 32
+
+  jieqi_dates_db: DecodedJieqiDates = DecodedJieqiDates()
+  month_starting_jieqis: list[Jieqi] = [ # List the jieqis that start new months in this ganzhi year.
+    Jieqi.立春, Jieqi.惊蛰, Jieqi.清明, Jieqi.立夏, Jieqi.芒种, Jieqi.小暑,
+    Jieqi.立秋, Jieqi.白露, Jieqi.寒露, Jieqi.立冬, Jieqi.大雪, Jieqi.小寒,
+  ]
+  for year in range(min_year, max_year + 1):
     dates: list[date] = []
-    for jieqi in Jieqi.as_list(ganzhi_year=False):
-      dates.append(hko_data_utils.jieqi_date(random_solar_year, jieqi))
-    for d1, d2 in itertools.pairwise(dates):
-      self.assertLess(d1, d2)
+    # First 11 Jieqis will be in `year`, and the last Jieqi will be in `year + 1`.
+    for jq in month_starting_jieqis[:-1]:
+      dates.append(jieqi_dates_db.get(year, jq))
+    dates.append(jieqi_dates_db.get(year + 1, month_starting_jieqis[-1]))
+    dates.append(hko_data_utils.jieqi_dates_db.get(year + 1, Jieqi.立春)) # Start of the next ganzhi year.
 
-  def test_get_jieqi_moment(self) -> None:
-    self.assertRaises(AssertionError, lambda: hko_data_utils.jieqi_moment('2024', Jieqi.大寒))
-    self.assertRaises(AssertionError, lambda: hko_data_utils.jieqi_moment(2024, '大寒'))
-    self.assertRaises(AssertionError, lambda: hko_data_utils.jieqi_moment(9999, Jieqi.大寒)) # Out of supported solar year range.
-    self.assertRaises(AssertionError, lambda: hko_data_utils.jieqi_moment(2101, Jieqi.小寒)) # Out of supported solar year range.
-    self.assertRaises(AssertionError, lambda: hko_data_utils.jieqi_moment(0, Jieqi.大寒)) # Out of supported solar year range.
+    days_counts = hko_data_utils.days_counts_in_ganzhi_year(year)
+    for idx, (start_date, next_start_date) in enumerate(itertools.pairwise(dates)):
+      days_in_this_month: int = days_counts[idx]
+      assert days_in_this_month == (next_start_date - start_date).days
 
-    # HKO data only supported day-level precision.
-    # So all returned moments are always at the beginning of the day.
-    self.assertEqual(hko_data_utils.jieqi_moment(1901, Jieqi.小寒), datetime(1901, 1, 6, 0, 0, 0))
-    self.assertEqual(hko_data_utils.jieqi_moment(2100, Jieqi.冬至), datetime(2100, 12, 22, 0, 0, 0))
 
-    self.assertEqual(hko_data_utils.jieqi_moment(2024, Jieqi.大寒), datetime(2024, 1, 20, 0, 0, 0))
-    self.assertEqual(hko_data_utils.jieqi_moment(1997, Jieqi.小寒), datetime(1997, 1, 5, 0, 0, 0))
-    self.assertEqual(hko_data_utils.jieqi_moment(2000, Jieqi.立春), datetime(2000, 2, 4, 0, 0, 0))
-    self.assertEqual(hko_data_utils.jieqi_moment(2005, Jieqi.雨水), datetime(2005, 2, 18, 0, 0, 0))
+def test_days_counts_in_ganzhi_year_cannot_poison_the_cache() -> None:
+  '''
+  The lengths come from a cache, so handing back the cached list itself would let one
+  caller's in-place edit corrupt every later answer.  Worse, it would not stay contained:
+  `is_valid_ganzhi_date` caches verdicts computed from these lengths, so a wrong answer
+  cached during the poisoned window would outlive the edit (issue #92).
+  '''
+  counts: list[int] = hko_data_utils.days_counts_in_ganzhi_year(2000)
+  assert counts is not hko_data_utils.days_counts_in_ganzhi_year(2000)
 
-    random_solar_year: int = random.randint(1901, 2100)
-    datetimes: list[datetime] = []
-    for jieqi in Jieqi.as_list(ganzhi_year=False): # The first Jieqi in a solar year is always "小寒".
-      datetimes.append(hko_data_utils.jieqi_moment(random_solar_year, jieqi))
-    for d1, d2 in itertools.pairwise(datetimes):
-      self.assertLess(d1, d2)
+  # Poison, then FIRST-query a verdict computed from the lengths: month 1 of ganzhi
+  # year 2000 has 30 days, so day 31 must stay invalid even while the edit is live.
+  hko_data_utils.is_valid_ganzhi_date.cache_clear()
+  assert counts[0] == 30
+  counts[0] = 999
+  assert hko_data_utils.days_counts_in_ganzhi_year(2000)[0] == 30
+  assert not hko_data_utils.is_valid_ganzhi_date(CalendarDate(2000, 1, 31, CalendarType.GANZHI))
 
-  def test_prev_jie(self) -> None:
-    supported_range: tuple[datetime, datetime] = hko_data_utils.supported_jie_boundaries()
-    
-    self.assertRaises(AssertionError, hko_data_utils.prev_jie, '2024-06-15')
-    self.assertRaises(ValueError, hko_data_utils.prev_jie, datetime(1899, 12, 31))
-    self.assertRaises(ValueError, hko_data_utils.prev_jie, datetime(2101, 1, 1))
-    self.assertRaises(ValueError, hko_data_utils.prev_jie, supported_range[0] - timedelta(microseconds=1))
-    self.assertRaises(ValueError, hko_data_utils.prev_jie, supported_range[1])
 
-    for _ in range(500):
-      random_dt: datetime = datetime(
-        year=random.randint(1800, 2200),
-        month=random.randint(1, 12),
-        day=random.randint(1, 28),
-        hour=random.randint(0, 23),
-        minute=random.randint(0, 59),
-        second=random.randint(0, 59),
-      )
-      if supported_range[0] <= random_dt < supported_range[1]: # In supported range.
-        self.assertIsInstance(hko_data_utils.prev_jie(random_dt), tuple)
-      else:
-        self.assertRaises(ValueError, hko_data_utils.prev_jie, random_dt)
+def test_is_valid() -> None:
+  for date_type in [CalendarType.SOLAR, CalendarType.LUNAR, CalendarType.GANZHI]:
+    min_date: CalendarDate = hko_data_utils.get_min_supported_date(date_type)
+    max_date: CalendarDate = hko_data_utils.get_max_supported_date(date_type)
 
-    self.assertTupleEqual(
-      hko_data_utils.prev_jie(hko_data_utils.jieqi_moment(2024, Jieqi.大雪)),
-      (Jieqi.大雪, hko_data_utils.jieqi_moment(2024, Jieqi.大雪))
+    assert hko_data_utils.is_valid(min_date)
+    assert hko_data_utils.is_valid(max_date)
+    assert not hko_data_utils.is_valid(CalendarDate(0, 1, 1, date_type)) # Out or supported range.
+    assert not hko_data_utils.is_valid(CalendarDate(9999, 1, 1, date_type)) # Out of supported range.
+
+  class __DuckTypeClass:
+    def __init__(self, anything: Any) -> None:
+      self.date_type = anything
+  assert not hko_data_utils.is_valid(__DuckTypeClass(0)) # Test duck type.
+
+
+def _solar_date_gen(d: CalendarDate):
+  assert d.date_type == CalendarType.SOLAR
+  _d: date = date(d.year, d.month, d.day)
+  while True:
+    yield CalendarDate(_d.year, _d.month, _d.day, CalendarType.SOLAR)
+    _d = _d + timedelta(days=1)
+
+
+def _lunar_date_gen(d: CalendarDate):
+  assert d.date_type == CalendarType.LUNAR
+  _y, _m, _d = d.year, d.month, d.day
+  _lunar_year_db: DecodedLunarYears = DecodedLunarYears()
+  _year_data = _lunar_year_db.get(_y)
+  while True:
+    yield CalendarDate(_y, _m, _d, CalendarType.LUNAR)
+    _d += 1
+    if _d > _year_data['days_counts'][_m - 1]:
+      _d = 1
+      _m += 1
+      if _m > len(_year_data['days_counts']):
+        _m = 1
+        _y += 1
+        _year_data = _lunar_year_db.get(_y)
+
+
+def _ganzhi_date_gen(d: CalendarDate):
+  assert d.date_type == CalendarType.GANZHI
+  _y, _m, _d = d.year, d.month, d.day
+  _month_lengths: list[int] = hko_data_utils.days_counts_in_ganzhi_year(_y)
+  while True:
+    yield CalendarDate(_y, _m, _d, CalendarType.GANZHI)
+    _d += 1
+    if _d > _month_lengths[_m - 1]:
+      _d = 1
+      _m += 1
+      if _m > 12:
+        _m = 1
+        _y += 1
+        _month_lengths = hko_data_utils.days_counts_in_ganzhi_year(_y)
+
+
+@pytest.mark.slow
+def test_lunar_to_solar() -> None:
+  min_lunar_date: CalendarDate = hko_data_utils.get_min_supported_date(CalendarType.LUNAR)
+  max_lunar_date: CalendarDate = hko_data_utils.get_max_supported_date(CalendarType.LUNAR)
+
+  assert hko_data_utils.lunar_to_solar(min_lunar_date) == hko_data_utils.get_min_supported_date(CalendarType.SOLAR)
+  assert hko_data_utils.lunar_to_solar(max_lunar_date) == hko_data_utils.get_max_supported_date(CalendarType.SOLAR)
+
+  solar_date_gen = _solar_date_gen(hko_data_utils.get_min_supported_date(CalendarType.SOLAR))
+  lunar_date_gen = _lunar_date_gen(hko_data_utils.get_min_supported_date(CalendarType.LUNAR))
+
+  while True:
+    solar_date = next(solar_date_gen)
+    lunar_date = next(lunar_date_gen)
+    assert solar_date == hko_data_utils.lunar_to_solar(lunar_date)
+
+    if lunar_date == max_lunar_date:
+      assert solar_date == hko_data_utils.get_max_supported_date(CalendarType.SOLAR)
+      break
+
+
+@pytest.mark.slow
+def test_solar_to_lunar() -> None:
+  min_solar_date: CalendarDate = hko_data_utils.get_min_supported_date(CalendarType.SOLAR)
+  max_solar_date: CalendarDate = hko_data_utils.get_max_supported_date(CalendarType.SOLAR)
+
+  assert hko_data_utils.solar_to_lunar(min_solar_date) == hko_data_utils.get_min_supported_date(CalendarType.LUNAR)
+  assert hko_data_utils.solar_to_lunar(max_solar_date) == hko_data_utils.get_max_supported_date(CalendarType.LUNAR)
+
+  solar_date_gen = _solar_date_gen(hko_data_utils.get_min_supported_date(CalendarType.SOLAR))
+  lunar_date_gen = _lunar_date_gen(hko_data_utils.get_min_supported_date(CalendarType.LUNAR))
+
+  while True:
+    solar_date = next(solar_date_gen)
+    lunar_date = next(lunar_date_gen)
+    assert lunar_date == hko_data_utils.solar_to_lunar(solar_date)
+
+    if solar_date == max_solar_date:
+      assert lunar_date == hko_data_utils.get_max_supported_date(CalendarType.LUNAR)
+      break
+
+
+@pytest.mark.slow
+def test_ganzhi_to_solar() -> None:
+  min_ganzhi_date: CalendarDate = hko_data_utils.get_min_supported_date(CalendarType.GANZHI)
+  max_ganzhi_date: CalendarDate = hko_data_utils.get_max_supported_date(CalendarType.GANZHI)
+
+  assert hko_data_utils.ganzhi_to_solar(min_ganzhi_date) == hko_data_utils.get_min_supported_date(CalendarType.SOLAR)
+  assert hko_data_utils.ganzhi_to_solar(max_ganzhi_date) == hko_data_utils.get_max_supported_date(CalendarType.SOLAR)
+
+  solar_date_gen = _solar_date_gen(hko_data_utils.get_min_supported_date(CalendarType.SOLAR))
+  ganzhi_date_gen = _ganzhi_date_gen(hko_data_utils.get_min_supported_date(CalendarType.GANZHI))
+
+  while True:
+    solar_date = next(solar_date_gen)
+    ganzhi_date = next(ganzhi_date_gen)
+    assert solar_date == hko_data_utils.ganzhi_to_solar(ganzhi_date)
+
+    if ganzhi_date == max_ganzhi_date:
+      assert solar_date == hko_data_utils.get_max_supported_date(CalendarType.SOLAR)
+      break
+
+
+@pytest.mark.slow
+def test_solar_to_ganzhi() -> None:
+  min_solar_date: CalendarDate = hko_data_utils.get_min_supported_date(CalendarType.SOLAR)
+  max_solar_date: CalendarDate = hko_data_utils.get_max_supported_date(CalendarType.SOLAR)
+
+  assert hko_data_utils.solar_to_ganzhi(min_solar_date) == hko_data_utils.get_min_supported_date(CalendarType.GANZHI)
+  assert hko_data_utils.solar_to_ganzhi(max_solar_date) == hko_data_utils.get_max_supported_date(CalendarType.GANZHI)
+
+  solar_date_gen = _solar_date_gen(hko_data_utils.get_min_supported_date(CalendarType.SOLAR))
+  ganzhi_date_gen = _ganzhi_date_gen(hko_data_utils.get_min_supported_date(CalendarType.GANZHI))
+
+  while True:
+    solar_date = next(solar_date_gen)
+    ganzhi_date = next(ganzhi_date_gen)
+    assert ganzhi_date == hko_data_utils.solar_to_ganzhi(solar_date)
+
+    if solar_date == max_solar_date:
+      assert ganzhi_date == hko_data_utils.get_max_supported_date(CalendarType.GANZHI)
+      break
+
+
+@pytest.mark.slow
+def test_lunar_to_ganzhi() -> None:
+  min_lunar_date: CalendarDate = hko_data_utils.get_min_supported_date(CalendarType.LUNAR)
+  max_lunar_date: CalendarDate = hko_data_utils.get_max_supported_date(CalendarType.LUNAR)
+
+  assert hko_data_utils.lunar_to_ganzhi(min_lunar_date) == hko_data_utils.get_min_supported_date(CalendarType.GANZHI)
+  assert hko_data_utils.lunar_to_ganzhi(max_lunar_date) == hko_data_utils.get_max_supported_date(CalendarType.GANZHI)
+
+  lunar_date_gen = _lunar_date_gen(hko_data_utils.get_min_supported_date(CalendarType.LUNAR))
+  ganzhi_date_gen = _ganzhi_date_gen(hko_data_utils.get_min_supported_date(CalendarType.GANZHI))
+
+  while True:
+    lunar_date = next(lunar_date_gen)
+    ganzhi_date = next(ganzhi_date_gen)
+    assert ganzhi_date == hko_data_utils.lunar_to_ganzhi(lunar_date)
+
+    if lunar_date == max_lunar_date:
+      assert ganzhi_date == hko_data_utils.get_max_supported_date(CalendarType.GANZHI)
+      break
+
+
+@pytest.mark.slow
+def test_ganzhi_to_lunar() -> None:
+  min_ganzhi_date: CalendarDate = hko_data_utils.get_min_supported_date(CalendarType.GANZHI)
+  max_ganzhi_date: CalendarDate = hko_data_utils.get_max_supported_date(CalendarType.GANZHI)
+
+  assert hko_data_utils.ganzhi_to_lunar(min_ganzhi_date) == hko_data_utils.get_min_supported_date(CalendarType.LUNAR)
+  assert hko_data_utils.ganzhi_to_lunar(max_ganzhi_date) == hko_data_utils.get_max_supported_date(CalendarType.LUNAR)
+
+  ganzhi_date_gen = _ganzhi_date_gen(hko_data_utils.get_min_supported_date(CalendarType.GANZHI))
+  lunar_date_gen = _lunar_date_gen(hko_data_utils.get_min_supported_date(CalendarType.LUNAR))
+
+  while True:
+    ganzhi_date = next(ganzhi_date_gen)
+    lunar_date = next(lunar_date_gen)
+    assert lunar_date == hko_data_utils.ganzhi_to_lunar(ganzhi_date)
+
+    if ganzhi_date == max_ganzhi_date:
+      assert lunar_date == hko_data_utils.get_max_supported_date(CalendarType.LUNAR)
+      break
+
+
+@pytest.mark.slow
+def test_complex_date_conversions() -> None:
+  solar_date_gen = _solar_date_gen(hko_data_utils.get_min_supported_date(CalendarType.SOLAR))
+  lunar_date_gen = _lunar_date_gen(hko_data_utils.get_min_supported_date(CalendarType.LUNAR))
+  ganzhi_date_gen = _ganzhi_date_gen(hko_data_utils.get_min_supported_date(CalendarType.GANZHI))
+
+  for _ in range(4096):
+    solar_date = next(solar_date_gen)
+    lunar_date = next(lunar_date_gen)
+    ganzhi_date = next(ganzhi_date_gen)
+
+    # ganzhi
+    _solar_date = hko_data_utils.ganzhi_to_solar(ganzhi_date)
+    _lunar_date = hko_data_utils.ganzhi_to_lunar(ganzhi_date)
+
+    assert solar_date == _solar_date
+    assert lunar_date == _lunar_date
+    assert ganzhi_date == hko_data_utils.solar_to_ganzhi(_solar_date)
+    assert ganzhi_date == hko_data_utils.lunar_to_ganzhi(_lunar_date)
+
+    # solar
+    _lunar_date = hko_data_utils.solar_to_lunar(solar_date)
+    _ganzhi_date = hko_data_utils.solar_to_ganzhi(solar_date)
+
+    assert lunar_date == _lunar_date
+    assert ganzhi_date == _ganzhi_date
+    assert solar_date == hko_data_utils.lunar_to_solar(_lunar_date)
+    assert solar_date == hko_data_utils.ganzhi_to_solar(_ganzhi_date)
+
+    # lunar
+    _solar_date = hko_data_utils.lunar_to_solar(lunar_date)
+    _ganzhi_date = hko_data_utils.lunar_to_ganzhi(lunar_date)
+
+    assert solar_date == _solar_date
+    assert ganzhi_date == _ganzhi_date
+    assert lunar_date == hko_data_utils.solar_to_lunar(_solar_date)
+    assert lunar_date == hko_data_utils.ganzhi_to_lunar(_ganzhi_date)
+
+
+def test_date_conversions_negative() -> None:
+  # ganzhi_to_lunar negative
+  with pytest.raises(AssertionError):
+    hko_data_utils.ganzhi_to_lunar(CalendarDate(1, 1, 1, CalendarType.GANZHI))
+  with pytest.raises(AssertionError):
+    hko_data_utils.ganzhi_to_lunar(CalendarDate(2024, 1, 1, CalendarType.SOLAR))
+
+  # lunar_to_ganzhi negative
+  with pytest.raises(AssertionError):
+    hko_data_utils.lunar_to_ganzhi(CalendarDate(1, 1, 1, CalendarType.LUNAR))
+  with pytest.raises(AssertionError):
+    hko_data_utils.lunar_to_ganzhi(CalendarDate(2024, 1, 1, CalendarType.SOLAR))
+
+  # solar_to_lunar negative
+  with pytest.raises(AssertionError):
+    hko_data_utils.solar_to_lunar(CalendarDate(1, 1, 1, CalendarType.SOLAR))
+  with pytest.raises(AssertionError):
+    hko_data_utils.solar_to_lunar(CalendarDate(2024, 1, 1, CalendarType.GANZHI))
+
+  # lunar_to_solar negative
+  with pytest.raises(AssertionError):
+    hko_data_utils.lunar_to_solar(CalendarDate(1, 1, 1, CalendarType.LUNAR))
+  with pytest.raises(AssertionError):
+    hko_data_utils.lunar_to_solar(CalendarDate(2024, 1, 1, CalendarType.GANZHI))
+
+  # solar_to_ganzhi negative
+  with pytest.raises(AssertionError):
+    hko_data_utils.solar_to_ganzhi(CalendarDate(1, 1, 1, CalendarType.SOLAR))
+  with pytest.raises(AssertionError):
+    hko_data_utils.solar_to_ganzhi(CalendarDate(2024, 1, 1, CalendarType.GANZHI))
+
+  # ganzhi_to_solar negative
+  with pytest.raises(AssertionError):
+    hko_data_utils.ganzhi_to_solar(CalendarDate(1, 1, 1, CalendarType.GANZHI))
+  with pytest.raises(AssertionError):
+    hko_data_utils.ganzhi_to_solar(CalendarDate(2024, 1, 1, CalendarType.SOLAR))
+
+
+def test_to_solar() -> None:
+  # Positive cases.
+  d: date = date(2023, 5, 8)
+  solar_date: CalendarDate = hko_data_utils.to_solar(d)
+  assert solar_date == CalendarDate(2023, 5, 8, CalendarType.SOLAR)
+  assert solar_date == hko_data_utils.to_solar(d)
+  assert solar_date == hko_data_utils.to_solar(solar_date)
+  assert solar_date == hko_data_utils.to_solar(hko_data_utils.solar_to_lunar(solar_date))
+  assert solar_date == hko_data_utils.to_solar(hko_data_utils.solar_to_ganzhi(solar_date))
+
+  # Negative cases.
+  with pytest.raises(AssertionError):
+    hko_data_utils.to_solar(CalendarDate(9999, 1, 1, CalendarType.SOLAR)) # Invalid date
+  with pytest.raises(AssertionError):
+    hko_data_utils.to_solar('2024-01-01') # Invalid type
+
+
+def test_to_lunar() -> None:
+  # Positive cases.
+  d: date = date(2023, 5, 8)
+  lunar_date: CalendarDate = hko_data_utils.to_lunar(d)
+  assert lunar_date == hko_data_utils.solar_to_lunar(CalendarDate(2023, 5, 8, CalendarType.SOLAR))
+  assert lunar_date == hko_data_utils.to_lunar(d)
+  assert lunar_date == hko_data_utils.to_lunar(lunar_date)
+  assert lunar_date == hko_data_utils.to_lunar(hko_data_utils.lunar_to_solar(lunar_date))
+  assert lunar_date == hko_data_utils.to_lunar(hko_data_utils.lunar_to_ganzhi(lunar_date))
+
+  # Negative cases.
+  with pytest.raises(AssertionError):
+    hko_data_utils.to_lunar(CalendarDate(9999, 1, 1, CalendarType.LUNAR)) # Invalid date
+  with pytest.raises(AssertionError):
+    hko_data_utils.to_lunar('2024-01-01') # Invalid type
+
+
+def test_to_ganzhi() -> None:
+  # Positive cases.
+  d: date = date(2023, 5, 8)
+  ganzhi_date: CalendarDate = hko_data_utils.to_ganzhi(d)
+  assert ganzhi_date == hko_data_utils.solar_to_ganzhi(CalendarDate(2023, 5, 8, CalendarType.SOLAR))
+  assert ganzhi_date == hko_data_utils.to_ganzhi(d)
+  assert ganzhi_date == hko_data_utils.to_ganzhi(ganzhi_date)
+  assert ganzhi_date == hko_data_utils.to_ganzhi(hko_data_utils.ganzhi_to_solar(ganzhi_date))
+  assert ganzhi_date == hko_data_utils.to_ganzhi(hko_data_utils.ganzhi_to_lunar(ganzhi_date))
+
+  # Negative cases.
+  with pytest.raises(AssertionError):
+    hko_data_utils.to_ganzhi(CalendarDate(9999, 1, 1, CalendarType.GANZHI)) # Invalid date
+  with pytest.raises(AssertionError):
+    hko_data_utils.to_ganzhi('2024-01-01') # Invalid type
+
+
+def test_to_date() -> None:
+  d = date(2023, 5, 8)
+  assert hko_data_utils.to_date(d) == d
+
+  dt = datetime(2023, 5, 8, 1, 2, 3)
+  assert hko_data_utils.to_date(dt) == d
+
+  cd = CalendarDate(2000, 1, 1, CalendarType.SOLAR)
+  assert hko_data_utils.to_date(cd) == date(2000, 1, 1)
+
+  cd = CalendarDate(1901, 1, 1, CalendarType.LUNAR)
+  assert hko_data_utils.to_date(cd) == date(1901, 2, 19)
+
+  # Negative cases.
+  with pytest.raises(AssertionError):
+    hko_data_utils.to_date(CalendarDate(9999, 1, 1, CalendarType.GANZHI)) # Invalid date
+  with pytest.raises(AssertionError):
+    hko_data_utils.to_date('2024-01-01') # Invalid type
+
+
+def test_get_jieqi_date() -> None:
+  with pytest.raises(AssertionError):
+    hko_data_utils.jieqi_date('2024', Jieqi.大寒)
+  with pytest.raises(AssertionError):
+    hko_data_utils.jieqi_date(2024, '大寒')
+  with pytest.raises(AssertionError):
+    hko_data_utils.jieqi_date(9999, Jieqi.大寒) # Out of supported solar year range.
+  with pytest.raises(AssertionError):
+    hko_data_utils.jieqi_date(2101, Jieqi.小寒) # Out of supported solar year range.
+  with pytest.raises(AssertionError):
+    hko_data_utils.jieqi_date(0, Jieqi.大寒) # Out of supported solar year range.
+  with pytest.raises(AssertionError):
+    hko_data_utils.jieqi_date(1900, Jieqi.冬至) # Out of supported solar year range.
+
+  assert hko_data_utils.jieqi_date(1901, Jieqi.小寒) == date(1901, 1, 6)
+  assert hko_data_utils.jieqi_date(2100, Jieqi.冬至) == date(2100, 12, 22)
+
+  assert hko_data_utils.jieqi_date(2024, Jieqi.大寒) == date(2024, 1, 20)
+  assert hko_data_utils.jieqi_date(1997, Jieqi.小寒) == date(1997, 1, 5)
+  assert hko_data_utils.jieqi_date(2000, Jieqi.立春) == date(2000, 2, 4)
+  assert hko_data_utils.jieqi_date(2005, Jieqi.雨水) == date(2005, 2, 18)
+
+  random_solar_year: int = random.randint(1901, 2100)
+  dates: list[date] = []
+  for jieqi in Jieqi.as_list(ganzhi_year=False):
+    dates.append(hko_data_utils.jieqi_date(random_solar_year, jieqi))
+  for d1, d2 in itertools.pairwise(dates):
+    assert d1 < d2
+
+
+def test_get_jieqi_moment() -> None:
+  with pytest.raises(AssertionError):
+    hko_data_utils.jieqi_moment('2024', Jieqi.大寒)
+  with pytest.raises(AssertionError):
+    hko_data_utils.jieqi_moment(2024, '大寒')
+  with pytest.raises(AssertionError):
+    hko_data_utils.jieqi_moment(9999, Jieqi.大寒) # Out of supported solar year range.
+  with pytest.raises(AssertionError):
+    hko_data_utils.jieqi_moment(2101, Jieqi.小寒) # Out of supported solar year range.
+  with pytest.raises(AssertionError):
+    hko_data_utils.jieqi_moment(0, Jieqi.大寒) # Out of supported solar year range.
+
+  # HKO data only supported day-level precision.
+  # So all returned moments are always at the beginning of the day.
+  assert hko_data_utils.jieqi_moment(1901, Jieqi.小寒) == datetime(1901, 1, 6, 0, 0, 0)
+  assert hko_data_utils.jieqi_moment(2100, Jieqi.冬至) == datetime(2100, 12, 22, 0, 0, 0)
+
+  assert hko_data_utils.jieqi_moment(2024, Jieqi.大寒) == datetime(2024, 1, 20, 0, 0, 0)
+  assert hko_data_utils.jieqi_moment(1997, Jieqi.小寒) == datetime(1997, 1, 5, 0, 0, 0)
+  assert hko_data_utils.jieqi_moment(2000, Jieqi.立春) == datetime(2000, 2, 4, 0, 0, 0)
+  assert hko_data_utils.jieqi_moment(2005, Jieqi.雨水) == datetime(2005, 2, 18, 0, 0, 0)
+
+  random_solar_year: int = random.randint(1901, 2100)
+  datetimes: list[datetime] = []
+  for jieqi in Jieqi.as_list(ganzhi_year=False): # The first Jieqi in a solar year is always "小寒".
+    datetimes.append(hko_data_utils.jieqi_moment(random_solar_year, jieqi))
+  for d1, d2 in itertools.pairwise(datetimes):
+    assert d1 < d2
+
+
+def test_prev_jie() -> None:
+  supported_range: tuple[datetime, datetime] = hko_data_utils.supported_jie_boundaries()
+
+  with pytest.raises(AssertionError):
+    hko_data_utils.prev_jie('2024-06-15')
+  with pytest.raises(ValueError):
+    hko_data_utils.prev_jie(datetime(1899, 12, 31))
+  with pytest.raises(ValueError):
+    hko_data_utils.prev_jie(datetime(2101, 1, 1))
+  with pytest.raises(ValueError):
+    hko_data_utils.prev_jie(supported_range[0] - timedelta(microseconds=1))
+  with pytest.raises(ValueError):
+    hko_data_utils.prev_jie(supported_range[1])
+
+  for _ in range(500):
+    random_dt: datetime = datetime(
+      year=random.randint(1800, 2200),
+      month=random.randint(1, 12),
+      day=random.randint(1, 28),
+      hour=random.randint(0, 23),
+      minute=random.randint(0, 59),
+      second=random.randint(0, 59),
+    )
+    if supported_range[0] <= random_dt < supported_range[1]: # In supported range.
+      assert isinstance(hko_data_utils.prev_jie(random_dt), tuple)
+    else:
+      with pytest.raises(ValueError):
+        hko_data_utils.prev_jie(random_dt)
+
+  assert hko_data_utils.prev_jie(hko_data_utils.jieqi_moment(2024, Jieqi.大雪)) == (
+    Jieqi.大雪, hko_data_utils.jieqi_moment(2024, Jieqi.大雪)
+  )
+
+  assert hko_data_utils.prev_jie(hko_data_utils.jieqi_moment(2024, Jieqi.大雪) + timedelta(microseconds=1)) == (
+    Jieqi.大雪, hko_data_utils.jieqi_moment(2024, Jieqi.大雪)
+  )
+
+  assert hko_data_utils.prev_jie(hko_data_utils.jieqi_moment(2024, Jieqi.大雪) - timedelta(microseconds=1)) == (
+    Jieqi.立冬, hko_data_utils.jieqi_moment(2024, Jieqi.立冬)
+  )
+
+  assert hko_data_utils.prev_jie(hko_data_utils.jieqi_moment(2024, Jieqi.小寒)) == (
+    Jieqi.小寒, hko_data_utils.jieqi_moment(2024, Jieqi.小寒)
+  )
+
+  assert hko_data_utils.prev_jie(hko_data_utils.jieqi_moment(2024, Jieqi.小寒) - timedelta(microseconds=1)) == (
+    Jieqi.大雪, hko_data_utils.jieqi_moment(2023, Jieqi.大雪)
+  )
+
+  first_year: int = hko_data_utils.jieqi_dates_db.start_year
+  jie_list: list[Jieqi] = Jieqi.as_list(ganzhi_year=False)[::2]
+  for jie1, jie2 in itertools.pairwise(jie_list):
+    assert hko_data_utils.prev_jie(hko_data_utils.jieqi_moment(first_year, jie1)) == (
+      jie1, hko_data_utils.jieqi_moment(first_year, jie1)
+    )
+    assert hko_data_utils.prev_jie(hko_data_utils.jieqi_moment(first_year, jie2) - timedelta(microseconds=1)) == (
+      jie1, hko_data_utils.jieqi_moment(first_year, jie1)
     )
 
-    self.assertTupleEqual(
-      hko_data_utils.prev_jie(hko_data_utils.jieqi_moment(2024, Jieqi.大雪) + timedelta(microseconds=1)),
-      (Jieqi.大雪, hko_data_utils.jieqi_moment(2024, Jieqi.大雪))
+
+def test_next_jie() -> None:
+  supported_range: tuple[datetime, datetime] = hko_data_utils.supported_jie_boundaries()
+
+  with pytest.raises(AssertionError):
+    hko_data_utils.next_jie('2024-06-15')
+  with pytest.raises(ValueError):
+    hko_data_utils.next_jie(datetime(1899, 12, 31))
+  with pytest.raises(ValueError):
+    hko_data_utils.next_jie(datetime(2101, 1, 1))
+  with pytest.raises(ValueError):
+    hko_data_utils.next_jie(supported_range[0] - timedelta(microseconds=1))
+  with pytest.raises(ValueError):
+    hko_data_utils.next_jie(supported_range[1])
+
+  for _ in range(500):
+    random_dt: datetime = datetime(
+      year=random.randint(1800, 2200),
+      month=random.randint(1, 12),
+      day=random.randint(1, 28),
+      hour=random.randint(0, 23),
+      minute=random.randint(0, 59),
+      second=random.randint(0, 59),
     )
+    if supported_range[0] <= random_dt < supported_range[1]: # In supported range.
+      assert isinstance(hko_data_utils.next_jie(random_dt), tuple)
+    else:
+      with pytest.raises(ValueError):
+        hko_data_utils.next_jie(random_dt)
 
-    self.assertTupleEqual(
-      hko_data_utils.prev_jie(hko_data_utils.jieqi_moment(2024, Jieqi.大雪) - timedelta(microseconds=1)),
-      (Jieqi.立冬, hko_data_utils.jieqi_moment(2024, Jieqi.立冬))
+  assert hko_data_utils.next_jie(hko_data_utils.jieqi_moment(2024, Jieqi.小寒)) == (
+    Jieqi.立春, hko_data_utils.jieqi_moment(2024, Jieqi.立春)
+  )
+
+  assert hko_data_utils.next_jie(hko_data_utils.jieqi_moment(2024, Jieqi.小寒) + timedelta(microseconds=1)) == (
+    Jieqi.立春, hko_data_utils.jieqi_moment(2024, Jieqi.立春)
+  )
+
+  assert hko_data_utils.next_jie(hko_data_utils.jieqi_moment(2024, Jieqi.小寒) - timedelta(microseconds=1)) == (
+    Jieqi.小寒, hko_data_utils.jieqi_moment(2024, Jieqi.小寒)
+  )
+
+  assert hko_data_utils.next_jie(hko_data_utils.jieqi_moment(2024, Jieqi.大雪)) == (
+    Jieqi.小寒, hko_data_utils.jieqi_moment(2025, Jieqi.小寒)
+  )
+
+  assert hko_data_utils.next_jie(hko_data_utils.jieqi_moment(2024, Jieqi.大雪) + timedelta(microseconds=1)) == (
+    Jieqi.小寒, hko_data_utils.jieqi_moment(2025, Jieqi.小寒)
+  )
+
+  assert hko_data_utils.next_jie(hko_data_utils.jieqi_moment(2024, Jieqi.大雪) - timedelta(microseconds=1)) == (
+    Jieqi.大雪, hko_data_utils.jieqi_moment(2024, Jieqi.大雪)
+  )
+
+  last_year: int = hko_data_utils.jieqi_dates_db.end_year
+  jie_list: list[Jieqi] = Jieqi.as_list(ganzhi_year=False)[::2]
+  for jie1, jie2 in itertools.pairwise(jie_list):
+    assert hko_data_utils.next_jie(hko_data_utils.jieqi_moment(last_year, jie1)) == (
+      jie2, hko_data_utils.jieqi_moment(last_year, jie2)
     )
-
-    self.assertTupleEqual(
-      hko_data_utils.prev_jie(hko_data_utils.jieqi_moment(2024, Jieqi.小寒)),
-      (Jieqi.小寒, hko_data_utils.jieqi_moment(2024, Jieqi.小寒))
+    assert hko_data_utils.next_jie(hko_data_utils.jieqi_moment(last_year, jie1) - timedelta(microseconds=1)) == (
+      jie1, hko_data_utils.jieqi_moment(last_year, jie1)
     )
-
-    self.assertTupleEqual(
-      hko_data_utils.prev_jie(hko_data_utils.jieqi_moment(2024, Jieqi.小寒) - timedelta(microseconds=1)),
-      (Jieqi.大雪, hko_data_utils.jieqi_moment(2023, Jieqi.大雪))
+    assert hko_data_utils.next_jie(hko_data_utils.jieqi_moment(last_year, jie2) - timedelta(microseconds=1)) == (
+      jie2, hko_data_utils.jieqi_moment(last_year, jie2)
     )
-
-    first_year: int = hko_data_utils.jieqi_dates_db.start_year
-    jie_list: list[Jieqi] = Jieqi.as_list(ganzhi_year=False)[::2]
-    for jie1, jie2 in itertools.pairwise(jie_list):
-      self.assertTupleEqual(
-        hko_data_utils.prev_jie(hko_data_utils.jieqi_moment(first_year, jie1)),
-        (jie1, hko_data_utils.jieqi_moment(first_year, jie1))
-      )
-      self.assertTupleEqual(
-        hko_data_utils.prev_jie(hko_data_utils.jieqi_moment(first_year, jie2) - timedelta(microseconds=1)),
-        (jie1, hko_data_utils.jieqi_moment(first_year, jie1))
-      )
-  
-  def test_next_jie(self) -> None:
-    supported_range: tuple[datetime, datetime] = hko_data_utils.supported_jie_boundaries()
-    
-    self.assertRaises(AssertionError, hko_data_utils.next_jie, '2024-06-15')
-    self.assertRaises(ValueError, hko_data_utils.next_jie, datetime(1899, 12, 31))
-    self.assertRaises(ValueError, hko_data_utils.next_jie, datetime(2101, 1, 1))
-    self.assertRaises(ValueError, hko_data_utils.next_jie, supported_range[0] - timedelta(microseconds=1))
-    self.assertRaises(ValueError, hko_data_utils.next_jie, supported_range[1])
-
-    for _ in range(500):
-      random_dt: datetime = datetime(
-        year=random.randint(1800, 2200),
-        month=random.randint(1, 12),
-        day=random.randint(1, 28),
-        hour=random.randint(0, 23),
-        minute=random.randint(0, 59),
-        second=random.randint(0, 59),
-      )
-      if supported_range[0] <= random_dt < supported_range[1]: # In supported range.
-        self.assertIsInstance(hko_data_utils.next_jie(random_dt), tuple)
-      else:
-        self.assertRaises(ValueError, hko_data_utils.next_jie, random_dt)
-
-    self.assertTupleEqual(
-      hko_data_utils.next_jie(hko_data_utils.jieqi_moment(2024, Jieqi.小寒)),
-      (Jieqi.立春, hko_data_utils.jieqi_moment(2024, Jieqi.立春))
-    )
-
-    self.assertTupleEqual(
-      hko_data_utils.next_jie(hko_data_utils.jieqi_moment(2024, Jieqi.小寒) + timedelta(microseconds=1)),
-      (Jieqi.立春, hko_data_utils.jieqi_moment(2024, Jieqi.立春))
-    )
-
-    self.assertTupleEqual(
-      hko_data_utils.next_jie(hko_data_utils.jieqi_moment(2024, Jieqi.小寒) - timedelta(microseconds=1)),
-      (Jieqi.小寒, hko_data_utils.jieqi_moment(2024, Jieqi.小寒))
-    )
-
-    self.assertTupleEqual(
-      hko_data_utils.next_jie(hko_data_utils.jieqi_moment(2024, Jieqi.大雪)),
-      (Jieqi.小寒, hko_data_utils.jieqi_moment(2025, Jieqi.小寒))
-    )
-
-    self.assertTupleEqual(
-      hko_data_utils.next_jie(hko_data_utils.jieqi_moment(2024, Jieqi.大雪) + timedelta(microseconds=1)),
-      (Jieqi.小寒, hko_data_utils.jieqi_moment(2025, Jieqi.小寒))
-    )
-
-    self.assertTupleEqual(
-      hko_data_utils.next_jie(hko_data_utils.jieqi_moment(2024, Jieqi.大雪) - timedelta(microseconds=1)),
-      (Jieqi.大雪, hko_data_utils.jieqi_moment(2024, Jieqi.大雪))
-    )
-
-    last_year: int = hko_data_utils.jieqi_dates_db.end_year
-    jie_list: list[Jieqi] = Jieqi.as_list(ganzhi_year=False)[::2]
-    for jie1, jie2 in itertools.pairwise(jie_list):
-      self.assertTupleEqual(
-        hko_data_utils.next_jie(hko_data_utils.jieqi_moment(last_year, jie1)),
-        (jie2, hko_data_utils.jieqi_moment(last_year, jie2))
-      )
-      self.assertTupleEqual(
-        hko_data_utils.next_jie(hko_data_utils.jieqi_moment(last_year, jie1) - timedelta(microseconds=1)),
-        (jie1, hko_data_utils.jieqi_moment(last_year, jie1))
-      )
-      self.assertTupleEqual(
-        hko_data_utils.next_jie(hko_data_utils.jieqi_moment(last_year, jie2) - timedelta(microseconds=1)),
-        (jie2, hko_data_utils.jieqi_moment(last_year, jie2))
-      )

--- a/tests/calendar/test_hko_data_utils.py
+++ b/tests/calendar/test_hko_data_utils.py
@@ -368,37 +368,31 @@ def test_complex_date_conversions() -> None:
 
 
 def test_date_conversions_negative() -> None:
-  # ganzhi_to_lunar negative
   with pytest.raises(AssertionError):
     hko_data_utils.ganzhi_to_lunar(CalendarDate(1, 1, 1, CalendarType.GANZHI))
   with pytest.raises(AssertionError):
     hko_data_utils.ganzhi_to_lunar(CalendarDate(2024, 1, 1, CalendarType.SOLAR))
 
-  # lunar_to_ganzhi negative
   with pytest.raises(AssertionError):
     hko_data_utils.lunar_to_ganzhi(CalendarDate(1, 1, 1, CalendarType.LUNAR))
   with pytest.raises(AssertionError):
     hko_data_utils.lunar_to_ganzhi(CalendarDate(2024, 1, 1, CalendarType.SOLAR))
 
-  # solar_to_lunar negative
   with pytest.raises(AssertionError):
     hko_data_utils.solar_to_lunar(CalendarDate(1, 1, 1, CalendarType.SOLAR))
   with pytest.raises(AssertionError):
     hko_data_utils.solar_to_lunar(CalendarDate(2024, 1, 1, CalendarType.GANZHI))
 
-  # lunar_to_solar negative
   with pytest.raises(AssertionError):
     hko_data_utils.lunar_to_solar(CalendarDate(1, 1, 1, CalendarType.LUNAR))
   with pytest.raises(AssertionError):
     hko_data_utils.lunar_to_solar(CalendarDate(2024, 1, 1, CalendarType.GANZHI))
 
-  # solar_to_ganzhi negative
   with pytest.raises(AssertionError):
     hko_data_utils.solar_to_ganzhi(CalendarDate(1, 1, 1, CalendarType.SOLAR))
   with pytest.raises(AssertionError):
     hko_data_utils.solar_to_ganzhi(CalendarDate(2024, 1, 1, CalendarType.GANZHI))
 
-  # ganzhi_to_solar negative
   with pytest.raises(AssertionError):
     hko_data_utils.ganzhi_to_solar(CalendarDate(1, 1, 1, CalendarType.GANZHI))
   with pytest.raises(AssertionError):

--- a/tests/defines/test_dizhi.py
+++ b/tests/defines/test_dizhi.py
@@ -1,114 +1,119 @@
 # Copyright (C) 2026 Ningqi Wang (0xf3cd) <https://github.com/0xf3cd>
 # test_dizhi.py
 
-import unittest
+import pytest
 
 from src.defines import (
   Tiangan, Dizhi, 地支,
 )
 
 
-class TestDizhi(unittest.TestCase):
-  def test_basic(self) -> None:
-    self.assertEqual(12, len(Dizhi))
-    self.assertEqual('子', Dizhi.ZI.value)
-    self.assertEqual(Dizhi('子'), Dizhi.子)
-    self.assertNotEqual(Dizhi.WEI, Dizhi.SHEN)
-    self.assertNotEqual(Dizhi.WEI.value, Dizhi.SHEN.value)
+def test_basic() -> None:
+  assert 12 == len(Dizhi)
+  assert '子' == Dizhi.ZI.value
+  assert Dizhi('子') == Dizhi.子
+  assert Dizhi.WEI != Dizhi.SHEN
+  assert Dizhi.WEI.value != Dizhi.SHEN.value
 
-  def test_alias(self) -> None:
-    self.assertEqual(地支, Dizhi)
-    self.assertIs(地支, Dizhi)
-    self.assertEqual(12, len(地支))
 
-    self.assertIs(Dizhi.子, Dizhi.ZI)
-    self.assertIs(Dizhi.子, 地支.ZI)
-    self.assertIs(Dizhi.子, 地支.子)
-    
-    self.assertIsNot(Dizhi.丑, Dizhi.午)
+def test_alias() -> None:
+  assert 地支 == Dizhi
+  assert 地支 is Dizhi
+  assert 12 == len(地支)
 
-    self.assertEqual('午', 地支.午.value)
-    self.assertEqual('午', Dizhi.午.value)
-    self.assertEqual('未', 地支.WEI.value)
-    self.assertEqual(Dizhi.午.value, Dizhi.WU.value)
-    self.assertEqual(Dizhi.午.value, 地支.WU.value)
-    
-    self.assertNotEqual('未', 地支.SHEN.value)
-    self.assertNotEqual(地支.申, 地支.未)
+  assert Dizhi.子 is Dizhi.ZI
+  assert Dizhi.子 is 地支.ZI
+  assert Dizhi.子 is 地支.子
 
-    for e in 地支:
-      self.assertIsNotNone(e.value)
-      self.assertIn(e, Dizhi)
+  assert Dizhi.丑 is not Dizhi.午
 
-    for e in Dizhi:
-      self.assertIsNotNone(e.value)
-      self.assertIn(e, 地支)
+  assert '午' == 地支.午.value
+  assert '午' == Dizhi.午.value
+  assert '未' == 地支.WEI.value
+  assert Dizhi.午.value == Dizhi.WU.value
+  assert Dizhi.午.value == 地支.WU.value
 
-  def test_as_list(self) -> None:
-    self.assertListEqual(Dizhi.as_list(), list(Dizhi))
-    self.assertListEqual(Dizhi.as_list(), \
-      [Dizhi.子, Dizhi.丑, Dizhi.寅, Dizhi.卯, Dizhi.辰, Dizhi.巳, Dizhi.午, Dizhi.未, Dizhi.申, Dizhi.酉, Dizhi.戌, Dizhi.亥])
-  
-  def test_from_str(self) -> None:
-    with self.assertRaises(ValueError):
-      Dizhi.from_str('子子')
-    with self.assertRaises(ValueError):
-      Dizhi.from_str('ZI')
-    with self.assertRaises(ValueError):
-      Dizhi.from_str('Zi')
-    with self.assertRaises(ValueError):
-      Dizhi.from_str('甲')
-    with self.assertRaises(AssertionError):
-      Dizhi.from_str(Dizhi.子) # type: ignore
-    with self.assertRaises(AssertionError):
-      Dizhi.from_str(0) # type: ignore
-    with self.assertRaises(AssertionError):
-      Dizhi.from_str(Tiangan.丁) # type: ignore
+  assert '未' != 地支.SHEN.value
+  assert 地支.申 != 地支.未
 
-    self.assertEqual(Dizhi.from_str('寅'), Dizhi.寅)
-    self.assertEqual(Dizhi.寅, Dizhi.from_str('寅'))
-    self.assertEqual(Dizhi.from_str('卯'), Dizhi.from_str('卯'))
-    self.assertNotEqual(Dizhi.寅, Dizhi.from_str('卯'))
-    self.assertNotEqual(Dizhi.from_str('卯'), Dizhi.from_str('寅'))
+  for e in 地支:
+    assert e.value is not None
+    assert e in Dizhi
 
-  def test_str(self) -> None:
-    for e in Dizhi:
-      self.assertEqual(str(e), e.value)
-      self.assertIs(Dizhi(str(e)), e)
-    for e in Dizhi.as_list():
-      self.assertEqual(str(e), e.value)
-      self.assertIs(Dizhi(str(e)), e)
+  for e in Dizhi:
+    assert e.value is not None
+    assert e in 地支
 
-    self.assertEqual('子丑寅卯辰巳午未申酉戌亥', ''.join([str(e) for e in Dizhi.as_list()]))
 
-  def test_index(self) -> None:
-    self.assertEqual(Dizhi.子.index, 0)
-    self.assertEqual(Dizhi.丑.index, 1)
-    self.assertEqual(Dizhi.寅.index, 2)
-    self.assertEqual(Dizhi.卯.index, 3)
-    self.assertEqual(Dizhi.辰.index, 4)
-    self.assertEqual(Dizhi.巳.index, 5)
-    self.assertEqual(Dizhi.午.index, 6)
-    self.assertEqual(Dizhi.未.index, 7)
-    self.assertEqual(Dizhi.申.index, 8)
-    self.assertEqual(Dizhi.酉.index, 9)
-    self.assertEqual(Dizhi.戌.index, 10)
-    self.assertEqual(Dizhi.亥.index, 11)
+def test_as_list() -> None:
+  assert Dizhi.as_list() == list(Dizhi)
+  assert Dizhi.as_list() == \
+    [Dizhi.子, Dizhi.丑, Dizhi.寅, Dizhi.卯, Dizhi.辰, Dizhi.巳, Dizhi.午, Dizhi.未, Dizhi.申, Dizhi.酉, Dizhi.戌, Dizhi.亥]
 
-  def test_from_index(self) -> None:
-    self.assertEqual(Dizhi.from_index(0), Dizhi.子)
-    self.assertEqual(Dizhi.from_index(1), Dizhi.丑)
-    self.assertEqual(Dizhi.from_index(2), Dizhi.寅)
-    self.assertEqual(Dizhi.from_index(3), Dizhi.卯)
-    self.assertEqual(Dizhi.from_index(4), Dizhi.辰)
-    self.assertEqual(Dizhi.from_index(5), Dizhi.巳)
-    self.assertEqual(Dizhi.from_index(6), Dizhi.午)
-    self.assertEqual(Dizhi.from_index(7), Dizhi.未)
-    self.assertEqual(Dizhi.from_index(8), Dizhi.申)
-    self.assertEqual(Dizhi.from_index(9), Dizhi.酉)
-    self.assertEqual(Dizhi.from_index(10), Dizhi.戌)
-    self.assertEqual(Dizhi.from_index(11), Dizhi.亥)
-    with self.assertRaises(IndexError):
-      Dizhi.from_index(12)
-    with self.assertRaises(IndexError):
-      Dizhi.from_index(-13)
+
+def test_from_str() -> None:
+  with pytest.raises(ValueError):
+    Dizhi.from_str('子子')
+  with pytest.raises(ValueError):
+    Dizhi.from_str('ZI')
+  with pytest.raises(ValueError):
+    Dizhi.from_str('Zi')
+  with pytest.raises(ValueError):
+    Dizhi.from_str('甲')
+  with pytest.raises(AssertionError):
+    Dizhi.from_str(Dizhi.子) # type: ignore
+  with pytest.raises(AssertionError):
+    Dizhi.from_str(0) # type: ignore
+  with pytest.raises(AssertionError):
+    Dizhi.from_str(Tiangan.丁) # type: ignore
+
+  assert Dizhi.from_str('寅') == Dizhi.寅
+  assert Dizhi.寅 == Dizhi.from_str('寅')
+  assert Dizhi.from_str('卯') == Dizhi.from_str('卯')
+  assert Dizhi.寅 != Dizhi.from_str('卯')
+  assert Dizhi.from_str('卯') != Dizhi.from_str('寅')
+
+
+def test_str() -> None:
+  for e in Dizhi:
+    assert str(e) == e.value
+    assert Dizhi(str(e)) is e
+  for e in Dizhi.as_list():
+    assert str(e) == e.value
+    assert Dizhi(str(e)) is e
+
+  assert '子丑寅卯辰巳午未申酉戌亥' == ''.join([str(e) for e in Dizhi.as_list()])
+
+
+def test_index() -> None:
+  assert Dizhi.子.index == 0
+  assert Dizhi.丑.index == 1
+  assert Dizhi.寅.index == 2
+  assert Dizhi.卯.index == 3
+  assert Dizhi.辰.index == 4
+  assert Dizhi.巳.index == 5
+  assert Dizhi.午.index == 6
+  assert Dizhi.未.index == 7
+  assert Dizhi.申.index == 8
+  assert Dizhi.酉.index == 9
+  assert Dizhi.戌.index == 10
+  assert Dizhi.亥.index == 11
+
+
+def test_from_index() -> None:
+  assert Dizhi.from_index(0) == Dizhi.子
+  assert Dizhi.from_index(1) == Dizhi.丑
+  assert Dizhi.from_index(2) == Dizhi.寅
+  assert Dizhi.from_index(3) == Dizhi.卯
+  assert Dizhi.from_index(4) == Dizhi.辰
+  assert Dizhi.from_index(5) == Dizhi.巳
+  assert Dizhi.from_index(6) == Dizhi.午
+  assert Dizhi.from_index(7) == Dizhi.未
+  assert Dizhi.from_index(8) == Dizhi.申
+  assert Dizhi.from_index(9) == Dizhi.酉
+  assert Dizhi.from_index(10) == Dizhi.戌
+  assert Dizhi.from_index(11) == Dizhi.亥
+  with pytest.raises(IndexError):
+    Dizhi.from_index(12)
+  with pytest.raises(IndexError):
+    Dizhi.from_index(-13)

--- a/tests/defines/test_ganzhi.py
+++ b/tests/defines/test_ganzhi.py
@@ -1,8 +1,9 @@
 # Copyright (C) 2026 Ningqi Wang (0xf3cd) <https://github.com/0xf3cd>
 # test_ganzhi.py
 
-import pytest
 import random
+
+import pytest
 
 from src.defines import (
   Tiangan, 天干, Dizhi, 地支, Ganzhi, 干支,
@@ -158,10 +159,8 @@ def test_ganzhi_next_prev() -> None:
     assert random_gz1 == random_gz1.prev(60)
 
     random_int: int = random.randint(-1000, 1000)
-    assert random_gz1.next(random_int) == \
-           cycle[(cycle.index(random_gz1) + random_int) % 60]
-    assert random_gz1.prev(random_int) == \
-           cycle[(cycle.index(random_gz1) - random_int) % 60]
+    assert random_gz1.next(random_int) == cycle[(cycle.index(random_gz1) + random_int) % 60]
+    assert random_gz1.prev(random_int) == cycle[(cycle.index(random_gz1) - random_int) % 60]
 
   # Immutability.
   gz: Ganzhi = Ganzhi(Tiangan.甲, Dizhi.子)
@@ -173,9 +172,7 @@ def test_ganzhi_next_prev() -> None:
     random_gz2: Ganzhi = __random_gz()
     for __ in range(16):
       x: int = random.randint(-1000, 1000)
-      assert random_gz2 == \
-             random_gz2.next(x).prev(x)
-      assert random_gz2 == \
-             random_gz2.prev(x).next(x)
+      assert random_gz2 == random_gz2.next(x).prev(x)
+      assert random_gz2 == random_gz2.prev(x).next(x)
       assert random_gz2.next(x) == random_gz2.prev(-x)
       assert random_gz2.prev(x) == random_gz2.next(-x)

--- a/tests/defines/test_ganzhi.py
+++ b/tests/defines/test_ganzhi.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2026 Ningqi Wang (0xf3cd) <https://github.com/0xf3cd>
 # test_ganzhi.py
 
-import unittest
+import pytest
 import random
 
 from src.defines import (
@@ -9,167 +9,173 @@ from src.defines import (
 )
 
 
-class TestGanzhi(unittest.TestCase):
-  def test_basic(self) -> None:
-    gz_jiazi: Ganzhi = Ganzhi(Tiangan.JIA, Dizhi.ZI)
-    gz_jiazi2: Ganzhi = Ganzhi(Tiangan.甲, Dizhi.子)
-    gz_bingwu: Ganzhi = Ganzhi(Tiangan.丙, Dizhi.午)
+def test_basic() -> None:
+  gz_jiazi: Ganzhi = Ganzhi(Tiangan.JIA, Dizhi.ZI)
+  gz_jiazi2: Ganzhi = Ganzhi(Tiangan.甲, Dizhi.子)
+  gz_bingwu: Ganzhi = Ganzhi(Tiangan.丙, Dizhi.午)
 
-    self.assertEqual(gz_jiazi.tiangan, Tiangan.甲)
-    self.assertEqual(gz_jiazi.dizhi, Dizhi.子)
-    self.assertEqual(gz_jiazi2.tiangan, Tiangan.甲)
-    self.assertEqual(gz_jiazi2.dizhi, Dizhi.子)
-    self.assertEqual(gz_bingwu.tiangan, Tiangan.丙)
-    self.assertEqual(gz_bingwu.dizhi, Dizhi.午)
-    self.assertEqual(gz_jiazi, gz_jiazi2)
-    self.assertNotEqual(gz_jiazi, gz_bingwu)
-    self.assertNotEqual(gz_jiazi2, gz_bingwu)
+  assert gz_jiazi.tiangan == Tiangan.甲
+  assert gz_jiazi.dizhi == Dizhi.子
+  assert gz_jiazi2.tiangan == Tiangan.甲
+  assert gz_jiazi2.dizhi == Dizhi.子
+  assert gz_bingwu.tiangan == Tiangan.丙
+  assert gz_bingwu.dizhi == Dizhi.午
+  assert gz_jiazi == gz_jiazi2
+  assert gz_jiazi != gz_bingwu
+  assert gz_jiazi2 != gz_bingwu
 
-    gz_list: list[Ganzhi] = []
-    for _ in range(3):
-      for tg in Tiangan:
-        for dz in Dizhi:
-          gz_list.append(Ganzhi(tg, dz))
-          
-    # In theory, 10 tiangans and 12 dizhis can produce 120 different Ganzhis.
-    self.assertEqual(len(set(gz_list)), 120)
+  gz_list: list[Ganzhi] = []
+  for _ in range(3):
+    for tg in Tiangan:
+      for dz in Dizhi:
+        gz_list.append(Ganzhi(tg, dz))
 
-  def test_alias(self) -> None:
-    self.assertIs(Ganzhi, 干支)
-    self.assertEqual(Ganzhi(Tiangan.WU, Dizhi.XU), 干支(天干.戊, 地支.戌))  
-    self.assertNotEqual(Ganzhi(Tiangan.WU, Dizhi.XU), Ganzhi(Tiangan.WU, Dizhi.MAO))
+  # In theory, 10 tiangans and 12 dizhis can produce 120 different Ganzhis.
+  assert len(set(gz_list)) == 120
 
-  def test_from_strs(self) -> None:
-    self.assertEqual(Ganzhi.from_strs('甲', '子'), Ganzhi(Tiangan.甲, Dizhi.子))
-    self.assertEqual(Ganzhi.from_strs('戊', '午'), Ganzhi(Tiangan.戊, Dizhi.午))
-    self.assertNotEqual(Ganzhi.from_strs('丙', '子'), Ganzhi(Tiangan.丙, Dizhi.寅))
 
-    with self.assertRaises(ValueError):
-      Ganzhi.from_strs('假', '子')
-    with self.assertRaises(ValueError):
-      Ganzhi.from_strs('JIA', '子')
-    with self.assertRaises(ValueError):
-      Ganzhi.from_strs('Jia', '子')
-    with self.assertRaises(ValueError):
-      Ganzhi.from_strs('甲', '子子')
-    with self.assertRaises(ValueError):
-      Ganzhi.from_strs('子', '甲')
-    with self.assertRaises(ValueError):
-      Ganzhi.from_strs('子', '子')
-    with self.assertRaises(ValueError):
-      Ganzhi.from_strs('甲', '甲')
-    with self.assertRaises(AssertionError):
-      Ganzhi.from_strs('甲', Dizhi.子) # type: ignore
-    with self.assertRaises(AssertionError):
-      Ganzhi.from_strs(Tiangan.甲, '子') # type: ignore
-    with self.assertRaises(AssertionError):
-      Ganzhi.from_strs(0, 0) # type: ignore
+def test_alias() -> None:
+  assert Ganzhi is 干支
+  assert Ganzhi(Tiangan.WU, Dizhi.XU) == 干支(天干.戊, 地支.戌)
+  assert Ganzhi(Tiangan.WU, Dizhi.XU) != Ganzhi(Tiangan.WU, Dizhi.MAO)
 
-  def test_from_str(self) -> None:
-    self.assertEqual(Ganzhi.from_str('甲子'), Ganzhi(Tiangan.甲, Dizhi.子))
-    self.assertEqual(Ganzhi.from_str('戊午'), Ganzhi(Tiangan.戊, Dizhi.午))
-    self.assertNotEqual(Ganzhi.from_str('丙子'), Ganzhi(Tiangan.丙, Dizhi.寅))
 
-    with self.assertRaises(ValueError):
-      Ganzhi.from_str('假子')
-    with self.assertRaises(AssertionError):
-      Ganzhi.from_str('JIA子')
-    with self.assertRaises(AssertionError):
-      Ganzhi.from_str('Jia子')
-    with self.assertRaises(AssertionError):
-      Ganzhi.from_str('甲子子')
-    with self.assertRaises(ValueError):
-      Ganzhi.from_str('子甲')
-    with self.assertRaises(ValueError):
-      Ganzhi.from_str('子子')
-    with self.assertRaises(ValueError):
-      Ganzhi.from_str('甲甲')
-    with self.assertRaises(TypeError):
-      Ganzhi.from_str(0) # type: ignore
+def test_from_strs() -> None:
+  assert Ganzhi.from_strs('甲', '子') == Ganzhi(Tiangan.甲, Dizhi.子)
+  assert Ganzhi.from_strs('戊', '午') == Ganzhi(Tiangan.戊, Dizhi.午)
+  assert Ganzhi.from_strs('丙', '子') != Ganzhi(Tiangan.丙, Dizhi.寅)
 
-  def test_str(self) -> None:
-    for tg in Tiangan.as_list():
-      for dz in Dizhi.as_list():
-        # `Ganzhi` should be able to hold all 120 possible Tiangan-Dizhi pairs
-        self.assertEqual(str(Ganzhi(tg, dz)), f'{tg}{dz}')
-        self.assertEqual(Ganzhi.from_str(str(Ganzhi(tg, dz))), Ganzhi(tg, dz))
+  with pytest.raises(ValueError):
+    Ganzhi.from_strs('假', '子')
+  with pytest.raises(ValueError):
+    Ganzhi.from_strs('JIA', '子')
+  with pytest.raises(ValueError):
+    Ganzhi.from_strs('Jia', '子')
+  with pytest.raises(ValueError):
+    Ganzhi.from_strs('甲', '子子')
+  with pytest.raises(ValueError):
+    Ganzhi.from_strs('子', '甲')
+  with pytest.raises(ValueError):
+    Ganzhi.from_strs('子', '子')
+  with pytest.raises(ValueError):
+    Ganzhi.from_strs('甲', '甲')
+  with pytest.raises(AssertionError):
+    Ganzhi.from_strs('甲', Dizhi.子) # type: ignore
+  with pytest.raises(AssertionError):
+    Ganzhi.from_strs(Tiangan.甲, '子') # type: ignore
+  with pytest.raises(AssertionError):
+    Ganzhi.from_strs(0, 0) # type: ignore
 
-  def test_list_sexagenary_cycle(self) -> None:
-    sexagenary_cycle = Ganzhi.list_sexagenary_cycle()
 
-    self.assertEqual(len(sexagenary_cycle), 60)
-    self.assertEqual(sexagenary_cycle[0], Ganzhi(Tiangan.甲, Dizhi.子))
-    self.assertEqual(sexagenary_cycle[-1], Ganzhi(Tiangan.癸, Dizhi.亥))
+def test_from_str() -> None:
+  assert Ganzhi.from_str('甲子') == Ganzhi(Tiangan.甲, Dizhi.子)
+  assert Ganzhi.from_str('戊午') == Ganzhi(Tiangan.戊, Dizhi.午)
+  assert Ganzhi.from_str('丙子') != Ganzhi(Tiangan.丙, Dizhi.寅)
 
-    tg_list = Tiangan.as_list()
-    dz_list = Dizhi.as_list()
-    for i, gz in enumerate(sexagenary_cycle):
-      self.assertIs(gz.tiangan, tg_list[i % 10])
-      self.assertIs(gz.dizhi, dz_list[i % 12])
+  with pytest.raises(ValueError):
+    Ganzhi.from_str('假子')
+  with pytest.raises(AssertionError):
+    Ganzhi.from_str('JIA子')
+  with pytest.raises(AssertionError):
+    Ganzhi.from_str('Jia子')
+  with pytest.raises(AssertionError):
+    Ganzhi.from_str('甲子子')
+  with pytest.raises(ValueError):
+    Ganzhi.from_str('子甲')
+  with pytest.raises(ValueError):
+    Ganzhi.from_str('子子')
+  with pytest.raises(ValueError):
+    Ganzhi.from_str('甲甲')
+  with pytest.raises(TypeError):
+    Ganzhi.from_str(0) # type: ignore
 
-  def test_list_sexagenary_cycle_strs(self) -> None:
-    sexagenary_cycle_strs = Ganzhi.list_sexagenary_cycle_strs()
 
-    self.assertEqual(len(sexagenary_cycle_strs), 60)
-    self.assertEqual(sexagenary_cycle_strs[0], '甲子')
-    self.assertEqual(sexagenary_cycle_strs[-1], '癸亥')
+def test_str() -> None:
+  for tg in Tiangan.as_list():
+    for dz in Dizhi.as_list():
+      # `Ganzhi` should be able to hold all 120 possible Tiangan-Dizhi pairs
+      assert str(Ganzhi(tg, dz)) == f'{tg}{dz}'
+      assert Ganzhi.from_str(str(Ganzhi(tg, dz))) == Ganzhi(tg, dz)
 
-    tg_list = Tiangan.as_list()
-    dz_list = Dizhi.as_list()
-    for i, gz_str in enumerate(sexagenary_cycle_strs):
-      self.assertEqual(gz_str, f'{tg_list[i % 10]}{dz_list[i % 12]}')
 
-  def test_ganzhi_next_prev(self) -> None:
-    with self.subTest('negative'):
-      with self.assertRaises(AssertionError):
-        Ganzhi(Tiangan.甲, Dizhi.子).next('1')
-      with self.assertRaises(AssertionError):
-        Ganzhi(Tiangan.甲, Dizhi.子).prev('1')
-      with self.assertRaises(AssertionError):
-        Ganzhi(Tiangan.甲, Dizhi.子).next(3.5)
-      with self.assertRaises(AssertionError):
-        Ganzhi(Tiangan.甲, Dizhi.子).prev(3.5)
+def test_list_sexagenary_cycle() -> None:
+  sexagenary_cycle = Ganzhi.list_sexagenary_cycle()
 
-    def __random_gz() -> Ganzhi:
-      while True:
-        tg: Tiangan = random.choice(Tiangan.as_list())
-        dz: Dizhi = random.choice(Dizhi.as_list())
-        if (tg.index % 2) == (dz.index % 2):
-          return Ganzhi(tg, dz)
+  assert len(sexagenary_cycle) == 60
+  assert sexagenary_cycle[0] == Ganzhi(Tiangan.甲, Dizhi.子)
+  assert sexagenary_cycle[-1] == Ganzhi(Tiangan.癸, Dizhi.亥)
 
-    with self.subTest('correctness'):
-      self.assertEqual(Ganzhi(Tiangan.甲, Dizhi.子).next(1), Ganzhi(Tiangan.乙, Dizhi.丑))
-      self.assertEqual(Ganzhi(Tiangan.甲, Dizhi.子).prev(-1), Ganzhi(Tiangan.乙, Dizhi.丑))
-      self.assertEqual(Ganzhi(Tiangan.甲, Dizhi.子).prev(1), Ganzhi(Tiangan.癸, Dizhi.亥))
-      self.assertEqual(Ganzhi(Tiangan.甲, Dizhi.子).next(-1), Ganzhi(Tiangan.癸, Dizhi.亥))
+  tg_list = Tiangan.as_list()
+  dz_list = Dizhi.as_list()
+  for i, gz in enumerate(sexagenary_cycle):
+    assert gz.tiangan is tg_list[i % 10]
+    assert gz.dizhi is dz_list[i % 12]
 
-      cycle: list[Ganzhi] = Ganzhi.list_sexagenary_cycle()
-      for _ in range(16):
-        random_gz1: Ganzhi = __random_gz()
-        self.assertEqual(random_gz1, random_gz1.next(0))
-        self.assertEqual(random_gz1, random_gz1.next(60))
-        self.assertEqual(random_gz1, random_gz1.prev(0))
-        self.assertEqual(random_gz1, random_gz1.prev(60))
 
-        random_int: int = random.randint(-1000, 1000)
-        self.assertEqual(random_gz1.next(random_int), 
-                         cycle[(cycle.index(random_gz1) + random_int) % 60])
-        self.assertEqual(random_gz1.prev(random_int),
-                         cycle[(cycle.index(random_gz1) - random_int) % 60])
+def test_list_sexagenary_cycle_strs() -> None:
+  sexagenary_cycle_strs = Ganzhi.list_sexagenary_cycle_strs()
 
-    with self.subTest('immutability'):
-      gz: Ganzhi = Ganzhi(Tiangan.甲, Dizhi.子)
-      self.assertIsNot(gz, gz.next(0))
-      self.assertIsNot(gz, gz.prev(0))
+  assert len(sexagenary_cycle_strs) == 60
+  assert sexagenary_cycle_strs[0] == '甲子'
+  assert sexagenary_cycle_strs[-1] == '癸亥'
 
-    with self.subTest('consistency'):
-      for _ in range(16):
-        random_gz2: Ganzhi = __random_gz()
-        for __ in range(16):
-          x: int = random.randint(-1000, 1000)
-          self.assertEqual(random_gz2,
-                           random_gz2.next(x).prev(x))
-          self.assertEqual(random_gz2,
-                           random_gz2.prev(x).next(x))
-          self.assertEqual(random_gz2.next(x), random_gz2.prev(-x))
-          self.assertEqual(random_gz2.prev(x), random_gz2.next(-x))
+  tg_list = Tiangan.as_list()
+  dz_list = Dizhi.as_list()
+  for i, gz_str in enumerate(sexagenary_cycle_strs):
+    assert gz_str == f'{tg_list[i % 10]}{dz_list[i % 12]}'
+
+
+def test_ganzhi_next_prev() -> None:
+  # Negative.
+  with pytest.raises(AssertionError):
+    Ganzhi(Tiangan.甲, Dizhi.子).next('1')
+  with pytest.raises(AssertionError):
+    Ganzhi(Tiangan.甲, Dizhi.子).prev('1')
+  with pytest.raises(AssertionError):
+    Ganzhi(Tiangan.甲, Dizhi.子).next(3.5)
+  with pytest.raises(AssertionError):
+    Ganzhi(Tiangan.甲, Dizhi.子).prev(3.5)
+
+  def __random_gz() -> Ganzhi:
+    while True:
+      tg: Tiangan = random.choice(Tiangan.as_list())
+      dz: Dizhi = random.choice(Dizhi.as_list())
+      if (tg.index % 2) == (dz.index % 2):
+        return Ganzhi(tg, dz)
+
+  # Correctness.
+  assert Ganzhi(Tiangan.甲, Dizhi.子).next(1) == Ganzhi(Tiangan.乙, Dizhi.丑)
+  assert Ganzhi(Tiangan.甲, Dizhi.子).prev(-1) == Ganzhi(Tiangan.乙, Dizhi.丑)
+  assert Ganzhi(Tiangan.甲, Dizhi.子).prev(1) == Ganzhi(Tiangan.癸, Dizhi.亥)
+  assert Ganzhi(Tiangan.甲, Dizhi.子).next(-1) == Ganzhi(Tiangan.癸, Dizhi.亥)
+
+  cycle: list[Ganzhi] = Ganzhi.list_sexagenary_cycle()
+  for _ in range(16):
+    random_gz1: Ganzhi = __random_gz()
+    assert random_gz1 == random_gz1.next(0)
+    assert random_gz1 == random_gz1.next(60)
+    assert random_gz1 == random_gz1.prev(0)
+    assert random_gz1 == random_gz1.prev(60)
+
+    random_int: int = random.randint(-1000, 1000)
+    assert random_gz1.next(random_int) == \
+           cycle[(cycle.index(random_gz1) + random_int) % 60]
+    assert random_gz1.prev(random_int) == \
+           cycle[(cycle.index(random_gz1) - random_int) % 60]
+
+  # Immutability.
+  gz: Ganzhi = Ganzhi(Tiangan.甲, Dizhi.子)
+  assert gz is not gz.next(0)
+  assert gz is not gz.prev(0)
+
+  # Consistency.
+  for _ in range(16):
+    random_gz2: Ganzhi = __random_gz()
+    for __ in range(16):
+      x: int = random.randint(-1000, 1000)
+      assert random_gz2 == \
+             random_gz2.next(x).prev(x)
+      assert random_gz2 == \
+             random_gz2.prev(x).next(x)
+      assert random_gz2.next(x) == random_gz2.prev(-x)
+      assert random_gz2.prev(x) == random_gz2.next(-x)

--- a/tests/defines/test_jieqi.py
+++ b/tests/defines/test_jieqi.py
@@ -115,5 +115,4 @@ def test_str() -> None:
     assert str(jq) == jq.value
     assert Jieqi.from_str(str(jq)) == jq
 
-  assert ''.join([str(jq) for jq in Jieqi.as_list()]) == \
-         '立春雨水惊蛰春分清明谷雨立夏小满芒种夏至小暑大暑立秋处暑白露秋分寒露霜降立冬小雪大雪冬至小寒大寒'
+  assert ''.join([str(jq) for jq in Jieqi.as_list()]) == '立春雨水惊蛰春分清明谷雨立夏小满芒种夏至小暑大暑立秋处暑白露秋分寒露霜降立冬小雪大雪冬至小寒大寒'

--- a/tests/defines/test_jieqi.py
+++ b/tests/defines/test_jieqi.py
@@ -1,116 +1,119 @@
 # Copyright (C) 2026 Ningqi Wang (0xf3cd) <https://github.com/0xf3cd>
 # test_jieqi.py
 
-import unittest
+import pytest
 
 from src.defines import (
   Tiangan, Jieqi, 节气,
 )
 
 
-class TestJieqi(unittest.TestCase):
-  def test_basic(self) -> None:
-    self.assertEqual(len(Jieqi), 24)
-    self.assertEqual(Jieqi.QINGMING.value, '清明')
-    self.assertEqual(Jieqi('清明'), Jieqi.清明)
-    self.assertNotEqual(Jieqi.QINGMING, Jieqi.LICHUN)
-    self.assertNotEqual(Jieqi.QINGMING.value, Jieqi.LICHUN.value)
+def test_basic() -> None:
+  assert len(Jieqi) == 24
+  assert Jieqi.QINGMING.value == '清明'
+  assert Jieqi('清明') == Jieqi.清明
+  assert Jieqi.QINGMING != Jieqi.LICHUN
+  assert Jieqi.QINGMING.value != Jieqi.LICHUN.value
 
-  def test_alias(self) -> None:
-    self.assertIs(节气, Jieqi)
-    self.assertEqual(len(节气), len(Jieqi))
 
-    for jq in Jieqi:
-      self.assertIsNotNone(jq.value)
-      self.assertIn(jq, 节气)
-      self.assertIn(jq.value, (jq.value for jq in 节气))
+def test_alias() -> None:
+  assert 节气 is Jieqi
+  assert len(节气) == len(Jieqi)
 
-    for jq in 节气:
-      self.assertIsNotNone(jq.value)
-      self.assertIn(jq, Jieqi)
-      self.assertIn(jq.value, (jq.value for jq in Jieqi))
+  for jq in Jieqi:
+    assert jq.value is not None
+    assert jq in 节气
+    assert jq.value in (jq.value for jq in 节气)
 
-    self.assertIs(节气.雨水, Jieqi.YUSHUI)
-    self.assertIs(节气.雨水, 节气.YUSHUI)
-    self.assertIs(节气.雨水, Jieqi.雨水)
+  for jq in 节气:
+    assert jq.value is not None
+    assert jq in Jieqi
+    assert jq.value in (jq.value for jq in Jieqi)
 
-    self.assertEqual(节气.惊蛰, Jieqi.JINGZHE)
-    self.assertNotEqual(节气.春分, 节气.秋分)
-    self.assertNotEqual(Jieqi.春分, Jieqi.秋分)
+  assert 节气.雨水 is Jieqi.YUSHUI
+  assert 节气.雨水 is 节气.YUSHUI
+  assert 节气.雨水 is Jieqi.雨水
 
-  def test_as_list(self) -> None:
-    self.assertListEqual(Jieqi.as_list(), list(Jieqi))
-    self.assertListEqual(Jieqi.as_list(), [
-      Jieqi.立春, Jieqi.雨水, Jieqi.惊蛰, Jieqi.春分, Jieqi.清明, Jieqi.谷雨, Jieqi.立夏, Jieqi.小满, Jieqi.芒种, Jieqi.夏至, Jieqi.小暑, Jieqi.大暑, 
-      Jieqi.立秋, Jieqi.处暑, Jieqi.白露, Jieqi.秋分, Jieqi.寒露, Jieqi.霜降, Jieqi.立冬, Jieqi.小雪, Jieqi.大雪, Jieqi.冬至, Jieqi.小寒, Jieqi.大寒
-    ])
-    self.assertListEqual(Jieqi.as_list(ganzhi_year=True), [
-      Jieqi.立春, Jieqi.雨水, Jieqi.惊蛰, Jieqi.春分, Jieqi.清明, Jieqi.谷雨, Jieqi.立夏, Jieqi.小满, Jieqi.芒种, Jieqi.夏至, Jieqi.小暑, Jieqi.大暑, 
-      Jieqi.立秋, Jieqi.处暑, Jieqi.白露, Jieqi.秋分, Jieqi.寒露, Jieqi.霜降, Jieqi.立冬, Jieqi.小雪, Jieqi.大雪, Jieqi.冬至, Jieqi.小寒, Jieqi.大寒
-    ])
-    self.assertListEqual(Jieqi.as_list(ganzhi_year=False), [
-      Jieqi.小寒, Jieqi.大寒, Jieqi.立春, Jieqi.雨水, Jieqi.惊蛰, Jieqi.春分, Jieqi.清明, Jieqi.谷雨, Jieqi.立夏, Jieqi.小满, Jieqi.芒种, Jieqi.夏至,
-      Jieqi.小暑, Jieqi.大暑, Jieqi.立秋, Jieqi.处暑, Jieqi.白露, Jieqi.秋分, Jieqi.寒露, Jieqi.霜降, Jieqi.立冬, Jieqi.小雪, Jieqi.大雪, Jieqi.冬至, 
-    ])
+  assert 节气.惊蛰 == Jieqi.JINGZHE
+  assert 节气.春分 != 节气.秋分
+  assert Jieqi.春分 != Jieqi.秋分
 
-  def test_from_str(self) -> None:
-    with self.assertRaises(ValueError):
-      Jieqi.from_str('甲甲')
-    with self.assertRaises(ValueError):
-      Jieqi.from_str('處暑') # Not supporting traditional Chinese.
-    with self.assertRaises(AssertionError):
-      Jieqi.from_str('立秋 ')
-    with self.assertRaises(AssertionError):
-      Jieqi.from_str('SHUNFEN')
-    with self.assertRaises(AssertionError):
-      Jieqi.from_str('Xiazhi')
-    with self.assertRaises(AssertionError):
-      Jieqi.from_str('春')
-    with self.assertRaises(AssertionError):
-      Jieqi.from_str(Tiangan.甲) # type: ignore
-    with self.assertRaises(AssertionError):
-      Jieqi.from_str(0) # type: ignore
 
-    for jq in Jieqi:
-      self.assertEqual(Jieqi.from_str(str(jq)), jq)
-      self.assertEqual(Jieqi(str(jq)), jq)
+def test_as_list() -> None:
+  assert Jieqi.as_list() == list(Jieqi)
+  assert Jieqi.as_list() == [
+    Jieqi.立春, Jieqi.雨水, Jieqi.惊蛰, Jieqi.春分, Jieqi.清明, Jieqi.谷雨, Jieqi.立夏, Jieqi.小满, Jieqi.芒种, Jieqi.夏至, Jieqi.小暑, Jieqi.大暑,
+    Jieqi.立秋, Jieqi.处暑, Jieqi.白露, Jieqi.秋分, Jieqi.寒露, Jieqi.霜降, Jieqi.立冬, Jieqi.小雪, Jieqi.大雪, Jieqi.冬至, Jieqi.小寒, Jieqi.大寒
+  ]
+  assert Jieqi.as_list(ganzhi_year=True) == [
+    Jieqi.立春, Jieqi.雨水, Jieqi.惊蛰, Jieqi.春分, Jieqi.清明, Jieqi.谷雨, Jieqi.立夏, Jieqi.小满, Jieqi.芒种, Jieqi.夏至, Jieqi.小暑, Jieqi.大暑,
+    Jieqi.立秋, Jieqi.处暑, Jieqi.白露, Jieqi.秋分, Jieqi.寒露, Jieqi.霜降, Jieqi.立冬, Jieqi.小雪, Jieqi.大雪, Jieqi.冬至, Jieqi.小寒, Jieqi.大寒
+  ]
+  assert Jieqi.as_list(ganzhi_year=False) == [
+    Jieqi.小寒, Jieqi.大寒, Jieqi.立春, Jieqi.雨水, Jieqi.惊蛰, Jieqi.春分, Jieqi.清明, Jieqi.谷雨, Jieqi.立夏, Jieqi.小满, Jieqi.芒种, Jieqi.夏至,
+    Jieqi.小暑, Jieqi.大暑, Jieqi.立秋, Jieqi.处暑, Jieqi.白露, Jieqi.秋分, Jieqi.寒露, Jieqi.霜降, Jieqi.立冬, Jieqi.小雪, Jieqi.大雪, Jieqi.冬至,
+  ]
 
-    self.assertEqual(Jieqi.from_str('秋分'), Jieqi.秋分)
-    self.assertEqual(Jieqi.from_str('秋分'), Jieqi.from_str('秋分'))
-    self.assertNotEqual(Jieqi.from_str('秋分'), Jieqi.from_str('小寒'))
 
-    self.assertIs(Jieqi.from_str('立春'), Jieqi.立春)
-    self.assertIs(Jieqi.from_str('雨水'), Jieqi.雨水)
-    self.assertIs(Jieqi.from_str('惊蛰'), Jieqi.惊蛰)
-    self.assertIs(Jieqi.from_str('春分'), Jieqi.春分)
-    self.assertIs(Jieqi.from_str('清明'), Jieqi.清明)
-    self.assertIs(Jieqi.from_str('谷雨'), Jieqi.谷雨)
-    self.assertIs(Jieqi.from_str('立夏'), Jieqi.立夏)
-    self.assertIs(Jieqi.from_str('小满'), Jieqi.小满)
-    self.assertIs(Jieqi.from_str('芒种'), Jieqi.芒种)
-    self.assertIs(Jieqi.from_str('夏至'), Jieqi.夏至)
-    self.assertIs(Jieqi.from_str('小暑'), Jieqi.小暑)
-    self.assertIs(Jieqi.from_str('大暑'), Jieqi.大暑)
-    self.assertIs(Jieqi.from_str('立秋'), Jieqi.立秋)
-    self.assertIs(Jieqi.from_str('处暑'), Jieqi.处暑)
-    self.assertIs(Jieqi.from_str('白露'), Jieqi.白露)
-    self.assertIs(Jieqi.from_str('秋分'), Jieqi.秋分)
-    self.assertIs(Jieqi.from_str('寒露'), Jieqi.寒露)
-    self.assertIs(Jieqi.from_str('霜降'), Jieqi.霜降)
-    self.assertIs(Jieqi.from_str('立冬'), Jieqi.立冬)
-    self.assertIs(Jieqi.from_str('小雪'), Jieqi.小雪)
-    self.assertIs(Jieqi.from_str('大雪'), Jieqi.大雪)
-    self.assertIs(Jieqi.from_str('冬至'), Jieqi.冬至)
-    self.assertIs(Jieqi.from_str('小寒'), Jieqi.小寒)
-    self.assertIs(Jieqi.from_str('大寒'), Jieqi.大寒)
+def test_from_str() -> None:
+  with pytest.raises(ValueError):
+    Jieqi.from_str('甲甲')
+  with pytest.raises(ValueError):
+    Jieqi.from_str('處暑') # Not supporting traditional Chinese.
+  with pytest.raises(AssertionError):
+    Jieqi.from_str('立秋 ')
+  with pytest.raises(AssertionError):
+    Jieqi.from_str('SHUNFEN')
+  with pytest.raises(AssertionError):
+    Jieqi.from_str('Xiazhi')
+  with pytest.raises(AssertionError):
+    Jieqi.from_str('春')
+  with pytest.raises(AssertionError):
+    Jieqi.from_str(Tiangan.甲) # type: ignore
+  with pytest.raises(AssertionError):
+    Jieqi.from_str(0) # type: ignore
 
-  def test_str(self) -> None:
-    for jq in Jieqi:
-      self.assertEqual(str(jq), jq.value)
-      self.assertEqual(Jieqi.from_str(str(jq)), jq)
-    for jq in Jieqi.as_list():
-      self.assertEqual(str(jq), jq.value)
-      self.assertEqual(Jieqi.from_str(str(jq)), jq)
+  for jq in Jieqi:
+    assert Jieqi.from_str(str(jq)) == jq
+    assert Jieqi(str(jq)) == jq
 
-    self.assertEqual(''.join([str(jq) for jq in Jieqi.as_list()]), 
-                     '立春雨水惊蛰春分清明谷雨立夏小满芒种夏至小暑大暑立秋处暑白露秋分寒露霜降立冬小雪大雪冬至小寒大寒')
+  assert Jieqi.from_str('秋分') == Jieqi.秋分
+  assert Jieqi.from_str('秋分') == Jieqi.from_str('秋分')
+  assert Jieqi.from_str('秋分') != Jieqi.from_str('小寒')
+
+  assert Jieqi.from_str('立春') is Jieqi.立春
+  assert Jieqi.from_str('雨水') is Jieqi.雨水
+  assert Jieqi.from_str('惊蛰') is Jieqi.惊蛰
+  assert Jieqi.from_str('春分') is Jieqi.春分
+  assert Jieqi.from_str('清明') is Jieqi.清明
+  assert Jieqi.from_str('谷雨') is Jieqi.谷雨
+  assert Jieqi.from_str('立夏') is Jieqi.立夏
+  assert Jieqi.from_str('小满') is Jieqi.小满
+  assert Jieqi.from_str('芒种') is Jieqi.芒种
+  assert Jieqi.from_str('夏至') is Jieqi.夏至
+  assert Jieqi.from_str('小暑') is Jieqi.小暑
+  assert Jieqi.from_str('大暑') is Jieqi.大暑
+  assert Jieqi.from_str('立秋') is Jieqi.立秋
+  assert Jieqi.from_str('处暑') is Jieqi.处暑
+  assert Jieqi.from_str('白露') is Jieqi.白露
+  assert Jieqi.from_str('秋分') is Jieqi.秋分
+  assert Jieqi.from_str('寒露') is Jieqi.寒露
+  assert Jieqi.from_str('霜降') is Jieqi.霜降
+  assert Jieqi.from_str('立冬') is Jieqi.立冬
+  assert Jieqi.from_str('小雪') is Jieqi.小雪
+  assert Jieqi.from_str('大雪') is Jieqi.大雪
+  assert Jieqi.from_str('冬至') is Jieqi.冬至
+  assert Jieqi.from_str('小寒') is Jieqi.小寒
+  assert Jieqi.from_str('大寒') is Jieqi.大寒
+
+
+def test_str() -> None:
+  for jq in Jieqi:
+    assert str(jq) == jq.value
+    assert Jieqi.from_str(str(jq)) == jq
+  for jq in Jieqi.as_list():
+    assert str(jq) == jq.value
+    assert Jieqi.from_str(str(jq)) == jq
+
+  assert ''.join([str(jq) for jq in Jieqi.as_list()]) == \
+         '立春雨水惊蛰春分清明谷雨立夏小满芒种夏至小暑大暑立秋处暑白露秋分寒露霜降立冬小雪大雪冬至小寒大寒'

--- a/tests/defines/test_relations.py
+++ b/tests/defines/test_relations.py
@@ -1,52 +1,52 @@
 # Copyright (C) 2026 Ningqi Wang (0xf3cd) <https://github.com/0xf3cd>
 # test_relations.py
 
-import unittest
+import pytest
 
 from src.defines import (
   TianganRelation, 天干关系, DizhiRelation, 地支关系,
 )
 
 
-class TestTianganRelation(unittest.TestCase):
-  def test_basic(self) -> None:
-    self.assertIs(TianganRelation, 天干关系)
-    self.assertEqual(len(TianganRelation), 4) # 合、冲、生、克
-
-  def test_str(self) -> None:
-    for relation in TianganRelation:
-      self.assertEqual(str(relation), relation.value)
-      self.assertEqual(f'{relation}', relation.value)
-      self.assertEqual(TianganRelation.from_str(str(relation)), relation)
-      self.assertEqual(TianganRelation(str(relation)), relation)
-
-    with self.assertRaises(ValueError):
-      TianganRelation.from_str('甲')
-    with self.assertRaises(ValueError):
-      TianganRelation.from_str('和')
-    with self.assertRaises(ValueError):
-      TianganRelation.from_str('冲 ')
-
-    self.assertEqual(''.join([str(relation) for relation in TianganRelation]), '合冲生克')
+def test_tiangan_relation_basic() -> None:
+  assert TianganRelation is 天干关系
+  assert len(TianganRelation) == 4 # 合、冲、生、克
 
 
-class TestDizhiRelation(unittest.TestCase):
-  def test_basic(self) -> None:
-    self.assertIs(DizhiRelation, 地支关系)
-    self.assertEqual(len(DizhiRelation), 13) # 三会、六合、暗合、通合、通禄合、三合、半合、刑、冲、破、害、生、克
+def test_tiangan_relation_str() -> None:
+  for relation in TianganRelation:
+    assert str(relation) == relation.value
+    assert f'{relation}' == relation.value
+    assert TianganRelation.from_str(str(relation)) == relation
+    assert TianganRelation(str(relation)) == relation
 
-  def test_str(self) -> None:
-    for relation in DizhiRelation:
-      self.assertEqual(str(relation), relation.value)
-      self.assertEqual(f'{relation}', relation.value)
-      self.assertEqual(DizhiRelation.from_str(str(relation)), relation)
-      self.assertEqual(DizhiRelation(str(relation)), relation)
+  with pytest.raises(ValueError):
+    TianganRelation.from_str('甲')
+  with pytest.raises(ValueError):
+    TianganRelation.from_str('和')
+  with pytest.raises(ValueError):
+    TianganRelation.from_str('冲 ')
 
-    with self.assertRaises(ValueError):
-      DizhiRelation.from_str('甲')
-    with self.assertRaises(ValueError):
-      DizhiRelation.from_str('八合')
-    with self.assertRaises(ValueError):
-      DizhiRelation.from_str('冲 ')
+  assert ''.join([str(relation) for relation in TianganRelation]) == '合冲生克'
 
-    self.assertEqual(''.join([str(relation) for relation in DizhiRelation]), '三会六合暗合通合通禄合三合半合刑冲破害生克')
+
+def test_dizhi_relation_basic() -> None:
+  assert DizhiRelation is 地支关系
+  assert len(DizhiRelation) == 13 # 三会、六合、暗合、通合、通禄合、三合、半合、刑、冲、破、害、生、克
+
+
+def test_dizhi_relation_str() -> None:
+  for relation in DizhiRelation:
+    assert str(relation) == relation.value
+    assert f'{relation}' == relation.value
+    assert DizhiRelation.from_str(str(relation)) == relation
+    assert DizhiRelation(str(relation)) == relation
+
+  with pytest.raises(ValueError):
+    DizhiRelation.from_str('甲')
+  with pytest.raises(ValueError):
+    DizhiRelation.from_str('八合')
+  with pytest.raises(ValueError):
+    DizhiRelation.from_str('冲 ')
+
+  assert ''.join([str(relation) for relation in DizhiRelation]) == '三会六合暗合通合通禄合三合半合刑冲破害生克'

--- a/tests/defines/test_shier_zhangsheng.py
+++ b/tests/defines/test_shier_zhangsheng.py
@@ -1,37 +1,38 @@
 # Copyright (C) 2026 Ningqi Wang (0xf3cd) <https://github.com/0xf3cd>
 # test_shier_zhangsheng.py
 
-import unittest
+import pytest
 
 from src.defines import (
   ShierZhangsheng, 十二长生,
 )
 
 
-class TestShierZhangsheng(unittest.TestCase):
-  def test_basic(self) -> None:
-    self.assertIs(ShierZhangsheng, 十二长生)
-    self.assertEqual(len(ShierZhangsheng), 12)
-    self.assertEqual(len(ShierZhangsheng.as_list()), 12)
-    self.assertEqual(next(iter(ShierZhangsheng)).value, '长生')
-    self.assertEqual(list(ShierZhangsheng)[-1].value, '养')
+def test_basic() -> None:
+  assert ShierZhangsheng is 十二长生
+  assert len(ShierZhangsheng) == 12
+  assert len(ShierZhangsheng.as_list()) == 12
+  assert next(iter(ShierZhangsheng)).value == '长生'
+  assert list(ShierZhangsheng)[-1].value == '养'
 
-  def test_index(self) -> None:
-    for zs in ShierZhangsheng:
-      self.assertEqual(ShierZhangsheng.from_index(zs.index), zs)
-      self.assertEqual(ShierZhangsheng.from_index(zs.index), zs)
-      self.assertEqual(ShierZhangsheng.as_list()[zs.index], zs)
 
-    with self.assertRaises(IndexError):
-      ShierZhangsheng.from_index(12)
-    with self.assertRaises(IndexError):
-      ShierZhangsheng.from_index(-13)
+def test_index() -> None:
+  for zs in ShierZhangsheng:
+    assert ShierZhangsheng.from_index(zs.index) == zs
+    assert ShierZhangsheng.from_index(zs.index) == zs
+    assert ShierZhangsheng.as_list()[zs.index] == zs
 
-  def test_str(self) -> None:
-    for zs in ShierZhangsheng:
-      self.assertEqual(str(zs), zs.value)
-      self.assertEqual(ShierZhangsheng.from_str(str(zs)), zs)
-      self.assertEqual(ShierZhangsheng(str(zs)), zs)
+  with pytest.raises(IndexError):
+    ShierZhangsheng.from_index(12)
+  with pytest.raises(IndexError):
+    ShierZhangsheng.from_index(-13)
 
-      self.assertEqual(''.join([str(zs) for zs in ShierZhangsheng.as_list()]),
-                       '长生沐浴冠带临官帝旺衰病死墓绝胎养')
+
+def test_str() -> None:
+  for zs in ShierZhangsheng:
+    assert str(zs) == zs.value
+    assert ShierZhangsheng.from_str(str(zs)) == zs
+    assert ShierZhangsheng(str(zs)) == zs
+
+    assert ''.join([str(zs) for zs in ShierZhangsheng.as_list()]) == \
+           '长生沐浴冠带临官帝旺衰病死墓绝胎养'

--- a/tests/defines/test_shier_zhangsheng.py
+++ b/tests/defines/test_shier_zhangsheng.py
@@ -34,5 +34,4 @@ def test_str() -> None:
     assert ShierZhangsheng.from_str(str(zs)) == zs
     assert ShierZhangsheng(str(zs)) == zs
 
-    assert ''.join([str(zs) for zs in ShierZhangsheng.as_list()]) == \
-           '长生沐浴冠带临官帝旺衰病死墓绝胎养'
+    assert ''.join([str(zs) for zs in ShierZhangsheng.as_list()]) == '长生沐浴冠带临官帝旺衰病死墓绝胎养'

--- a/tests/defines/test_shishen.py
+++ b/tests/defines/test_shishen.py
@@ -1,68 +1,68 @@
 # Copyright (C) 2026 Ningqi Wang (0xf3cd) <https://github.com/0xf3cd>
 # test_shishen.py
 
-import unittest
+import pytest
 
 from src.defines import (
   Shishen, 十神,
 )
 
 
-class TestShishen(unittest.TestCase):
-  def test_basic(self) -> None:
-    self.assertEqual(len(Shishen), 10)
-    self.assertEqual(len(Shishen.as_list()), 10)
-    self.assertIs(十神, Shishen)
-    self.assertEqual(Shishen('比肩').value, '比肩')
-    self.assertEqual(Shishen('食神').value, '食神')
-    self.assertNotEqual(Shishen('偏印').value, '食神')
+def test_basic() -> None:
+  assert len(Shishen) == 10
+  assert len(Shishen.as_list()) == 10
+  assert 十神 is Shishen
+  assert Shishen('比肩').value == '比肩'
+  assert Shishen('食神').value == '食神'
+  assert Shishen('偏印').value != '食神'
 
-  def test_str(self) -> None:
-    with self.subTest('Two characters - fullname'):
-      self.assertEqual(str(Shishen.比肩), '比肩')
-      self.assertEqual(str(Shishen.劫财), '劫财')
-      self.assertEqual(str(Shishen.食神), '食神')
-      self.assertEqual(str(Shishen.伤官), '伤官')
-      self.assertEqual(str(Shishen.正财), '正财')
-      self.assertEqual(str(Shishen.偏财), '偏财')
-      self.assertEqual(str(Shishen.正官), '正官')
-      self.assertEqual(str(Shishen.七杀), '七杀')
-      self.assertEqual(str(Shishen.正印), '正印')
-      self.assertEqual(str(Shishen.偏印), '偏印')
 
-      for s in Shishen:
-        self.assertEqual(str(s), s.value)
-        self.assertEqual(Shishen.from_str(str(s)), s)
-        self.assertEqual(Shishen(str(s)), s)
+def test_str() -> None:
+  # Two characters - fullname.
+  assert str(Shishen.比肩) == '比肩'
+  assert str(Shishen.劫财) == '劫财'
+  assert str(Shishen.食神) == '食神'
+  assert str(Shishen.伤官) == '伤官'
+  assert str(Shishen.正财) == '正财'
+  assert str(Shishen.偏财) == '偏财'
+  assert str(Shishen.正官) == '正官'
+  assert str(Shishen.七杀) == '七杀'
+  assert str(Shishen.正印) == '正印'
+  assert str(Shishen.偏印) == '偏印'
 
-      self.assertEqual(''.join([str(s) for s in Shishen.as_list()]), 
-                      '比肩劫财食神伤官正财偏财正官七杀正印偏印')
-      
-    with self.subTest('One character - abbreviation'):
-      self.assertEqual(len(Shishen.str_mapping_table()), 10)
+  for s in Shishen:
+    assert str(s) == s.value
+    assert Shishen.from_str(str(s)) == s
+    assert Shishen(str(s)) == s
 
-      self.assertIs(Shishen.from_str('比'), Shishen.比肩)
-      self.assertIs(Shishen.from_str('劫'), Shishen.劫财)
-      self.assertIs(Shishen.from_str('食'), Shishen.食神)
-      self.assertIs(Shishen.from_str('伤'), Shishen.伤官)
-      self.assertIs(Shishen.from_str('财'), Shishen.正财)
-      self.assertIs(Shishen.from_str('才'), Shishen.偏财)
-      self.assertIs(Shishen.from_str('官'), Shishen.正官)
-      self.assertIs(Shishen.from_str('杀'), Shishen.七杀)
-      self.assertIs(Shishen.from_str('印'), Shishen.正印)
-      self.assertIs(Shishen.from_str('枭'), Shishen.偏印)
+  assert ''.join([str(s) for s in Shishen.as_list()]) == \
+         '比肩劫财食神伤官正财偏财正官七杀正印偏印'
 
-      self.assertEqual(''.join([s.abbr for s in Shishen]), '比劫食伤财才官杀印枭')
+  # One character - abbreviation.
+  assert len(Shishen.str_mapping_table()) == 10
 
-      with self.assertRaises(AssertionError):
-        Shishen.from_str('甲')
-      with self.assertRaises(AssertionError):
-        Shishen.from_str('辰')
-      with self.assertRaises(AssertionError):
-        Shishen.from_str('')
-      with self.assertRaises(ValueError):
-        Shishen.from_str('甲子')
-      with self.assertRaises(ValueError):
-        Shishen.from_str('比间')
-      with self.assertRaises(ValueError):
-        Shishen.from_str('枭神')
+  assert Shishen.from_str('比') is Shishen.比肩
+  assert Shishen.from_str('劫') is Shishen.劫财
+  assert Shishen.from_str('食') is Shishen.食神
+  assert Shishen.from_str('伤') is Shishen.伤官
+  assert Shishen.from_str('财') is Shishen.正财
+  assert Shishen.from_str('才') is Shishen.偏财
+  assert Shishen.from_str('官') is Shishen.正官
+  assert Shishen.from_str('杀') is Shishen.七杀
+  assert Shishen.from_str('印') is Shishen.正印
+  assert Shishen.from_str('枭') is Shishen.偏印
+
+  assert ''.join([s.abbr for s in Shishen]) == '比劫食伤财才官杀印枭'
+
+  with pytest.raises(AssertionError):
+    Shishen.from_str('甲')
+  with pytest.raises(AssertionError):
+    Shishen.from_str('辰')
+  with pytest.raises(AssertionError):
+    Shishen.from_str('')
+  with pytest.raises(ValueError):
+    Shishen.from_str('甲子')
+  with pytest.raises(ValueError):
+    Shishen.from_str('比间')
+  with pytest.raises(ValueError):
+    Shishen.from_str('枭神')

--- a/tests/defines/test_shishen.py
+++ b/tests/defines/test_shishen.py
@@ -35,8 +35,7 @@ def test_str() -> None:
     assert Shishen.from_str(str(s)) == s
     assert Shishen(str(s)) == s
 
-  assert ''.join([str(s) for s in Shishen.as_list()]) == \
-         '比肩劫财食神伤官正财偏财正官七杀正印偏印'
+  assert ''.join([str(s) for s in Shishen.as_list()]) == '比肩劫财食神伤官正财偏财正官七杀正印偏印'
 
   # One character - abbreviation.
   assert len(Shishen.str_mapping_table()) == 10

--- a/tests/defines/test_tiangan.py
+++ b/tests/defines/test_tiangan.py
@@ -1,111 +1,116 @@
 # Copyright (C) 2026 Ningqi Wang (0xf3cd) <https://github.com/0xf3cd>
 # test_tiangan.py
 
-import unittest
+import pytest
 
 from src.defines import (
   Tiangan, 天干,
 )
 
 
-class TestTiangan(unittest.TestCase):
-  def test_basic(self) -> None:
-    self.assertEqual(len(Tiangan), 10)
-    self.assertEqual(Tiangan.JIA.value, '甲')
-    self.assertEqual(Tiangan('甲').value, '甲')
-    self.assertNotEqual(Tiangan.WU, Tiangan.REN)
-    self.assertNotEqual(Tiangan.WU.value, Tiangan.REN.value)
+def test_basic() -> None:
+  assert len(Tiangan) == 10
+  assert Tiangan.JIA.value == '甲'
+  assert Tiangan('甲').value == '甲'
+  assert Tiangan.WU != Tiangan.REN
+  assert Tiangan.WU.value != Tiangan.REN.value
 
-  def test_alias(self) -> None:
-    self.assertEqual(天干, Tiangan)
-    self.assertIs(天干, Tiangan)
-    self.assertEqual(len(天干), 10)
 
-    self.assertIs(Tiangan.甲, Tiangan.JIA)
-    self.assertIs(Tiangan.甲, Tiangan.甲)
-    self.assertIs(天干.甲, Tiangan.甲)
-    self.assertIs(天干.甲, 天干.JIA)
-    self.assertIs(天干.BING, 天干.丙)
+def test_alias() -> None:
+  assert 天干 == Tiangan
+  assert 天干 is Tiangan
+  assert len(天干) == 10
 
-    self.assertIsNot(Tiangan.甲, Tiangan.乙)
+  assert Tiangan.甲 is Tiangan.JIA
+  assert Tiangan.甲 is Tiangan.甲
+  assert 天干.甲 is Tiangan.甲
+  assert 天干.甲 is 天干.JIA
+  assert 天干.BING is 天干.丙
 
-    self.assertEqual(天干.甲.value, '甲')
-    self.assertEqual(天干.JIA.value, '甲')
-    self.assertEqual(天干.丁.value, Tiangan.丁.value)
-    self.assertEqual(天干.甲.value, Tiangan.JIA.value)
-    self.assertEqual(天干.甲.value, 天干.JIA.value)
+  assert Tiangan.甲 is not Tiangan.乙
 
-    self.assertNotEqual(天干.癸, 天干.庚)
-    self.assertNotEqual(天干.甲.value, Tiangan.丁.value)
-    self.assertNotEqual(天干.WU.value, '甲')
+  assert 天干.甲.value == '甲'
+  assert 天干.JIA.value == '甲'
+  assert 天干.丁.value == Tiangan.丁.value
+  assert 天干.甲.value == Tiangan.JIA.value
+  assert 天干.甲.value == 天干.JIA.value
 
-    for e in Tiangan:
-      self.assertIsNotNone(e.value)
-      self.assertIn(e, 天干)
+  assert 天干.癸 != 天干.庚
+  assert 天干.甲.value != Tiangan.丁.value
+  assert 天干.WU.value != '甲'
 
-    for e in 天干:
-      self.assertIsNotNone(e.value)
-      self.assertIn(e, Tiangan)
+  for e in Tiangan:
+    assert e.value is not None
+    assert e in 天干
 
-  def test_as_list(self) -> None:
-    self.assertListEqual(Tiangan.as_list(), list(Tiangan))
-    self.assertListEqual(Tiangan.as_list(), \
-      [Tiangan.甲, Tiangan.乙, Tiangan.丙, Tiangan.丁, Tiangan.戊, Tiangan.己, Tiangan.庚, Tiangan.辛, Tiangan.壬, Tiangan.癸])
-  
-  def test_from_str(self) -> None:
-    with self.assertRaises(ValueError):
-      Tiangan.from_str('甲甲')
-    with self.assertRaises(ValueError):
-      Tiangan.from_str('JIA')
-    with self.assertRaises(ValueError):
-      Tiangan.from_str('Jia')
-    with self.assertRaises(ValueError):
-      Tiangan.from_str('子')
-    with self.assertRaises(AssertionError):
-      Tiangan.from_str(Tiangan.甲) # type: ignore
-    with self.assertRaises(AssertionError):
-      Tiangan.from_str(0) # type: ignore
+  for e in 天干:
+    assert e.value is not None
+    assert e in Tiangan
 
-    self.assertEqual(Tiangan.from_str('甲'), Tiangan.甲)
-    self.assertEqual(Tiangan.甲, Tiangan.from_str('甲'))
-    self.assertEqual(Tiangan.from_str('丁'), Tiangan.from_str('丁'))
-    self.assertNotEqual(Tiangan.甲, Tiangan.from_str('丁'))
-    self.assertNotEqual(Tiangan.from_str('丁'), Tiangan.from_str('甲'))
-                        
-  def test_str(self) -> None:
-    for e in Tiangan:
-      self.assertEqual(str(e), e.value)
-      self.assertIs(Tiangan(str(e)), e)
-    for e in Tiangan.as_list():
-      self.assertEqual(str(e), e.value)
-      self.assertIs(Tiangan(str(e)), e)
 
-    self.assertEqual('甲乙丙丁戊己庚辛壬癸', ''.join([str(e) for e in Tiangan.as_list()]))
+def test_as_list() -> None:
+  assert Tiangan.as_list() == list(Tiangan)
+  assert Tiangan.as_list() == \
+    [Tiangan.甲, Tiangan.乙, Tiangan.丙, Tiangan.丁, Tiangan.戊, Tiangan.己, Tiangan.庚, Tiangan.辛, Tiangan.壬, Tiangan.癸]
 
-  def test_index(self) -> None:
-    self.assertEqual(Tiangan.甲.index, 0)
-    self.assertEqual(Tiangan.乙.index, 1)
-    self.assertEqual(Tiangan.丙.index, 2)
-    self.assertEqual(Tiangan.丁.index, 3)
-    self.assertEqual(Tiangan.戊.index, 4)
-    self.assertEqual(Tiangan.己.index, 5)
-    self.assertEqual(Tiangan.庚.index, 6)
-    self.assertEqual(Tiangan.辛.index, 7)
-    self.assertEqual(Tiangan.壬.index, 8)
-    self.assertEqual(Tiangan.癸.index, 9)
 
-  def test_from_index(self) -> None:
-    self.assertEqual(Tiangan.from_index(0), Tiangan.甲)
-    self.assertEqual(Tiangan.from_index(1), Tiangan.乙)
-    self.assertEqual(Tiangan.from_index(2), Tiangan.丙)
-    self.assertEqual(Tiangan.from_index(3), Tiangan.丁)
-    self.assertEqual(Tiangan.from_index(4), Tiangan.戊)
-    self.assertEqual(Tiangan.from_index(5), Tiangan.己)
-    self.assertEqual(Tiangan.from_index(6), Tiangan.庚)
-    self.assertEqual(Tiangan.from_index(7), Tiangan.辛)
-    self.assertEqual(Tiangan.from_index(8), Tiangan.壬)
-    self.assertEqual(Tiangan.from_index(9), Tiangan.癸)
-    with self.assertRaises(IndexError):
-      Tiangan.from_index(10)
-    with self.assertRaises(IndexError):
-      Tiangan.from_index(-11)
+def test_from_str() -> None:
+  with pytest.raises(ValueError):
+    Tiangan.from_str('甲甲')
+  with pytest.raises(ValueError):
+    Tiangan.from_str('JIA')
+  with pytest.raises(ValueError):
+    Tiangan.from_str('Jia')
+  with pytest.raises(ValueError):
+    Tiangan.from_str('子')
+  with pytest.raises(AssertionError):
+    Tiangan.from_str(Tiangan.甲) # type: ignore
+  with pytest.raises(AssertionError):
+    Tiangan.from_str(0) # type: ignore
+
+  assert Tiangan.from_str('甲') == Tiangan.甲
+  assert Tiangan.甲 == Tiangan.from_str('甲')
+  assert Tiangan.from_str('丁') == Tiangan.from_str('丁')
+  assert Tiangan.甲 != Tiangan.from_str('丁')
+  assert Tiangan.from_str('丁') != Tiangan.from_str('甲')
+
+
+def test_str() -> None:
+  for e in Tiangan:
+    assert str(e) == e.value
+    assert Tiangan(str(e)) is e
+  for e in Tiangan.as_list():
+    assert str(e) == e.value
+    assert Tiangan(str(e)) is e
+
+  assert '甲乙丙丁戊己庚辛壬癸' == ''.join([str(e) for e in Tiangan.as_list()])
+
+
+def test_index() -> None:
+  assert Tiangan.甲.index == 0
+  assert Tiangan.乙.index == 1
+  assert Tiangan.丙.index == 2
+  assert Tiangan.丁.index == 3
+  assert Tiangan.戊.index == 4
+  assert Tiangan.己.index == 5
+  assert Tiangan.庚.index == 6
+  assert Tiangan.辛.index == 7
+  assert Tiangan.壬.index == 8
+  assert Tiangan.癸.index == 9
+
+
+def test_from_index() -> None:
+  assert Tiangan.from_index(0) == Tiangan.甲
+  assert Tiangan.from_index(1) == Tiangan.乙
+  assert Tiangan.from_index(2) == Tiangan.丙
+  assert Tiangan.from_index(3) == Tiangan.丁
+  assert Tiangan.from_index(4) == Tiangan.戊
+  assert Tiangan.from_index(5) == Tiangan.己
+  assert Tiangan.from_index(6) == Tiangan.庚
+  assert Tiangan.from_index(7) == Tiangan.辛
+  assert Tiangan.from_index(8) == Tiangan.壬
+  assert Tiangan.from_index(9) == Tiangan.癸
+  with pytest.raises(IndexError):
+    Tiangan.from_index(10)
+  with pytest.raises(IndexError):
+    Tiangan.from_index(-11)

--- a/tests/defines/test_wuxing.py
+++ b/tests/defines/test_wuxing.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2026 Ningqi Wang (0xf3cd) <https://github.com/0xf3cd>
 # test_wuxing.py
 
-import unittest
+import pytest
 
 from itertools import product
 from src.defines import (
@@ -9,73 +9,77 @@ from src.defines import (
 )
 
 
-class TestWuxing(unittest.TestCase):
-  def test_basic(self) -> None:
-    self.assertEqual(len(Wuxing), 5)
-    self.assertEqual(Wuxing.METAL.value, '金')
-    self.assertEqual(Wuxing.金.value, '金')
-    self.assertEqual(Wuxing('金'), Wuxing.金)
-    self.assertNotEqual(Wuxing.金, Wuxing.木)
-    self.assertNotEqual(Wuxing.金.value, Wuxing.木.value)
+def test_basic() -> None:
+  assert len(Wuxing) == 5
+  assert Wuxing.METAL.value == '金'
+  assert Wuxing.金.value == '金'
+  assert Wuxing('金') == Wuxing.金
+  assert Wuxing.金 != Wuxing.木
+  assert Wuxing.金.value != Wuxing.木.value
 
-  def test_alias(self) -> None:
-    self.assertIs(Wuxing.木, Wuxing.WOOD)
-    self.assertIs(Wuxing.火, Wuxing.FIRE)
-    self.assertIs(Wuxing.土, Wuxing.EARTH)
-    self.assertIs(Wuxing.金, Wuxing.METAL)
-    self.assertIs(Wuxing.水, Wuxing.WATER)
-    self.assertIs(Wuxing, 五行)
 
-  def test_as_list(self) -> None:
-    self.assertEqual(len(Wuxing.as_list()), 5)
-    self.assertEqual(Wuxing.as_list()[0], Wuxing.木)
-    self.assertEqual(Wuxing.as_list()[1], Wuxing.火)
-    self.assertEqual(Wuxing.as_list()[2], Wuxing.土)
-    self.assertEqual(Wuxing.as_list()[3], Wuxing.金)
-    self.assertEqual(Wuxing.as_list()[4], Wuxing.水)
+def test_alias() -> None:
+  assert Wuxing.木 is Wuxing.WOOD
+  assert Wuxing.火 is Wuxing.FIRE
+  assert Wuxing.土 is Wuxing.EARTH
+  assert Wuxing.金 is Wuxing.METAL
+  assert Wuxing.水 is Wuxing.WATER
+  assert Wuxing is 五行
 
-  def test_from_str(self) -> None:
-    self.assertIs(Wuxing.from_str('木'), Wuxing.木)
-    self.assertIs(Wuxing.from_str('火'), Wuxing.火)
-    self.assertIs(Wuxing.from_str('土'), Wuxing.土)
-    self.assertIs(Wuxing.from_str('金'), Wuxing.金)
-    self.assertIs(Wuxing.from_str('水'), Wuxing.水)
 
-    with self.assertRaises(AssertionError):
-      Wuxing.from_str('')
-    with self.assertRaises(AssertionError):
-      Wuxing.from_str('木木')
-    with self.assertRaises(ValueError):
-      Wuxing.from_str('甲')
-    with self.assertRaises(ValueError):
-      Wuxing.from_str('辰')
+def test_as_list() -> None:
+  assert len(Wuxing.as_list()) == 5
+  assert Wuxing.as_list()[0] == Wuxing.木
+  assert Wuxing.as_list()[1] == Wuxing.火
+  assert Wuxing.as_list()[2] == Wuxing.土
+  assert Wuxing.as_list()[3] == Wuxing.金
+  assert Wuxing.as_list()[4] == Wuxing.水
 
-  def test_str(self) -> None:
-    for wx in Wuxing:
-      self.assertEqual(str(wx), wx.value)
-      self.assertEqual(Wuxing.from_str(str(wx)), wx)
 
-    self.assertEqual(''.join([str(wx) for wx in Wuxing]), '木火土金水')
+def test_from_str() -> None:
+  assert Wuxing.from_str('木') is Wuxing.木
+  assert Wuxing.from_str('火') is Wuxing.火
+  assert Wuxing.from_str('土') is Wuxing.土
+  assert Wuxing.from_str('金') is Wuxing.金
+  assert Wuxing.from_str('水') is Wuxing.水
 
-  def test_generates_and_destructs(self) -> None:
-    self.assertTrue(Wuxing.木.generates(Wuxing.火))
-    self.assertTrue(Wuxing.火.destructs(Wuxing.金))
+  with pytest.raises(AssertionError):
+    Wuxing.from_str('')
+  with pytest.raises(AssertionError):
+    Wuxing.from_str('木木')
+  with pytest.raises(ValueError):
+    Wuxing.from_str('甲')
+  with pytest.raises(ValueError):
+    Wuxing.from_str('辰')
 
-    wx_list: list[Wuxing] = Wuxing.as_list()
-    for wx1, wx2 in product(wx_list, wx_list):
-      wx1_index: int = wx_list.index(wx1)
-      wx2_index: int = wx_list.index(wx2)
-      
-      if (wx1_index + 1) % 5 == wx2_index:
-        self.assertTrue(wx1.generates(wx2))
-        self.assertFalse(wx2.generates(wx1))
-        self.assertFalse(wx1.destructs(wx2))
-      else:
-        self.assertFalse(wx1.generates(wx2))
 
-      if (wx1_index + 2) % 5 == wx2_index:
-        self.assertTrue(wx1.destructs(wx2))
-        self.assertFalse(wx2.destructs(wx1))
-        self.assertFalse(wx1.generates(wx2))
-      else:
-        self.assertFalse(wx1.destructs(wx2))
+def test_str() -> None:
+  for wx in Wuxing:
+    assert str(wx) == wx.value
+    assert Wuxing.from_str(str(wx)) == wx
+
+  assert ''.join([str(wx) for wx in Wuxing]) == '木火土金水'
+
+
+def test_generates_and_destructs() -> None:
+  assert Wuxing.木.generates(Wuxing.火)
+  assert Wuxing.火.destructs(Wuxing.金)
+
+  wx_list: list[Wuxing] = Wuxing.as_list()
+  for wx1, wx2 in product(wx_list, wx_list):
+    wx1_index: int = wx_list.index(wx1)
+    wx2_index: int = wx_list.index(wx2)
+
+    if (wx1_index + 1) % 5 == wx2_index:
+      assert wx1.generates(wx2)
+      assert not wx2.generates(wx1)
+      assert not wx1.destructs(wx2)
+    else:
+      assert not wx1.generates(wx2)
+
+    if (wx1_index + 2) % 5 == wx2_index:
+      assert wx1.destructs(wx2)
+      assert not wx2.destructs(wx1)
+      assert not wx1.generates(wx2)
+    else:
+      assert not wx1.destructs(wx2)

--- a/tests/defines/test_yinyang.py
+++ b/tests/defines/test_yinyang.py
@@ -1,47 +1,48 @@
 # Copyright (C) 2026 Ningqi Wang (0xf3cd) <https://github.com/0xf3cd>
 # test_yinyang.py
 
-import unittest
+import pytest
 
 from src.defines import (
   Yinyang, 阴阳,
 )
 
 
-class TestYinyang(unittest.TestCase):
-  def test_basic(self) -> None:
-    self.assertEqual(len(Yinyang), 2)
-    self.assertIs(Yinyang.阴, Yinyang.YIN)
-    self.assertIs(Yinyang.阳, Yinyang.YANG)
+def test_basic() -> None:
+  assert len(Yinyang) == 2
+  assert Yinyang.阴 is Yinyang.YIN
+  assert Yinyang.阳 is Yinyang.YANG
 
-    self.assertEqual(Yinyang.阴.value, '阴')
-    self.assertNotEqual(Yinyang.阴, Yinyang.阳)
-    self.assertNotEqual(Yinyang.阴.value, Yinyang.阳.value)
+  assert Yinyang.阴.value == '阴'
+  assert Yinyang.阴 != Yinyang.阳
+  assert Yinyang.阴.value != Yinyang.阳.value
 
-    self.assertEqual(len(Yinyang.as_list()), 2)
-    self.assertEqual(Yinyang.as_list()[0], Yinyang.阳)
-    self.assertEqual(Yinyang.as_list()[1], Yinyang.阴)
+  assert len(Yinyang.as_list()) == 2
+  assert Yinyang.as_list()[0] == Yinyang.阳
+  assert Yinyang.as_list()[1] == Yinyang.阴
 
-    self.assertIs(阴阳, Yinyang)
+  assert 阴阳 is Yinyang
 
-  def test_str(self) -> None:
-    self.assertEqual(str(Yinyang.阴), '阴')
-    self.assertEqual(str(Yinyang.阳), '阳')
-    self.assertEqual(Yinyang.from_str('阴'), Yinyang.阴)
-    self.assertEqual(Yinyang.from_str('阳'), Yinyang.阳)
-    self.assertEqual(Yinyang('阴'), Yinyang.阴)
-    self.assertEqual(Yinyang('阳'), Yinyang.阳)
 
-    self.assertEqual(''.join([str(e) for e in Yinyang.as_list()]), '阳阴')
+def test_str() -> None:
+  assert str(Yinyang.阴) == '阴'
+  assert str(Yinyang.阳) == '阳'
+  assert Yinyang.from_str('阴') == Yinyang.阴
+  assert Yinyang.from_str('阳') == Yinyang.阳
+  assert Yinyang('阴') == Yinyang.阴
+  assert Yinyang('阳') == Yinyang.阳
 
-    self.assertEqual(Yinyang.from_str('阴'), Yinyang.阴)
-    self.assertEqual(Yinyang.from_str('阳'), Yinyang.阳)
+  assert ''.join([str(e) for e in Yinyang.as_list()]) == '阳阴'
 
-    with self.assertRaises(ValueError):
-      Yinyang.from_str('甲')
-    with self.assertRaises(ValueError):
-      Yinyang.from_str('辰')
+  assert Yinyang.from_str('阴') == Yinyang.阴
+  assert Yinyang.from_str('阳') == Yinyang.阳
 
-  def test_opposite(self) -> None:
-    self.assertEqual(Yinyang.阴.opposite, Yinyang.阳)
-    self.assertEqual(Yinyang.阳.opposite, Yinyang.阴)
+  with pytest.raises(ValueError):
+    Yinyang.from_str('甲')
+  with pytest.raises(ValueError):
+    Yinyang.from_str('辰')
+
+
+def test_opposite() -> None:
+  assert Yinyang.阴.opposite == Yinyang.阳
+  assert Yinyang.阳.opposite == Yinyang.阴

--- a/tests/integration/test_ganzhi_relations.py
+++ b/tests/integration/test_ganzhi_relations.py
@@ -12,6 +12,9 @@ from src.defines import Tiangan, Dizhi, Ganzhi, TianganRelation, DizhiRelation
 from src.utils import tiangan_utils, dizhi_utils
 
 
+pytestmark = pytest.mark.integration
+
+
 # Integration tests are mainly aiming to test the correctness of `tiangan_utils` and `dizhi_utils` in transit context.
 # The Bazi cases are collected from "测测" app / "问真八字" web site.
 #
@@ -24,6 +27,7 @@ from src.utils import tiangan_utils, dizhi_utils
 # are in `tiangan_utils`'s and `dizhi_utils`'s returns.
 # There can be some combos in the returns but not in 测测/问真八字's results.
 
+
 def _check_tiangan(expected: dict[TianganRelation, list[tiangan_utils.TianganCombo]], actual: tiangan_utils.TianganRelationDiscovery) -> bool:
   for rel, expected_combos in expected.items():
     if rel not in actual:
@@ -32,6 +36,7 @@ def _check_tiangan(expected: dict[TianganRelation, list[tiangan_utils.TianganCom
       if combo not in actual[rel]:
         return False
   return True
+
 
 def _check_dizhi(expected: dict[DizhiRelation, list[dizhi_utils.DizhiCombo]], actual: dizhi_utils.DizhiRelationDiscovery) -> bool:
   for rel, expected_combos in expected.items():
@@ -42,7 +47,7 @@ def _check_dizhi(expected: dict[DizhiRelation, list[dizhi_utils.DizhiCombo]], ac
         return False
   return True
 
-@pytest.mark.integration
+
 def test_case1() -> None:
   '''From 问真八字 https://pcbz.iwzwh.com/#/paipan/index'''
   bazi: Bazi = Bazi(
@@ -127,7 +132,7 @@ def test_case1() -> None:
     DizhiRelation.害 : [frozenset({Dizhi.未, Dizhi.子})],
   }, dizhi_utils.discover_mutual(bazi.four_dizhis, tuple(gz.dizhi for gz in ganzhis)))
 
-@pytest.mark.integration
+
 def test_case2() -> None:
   '''From 测测 and 问真八字'''
   bazi: Bazi = Bazi(

--- a/tests/integration/test_ganzhi_relations.py
+++ b/tests/integration/test_ganzhi_relations.py
@@ -2,7 +2,6 @@
 # test_ganzhi_relations.py
 
 import pytest
-import unittest
 
 from datetime import datetime
 
@@ -13,218 +12,214 @@ from src.defines import Tiangan, Dizhi, Ganzhi, TianganRelation, DizhiRelation
 from src.utils import tiangan_utils, dizhi_utils
 
 
+# Integration tests are mainly aiming to test the correctness of `tiangan_utils` and `dizhi_utils` in transit context.
+# The Bazi cases are collected from "测测" app / "问真八字" web site.
+#
+# In this project, `search`, `discover`, and `discover_mutual` methods in `tiangan_utils` and `dizhi_utils` will
+# return all possible combos.
+# However, for 测测 and 问真八字, they only consider part of the combos. For example,
+# they don't consider SHENG / 生 relation.
+#
+# So in the following tests, we only test that the relation combos that 测测/问真八字 find
+# are in `tiangan_utils`'s and `dizhi_utils`'s returns.
+# There can be some combos in the returns but not in 测测/问真八字's results.
+
+def _check_tiangan(expected: dict[TianganRelation, list[tiangan_utils.TianganCombo]], actual: tiangan_utils.TianganRelationDiscovery) -> bool:
+  for rel, expected_combos in expected.items():
+    if rel not in actual:
+      return False
+    for combo in expected_combos:
+      if combo not in actual[rel]:
+        return False
+  return True
+
+def _check_dizhi(expected: dict[DizhiRelation, list[dizhi_utils.DizhiCombo]], actual: dizhi_utils.DizhiRelationDiscovery) -> bool:
+  for rel, expected_combos in expected.items():
+    if rel not in actual:
+      return False
+    for combo in expected_combos:
+      if combo not in actual[rel]:
+        return False
+  return True
+
 @pytest.mark.integration
-class TestTianganDizhiRelations(unittest.TestCase):
-  '''
-  Integration tests are mainly aiming to test the correctness of `tiangan_utils` and `dizhi_utils` in transit context.
-  The Bazi cases are collected from "测测" app / "问真八字" web site.
+def test_case1() -> None:
+  '''From 问真八字 https://pcbz.iwzwh.com/#/paipan/index'''
+  bazi: Bazi = Bazi(
+    birth_time=datetime(1984, 4, 1, 11, 8),
+    gender=BaziGender.MALE,
+    precision=BaziPrecision.DAY,
+  )
+  chart: BaziChart = BaziChart(bazi)
+  db: TransitDatabase = TransitDatabase(chart)
 
-  In this project, `search`, `discover`, and `discover_mutual` methods in `tiangan_utils` and `dizhi_utils` will
-  return all possible combos.
-  However, for 测测 and 问真八字, they only consider part of the combos. For example, 
-  they don't consider SHENG / 生 relation.
+  # pillar correctness
+  assert bazi.year_pillar == Ganzhi.from_str('甲子')
+  assert bazi.month_pillar == Ganzhi.from_str('丁卯')
+  assert bazi.day_pillar == Ganzhi.from_str('乙丑')
+  assert bazi.hour_pillar == Ganzhi.from_str('壬午')
+  assert chart.xiaoyun[0].ganzhi == Ganzhi.from_str('癸未')
+  assert next(chart.dayun).ganzhi == Ganzhi.from_str('戊辰'), 'first dayun Ganzhi'
+  assert next(chart.dayun).ganzhi_year == 1985, 'first dayun year'
 
-  So in the following tests, we only test that the relation combos that 测测/问真八字 find 
-  are in `tiangan_utils`'s and `dizhi_utils`'s returns. 
-  There can be some combos in the returns but not in 测测/问真八字's results.
-  '''
+  # at birth
+  assert _check_tiangan({
+    TianganRelation.合 : [frozenset({Tiangan.丁, Tiangan.壬})],
+  }, tiangan_utils.discover(chart.bazi.four_tiangans))
 
-  @staticmethod
-  def __check_tiangan(expected: dict[TianganRelation, list[tiangan_utils.TianganCombo]], actual: tiangan_utils.TianganRelationDiscovery) -> bool:
-    for rel, expected_combos in expected.items():
-      if rel not in actual:
-        return False
-      for combo in expected_combos:
-        if combo not in actual[rel]:
-          return False
-    return True
+  assert _check_dizhi({
+    DizhiRelation.六合 : [frozenset({Dizhi.子, Dizhi.丑})],
+    DizhiRelation.刑 : [frozenset({Dizhi.子, Dizhi.卯})],
+    DizhiRelation.冲 : [frozenset({Dizhi.子, Dizhi.午})],
+    DizhiRelation.破 : [frozenset({Dizhi.午, Dizhi.卯})],
+    DizhiRelation.害 : [frozenset({Dizhi.丑, Dizhi.午})],
+  }, dizhi_utils.discover(chart.bazi.four_dizhis))
 
-  @staticmethod
-  def __check_dizhi(expected: dict[DizhiRelation, list[dizhi_utils.DizhiCombo]], actual: dizhi_utils.DizhiRelationDiscovery) -> bool:
-    for rel, expected_combos in expected.items():
-      if rel not in actual:
-        return False
-      for combo in expected_combos:
-        if combo not in actual[rel]:
-          return False
-    return True
+  # 1993 dayun and liunian - transits only
+  ganzhis = db.ganzhis(TransitMoment(1993), TransitOptions.DAYUN_LIUNIAN)
 
-  def test_case1(self) -> None:
-    '''From 问真八字 https://pcbz.iwzwh.com/#/paipan/index'''
-    bazi: Bazi = Bazi(
-      birth_time=datetime(1984, 4, 1, 11, 8),
-      gender=BaziGender.MALE,
-      precision=BaziPrecision.DAY,
-    )
-    chart: BaziChart = BaziChart(bazi)
-    db: TransitDatabase = TransitDatabase(chart)
+  assert _check_tiangan({
+    TianganRelation.合 : [frozenset({Tiangan.戊, Tiangan.癸})],
+  }, tiangan_utils.discover(tuple(gz.tiangan for gz in ganzhis)))
 
-    with self.subTest('pillar correctness'):
-      self.assertEqual(bazi.year_pillar, Ganzhi.from_str('甲子'))
-      self.assertEqual(bazi.month_pillar, Ganzhi.from_str('丁卯'))
-      self.assertEqual(bazi.day_pillar, Ganzhi.from_str('乙丑'))
-      self.assertEqual(bazi.hour_pillar, Ganzhi.from_str('壬午'))
-      self.assertEqual(chart.xiaoyun[0].ganzhi, Ganzhi.from_str('癸未'))
-      self.assertEqual(next(chart.dayun).ganzhi, Ganzhi.from_str('戊辰'), 'first dayun Ganzhi')
-      self.assertEqual(next(chart.dayun).ganzhi_year, 1985, 'first dayun year')
+  assert _check_dizhi({
+    DizhiRelation.六合 : [frozenset({Dizhi.辰, Dizhi.酉})],
+  }, dizhi_utils.discover(tuple(gz.dizhi for gz in ganzhis)))
 
-    with self.subTest('at birth'):
-      self.assertTrue(self.__check_tiangan({
-        TianganRelation.合 : [frozenset({Tiangan.丁, Tiangan.壬})],
-      }, tiangan_utils.discover(chart.bazi.four_tiangans)))
+  # 2024 dayun and liunian - between transits and at-birth
+  ganzhis = db.ganzhis(TransitMoment(2024), TransitOptions.DAYUN_LIUNIAN)
 
-      self.assertTrue(self.__check_dizhi({
-        DizhiRelation.六合 : [frozenset({Dizhi.子, Dizhi.丑})],
-        DizhiRelation.刑 : [frozenset({Dizhi.子, Dizhi.卯})],
-        DizhiRelation.冲 : [frozenset({Dizhi.子, Dizhi.午})],
-        DizhiRelation.破 : [frozenset({Dizhi.午, Dizhi.卯})],
-        DizhiRelation.害 : [frozenset({Dizhi.丑, Dizhi.午})],
-      }, dizhi_utils.discover(chart.bazi.four_dizhis)))
+  assert _check_tiangan({
+    TianganRelation.克 : [frozenset({Tiangan.丁, Tiangan.辛}), frozenset({Tiangan.辛, Tiangan.乙})],
+  }, tiangan_utils.discover_mutual(bazi.four_tiangans, tuple(gz.tiangan for gz in ganzhis)))
 
-    with self.subTest('1993 dayun and liunian - transits only'):
-      ganzhis = db.ganzhis(TransitMoment(1993), TransitOptions.DAYUN_LIUNIAN)
+  assert _check_dizhi({
+    DizhiRelation.六合 : [frozenset({Dizhi.午, Dizhi.未})],
+    DizhiRelation.半合 : [frozenset({Dizhi.子, Dizhi.辰}), frozenset({Dizhi.卯, Dizhi.未})],
+    DizhiRelation.刑 : [frozenset({Dizhi.未, Dizhi.丑})], # LOOSE mode is used for XING relation.
+    DizhiRelation.冲 : [frozenset({Dizhi.未, Dizhi.丑})],
+    DizhiRelation.破 : [frozenset({Dizhi.丑, Dizhi.辰})],
+    DizhiRelation.害 : [frozenset({Dizhi.未, Dizhi.子}), frozenset({Dizhi.辰, Dizhi.卯})],
+  }, dizhi_utils.discover_mutual(bazi.four_dizhis, tuple(gz.dizhi for gz in ganzhis)))
 
-      self.assertTrue(self.__check_tiangan({
-        TianganRelation.合 : [frozenset({Tiangan.戊, Tiangan.癸})],
-      }, tiangan_utils.discover(tuple(gz.tiangan for gz in ganzhis))))
+  # 2051 dayun and liunian - transits only
+  ganzhis = db.ganzhis(TransitMoment(2051), TransitOptions.DAYUN_LIUNIAN)
 
-      self.assertTrue(self.__check_dizhi({
-        DizhiRelation.六合 : [frozenset({Dizhi.辰, Dizhi.酉})],
-      }, dizhi_utils.discover(tuple(gz.dizhi for gz in ganzhis))))
+  assert _check_dizhi({
+    DizhiRelation.破 : [frozenset({Dizhi.戌, Dizhi.未})],
+    DizhiRelation.刑 : [frozenset({Dizhi.未, Dizhi.戌})],
+  }, dizhi_utils.discover(tuple(gz.dizhi for gz in ganzhis)))
 
-    with self.subTest('2024 dayun and liunian - between transits and at-birth'):
-      ganzhis = db.ganzhis(TransitMoment(2024), TransitOptions.DAYUN_LIUNIAN)
+  # 2051 dayun and liunian - between transits and at-birth
+  ganzhis = db.ganzhis(TransitMoment(2051), TransitOptions.DAYUN_LIUNIAN)
 
-      self.assertTrue(self.__check_tiangan({
-        TianganRelation.克 : [frozenset({Tiangan.丁, Tiangan.辛}), frozenset({Tiangan.辛, Tiangan.乙})],
-      }, tiangan_utils.discover_mutual(bazi.four_tiangans, tuple(gz.tiangan for gz in ganzhis))))
+  assert _check_tiangan({
+    TianganRelation.克 : [frozenset({Tiangan.丁, Tiangan.辛}), frozenset({Tiangan.辛, Tiangan.乙})],
+  }, tiangan_utils.discover_mutual(bazi.four_tiangans, tuple(gz.tiangan for gz in ganzhis)))
 
-      self.assertTrue(self.__check_dizhi({
-        DizhiRelation.六合 : [frozenset({Dizhi.午, Dizhi.未})],
-        DizhiRelation.半合 : [frozenset({Dizhi.子, Dizhi.辰}), frozenset({Dizhi.卯, Dizhi.未})],
-        DizhiRelation.刑 : [frozenset({Dizhi.未, Dizhi.丑})], # LOOSE mode is used for XING relation.
-        DizhiRelation.冲 : [frozenset({Dizhi.未, Dizhi.丑})],
-        DizhiRelation.破 : [frozenset({Dizhi.丑, Dizhi.辰})],
-        DizhiRelation.害 : [frozenset({Dizhi.未, Dizhi.子}), frozenset({Dizhi.辰, Dizhi.卯})],
-      }, dizhi_utils.discover_mutual(bazi.four_dizhis, tuple(gz.dizhi for gz in ganzhis))))
+  assert _check_dizhi({
+    DizhiRelation.六合 : [frozenset({Dizhi.卯, Dizhi.戌}), frozenset({Dizhi.午, Dizhi.未})],
+    DizhiRelation.半合 : [frozenset({Dizhi.卯, Dizhi.未}), frozenset({Dizhi.午, Dizhi.戌})],
+    DizhiRelation.刑 : [frozenset({Dizhi.丑, Dizhi.未, Dizhi.戌}),
+                        frozenset({Dizhi.未, Dizhi.丑}),
+                        frozenset({Dizhi.戌, Dizhi.丑}),], # LOOSE mode is used for XING relation.
+    DizhiRelation.冲 : [frozenset({Dizhi.丑, Dizhi.未})],
+    DizhiRelation.害 : [frozenset({Dizhi.未, Dizhi.子})],
+  }, dizhi_utils.discover_mutual(bazi.four_dizhis, tuple(gz.dizhi for gz in ganzhis)))
 
-    with self.subTest('2051 dayun and liunian - transits only'):
-      ganzhis = db.ganzhis(TransitMoment(2051), TransitOptions.DAYUN_LIUNIAN)
+@pytest.mark.integration
+def test_case2() -> None:
+  '''From 测测 and 问真八字'''
+  bazi: Bazi = Bazi(
+    birth_time=datetime(2024, 5, 19, 18, 59),
+    gender=BaziGender.FEMALE,
+    precision=BaziPrecision.DAY,
+  )
+  chart: BaziChart = BaziChart(bazi)
+  db: TransitDatabase = TransitDatabase(chart)
 
-      self.assertTrue(self.__check_dizhi({
-        DizhiRelation.破 : [frozenset({Dizhi.戌, Dizhi.未})],
-        DizhiRelation.刑 : [frozenset({Dizhi.未, Dizhi.戌})],
-      }, dizhi_utils.discover(tuple(gz.dizhi for gz in ganzhis))))
+  # pillar correctness
+  assert bazi.year_pillar == Ganzhi.from_str('甲辰')
+  assert bazi.month_pillar == Ganzhi.from_str('己巳')
+  assert bazi.day_pillar == Ganzhi.from_str('癸未')
+  assert bazi.hour_pillar == Ganzhi.from_str('辛酉')
+  assert chart.xiaoyun[0].ganzhi == Ganzhi.from_str('庚申')
+  assert next(chart.dayun).ganzhi == Ganzhi.from_str('戊辰'), 'first dayun Ganzhi'
+  assert next(chart.dayun).ganzhi_year == 2029, 'first dayun year'
 
-    with self.subTest('2051 dayun and liunian - between transits and at-birth'):
-      ganzhis = db.ganzhis(TransitMoment(2051), TransitOptions.DAYUN_LIUNIAN)
+  # at birth
+  assert _check_tiangan({
+    TianganRelation.合 : [frozenset({Tiangan.甲, Tiangan.己})],
+    TianganRelation.克 : [frozenset({Tiangan.己, Tiangan.癸})],
+  }, tiangan_utils.discover(bazi.four_tiangans))
 
-      self.assertTrue(self.__check_tiangan({
-        TianganRelation.克 : [frozenset({Tiangan.丁, Tiangan.辛}), frozenset({Tiangan.辛, Tiangan.乙})],
-      }, tiangan_utils.discover_mutual(bazi.four_tiangans, tuple(gz.tiangan for gz in ganzhis))))
+  assert _check_dizhi({
+    DizhiRelation.六合 : [frozenset({Dizhi.辰, Dizhi.酉})],
+    DizhiRelation.半合 : [frozenset({Dizhi.巳, Dizhi.酉})],
+  }, dizhi_utils.discover(bazi.four_dizhis))
 
-      self.assertTrue(self.__check_dizhi({
-        DizhiRelation.六合 : [frozenset({Dizhi.卯, Dizhi.戌}), frozenset({Dizhi.午, Dizhi.未})],
-        DizhiRelation.半合 : [frozenset({Dizhi.卯, Dizhi.未}), frozenset({Dizhi.午, Dizhi.戌})],
-        DizhiRelation.刑 : [frozenset({Dizhi.丑, Dizhi.未, Dizhi.戌}),
-                            frozenset({Dizhi.未, Dizhi.丑}),
-                            frozenset({Dizhi.戌, Dizhi.丑}),], # LOOSE mode is used for XING relation.
-        DizhiRelation.冲 : [frozenset({Dizhi.丑, Dizhi.未})],
-        DizhiRelation.害 : [frozenset({Dizhi.未, Dizhi.子})],
-      }, dizhi_utils.discover_mutual(bazi.four_dizhis, tuple(gz.dizhi for gz in ganzhis))))
+  # 2024 xiaoyun and liunian - between transits and at-birth
+  # 测测's Xiaoyun result is kinda buggy. So use 问真八字's Xiaoyun result here.
+  ganzhis = db.ganzhis(TransitMoment(2024), TransitOptions.XIAOYUN_LIUNIAN)
 
-  def test_case2(self) -> None:
-    '''From 测测 and 问真八字'''
-    bazi: Bazi = Bazi(
-      birth_time=datetime(2024, 5, 19, 18, 59),
-      gender=BaziGender.FEMALE,
-      precision=BaziPrecision.DAY,
-    )
-    chart: BaziChart = BaziChart(bazi)
-    db: TransitDatabase = TransitDatabase(chart)
+  assert _check_tiangan({
+    TianganRelation.合 : [frozenset({Tiangan.甲, Tiangan.己})],
+    TianganRelation.克 : [frozenset({Tiangan.庚, Tiangan.甲})],
+  }, tiangan_utils.discover_mutual(bazi.four_tiangans, tuple(gz.tiangan for gz in ganzhis)))
 
-    with self.subTest('pillar correctness'):
-      self.assertEqual(bazi.year_pillar, Ganzhi.from_str('甲辰'))
-      self.assertEqual(bazi.month_pillar, Ganzhi.from_str('己巳'))
-      self.assertEqual(bazi.day_pillar, Ganzhi.from_str('癸未'))
-      self.assertEqual(bazi.hour_pillar, Ganzhi.from_str('辛酉'))
-      self.assertEqual(chart.xiaoyun[0].ganzhi, Ganzhi.from_str('庚申'))
-      self.assertEqual(next(chart.dayun).ganzhi, Ganzhi.from_str('戊辰'), 'first dayun Ganzhi')
-      self.assertEqual(next(chart.dayun).ganzhi_year, 2029, 'first dayun year')
+  assert _check_dizhi({
+    DizhiRelation.六合 : [frozenset({Dizhi.辰, Dizhi.酉}), frozenset({Dizhi.巳, Dizhi.申})],
+    DizhiRelation.刑 : [frozenset({Dizhi.辰}), frozenset({Dizhi.巳, Dizhi.申})], # LOOSE mode is used.
+    DizhiRelation.破 : [frozenset({Dizhi.巳, Dizhi.申})],
+  }, dizhi_utils.discover_mutual(bazi.four_dizhis, tuple(gz.dizhi for gz in ganzhis)))
 
-    with self.subTest('at birth'):
-      self.assertTrue(self.__check_tiangan({
-        TianganRelation.合 : [frozenset({Tiangan.甲, Tiangan.己})],
-        TianganRelation.克 : [frozenset({Tiangan.己, Tiangan.癸})],
-      }, tiangan_utils.discover(bazi.four_tiangans)))
+  # 2052 dayun and liunian - transits only
+  ganzhis = db.ganzhis(TransitMoment(2052), TransitOptions.DAYUN_LIUNIAN)
 
-      self.assertTrue(self.__check_dizhi({
-        DizhiRelation.六合 : [frozenset({Dizhi.辰, Dizhi.酉})],
-        DizhiRelation.半合 : [frozenset({Dizhi.巳, Dizhi.酉})],
-      }, dizhi_utils.discover(bazi.four_dizhis)))
+  assert _check_tiangan({
+    TianganRelation.冲 : [frozenset({Tiangan.丙, Tiangan.壬})],
+  }, tiangan_utils.discover(tuple(gz.tiangan for gz in ganzhis)))
 
-    with self.subTest('2024 xiaoyun and liunian - between transits and at-birth'): 
-      # 测测's Xiaoyun result is kinda buggy. So use 问真八字's Xiaoyun result here.
-      ganzhis = db.ganzhis(TransitMoment(2024), TransitOptions.XIAOYUN_LIUNIAN)
+  assert _check_dizhi({
+    DizhiRelation.冲 : [frozenset({Dizhi.寅, Dizhi.申})],
+    DizhiRelation.刑 : [frozenset({Dizhi.寅, Dizhi.申})],
+  }, dizhi_utils.discover(tuple(gz.dizhi for gz in ganzhis)))
 
-      self.assertTrue(self.__check_tiangan({
-        TianganRelation.合 : [frozenset({Tiangan.甲, Tiangan.己})],
-        TianganRelation.克 : [frozenset({Tiangan.庚, Tiangan.甲})],
-      }, tiangan_utils.discover_mutual(bazi.four_tiangans, tuple(gz.tiangan for gz in ganzhis))))
+  # 2052 dayun and liunian - between transits and at-birth
+  ganzhis = db.ganzhis(TransitMoment(2052), TransitOptions.DAYUN_LIUNIAN)
 
-      self.assertTrue(self.__check_dizhi({
-        DizhiRelation.六合 : [frozenset({Dizhi.辰, Dizhi.酉}), frozenset({Dizhi.巳, Dizhi.申})],
-        DizhiRelation.刑 : [frozenset({Dizhi.辰}), frozenset({Dizhi.巳, Dizhi.申})], # LOOSE mode is used.
-        DizhiRelation.破 : [frozenset({Dizhi.巳, Dizhi.申})],
-      }, dizhi_utils.discover_mutual(bazi.four_dizhis, tuple(gz.dizhi for gz in ganzhis))))
+  assert _check_tiangan({
+    TianganRelation.合 : [frozenset({Tiangan.丙, Tiangan.辛})],
+  }, tiangan_utils.discover_mutual(bazi.four_tiangans, tuple(gz.tiangan for gz in ganzhis)))
 
-    with self.subTest('2052 dayun and liunian - transits only'):
-      ganzhis = db.ganzhis(TransitMoment(2052), TransitOptions.DAYUN_LIUNIAN)
+  assert _check_dizhi({
+    DizhiRelation.六合 : [frozenset({Dizhi.巳, Dizhi.申})],
+    DizhiRelation.破 : [frozenset({Dizhi.巳, Dizhi.申})],
+    DizhiRelation.刑 : [frozenset({Dizhi.寅, Dizhi.巳, Dizhi.申}),
+                       frozenset({Dizhi.寅, Dizhi.巳}),
+                       frozenset({Dizhi.巳, Dizhi.申}),],
+  }, dizhi_utils.discover_mutual(bazi.four_dizhis, tuple(gz.dizhi for gz in ganzhis)))
 
-      self.assertTrue(self.__check_tiangan({
-        TianganRelation.冲 : [frozenset({Tiangan.丙, Tiangan.壬})],
-      }, tiangan_utils.discover(tuple(gz.tiangan for gz in ganzhis))))
+  # 2062 dayun and liunian - transits only
+  ganzhis = db.ganzhis(TransitMoment(2062), TransitOptions.DAYUN_LIUNIAN)
 
-      self.assertTrue(self.__check_dizhi({
-        DizhiRelation.冲 : [frozenset({Dizhi.寅, Dizhi.申})],
-        DizhiRelation.刑 : [frozenset({Dizhi.寅, Dizhi.申})],
-      }, dizhi_utils.discover(tuple(gz.dizhi for gz in ganzhis))))
+  assert _check_dizhi({
+    DizhiRelation.害 : [frozenset({Dizhi.丑, Dizhi.午})],
+  }, dizhi_utils.discover(tuple(gz.dizhi for gz in ganzhis)))
 
-    with self.subTest('2052 dayun and liunian - between transits and at-birth'):
-      ganzhis = db.ganzhis(TransitMoment(2052), TransitOptions.DAYUN_LIUNIAN)
+  # 2062 dayun and liunian - between transits and at-birth
+  ganzhis = db.ganzhis(TransitMoment(2062), TransitOptions.DAYUN_LIUNIAN)
 
-      self.assertTrue(self.__check_tiangan({
-        TianganRelation.合 : [frozenset({Tiangan.丙, Tiangan.辛})],
-      }, tiangan_utils.discover_mutual(bazi.four_tiangans, tuple(gz.tiangan for gz in ganzhis))))
+  assert _check_tiangan({
+    TianganRelation.冲 : [frozenset({Tiangan.乙, Tiangan.辛})],
+    TianganRelation.克 : [frozenset({Tiangan.乙, Tiangan.己})],
+  }, tiangan_utils.discover_mutual(bazi.four_tiangans, tuple(gz.tiangan for gz in ganzhis)))
 
-      self.assertTrue(self.__check_dizhi({
-        DizhiRelation.六合 : [frozenset({Dizhi.巳, Dizhi.申})],
-        DizhiRelation.破 : [frozenset({Dizhi.巳, Dizhi.申})],
-        DizhiRelation.刑 : [frozenset({Dizhi.寅, Dizhi.巳, Dizhi.申}),
-                           frozenset({Dizhi.寅, Dizhi.巳}),
-                           frozenset({Dizhi.巳, Dizhi.申}),],
-      }, dizhi_utils.discover_mutual(bazi.four_dizhis, tuple(gz.dizhi for gz in ganzhis))))
-
-    with self.subTest('2062 dayun and liunian - transits only'):
-      ganzhis = db.ganzhis(TransitMoment(2062), TransitOptions.DAYUN_LIUNIAN)
-
-      self.assertTrue(self.__check_dizhi({
-        DizhiRelation.害 : [frozenset({Dizhi.丑, Dizhi.午})],
-      }, dizhi_utils.discover(tuple(gz.dizhi for gz in ganzhis))))
-
-    with self.subTest('2062 dayun and liunian - between transits and at-birth'):
-      ganzhis = db.ganzhis(TransitMoment(2062), TransitOptions.DAYUN_LIUNIAN)
-
-      self.assertTrue(self.__check_tiangan({
-        TianganRelation.冲 : [frozenset({Tiangan.乙, Tiangan.辛})],
-        TianganRelation.克 : [frozenset({Tiangan.乙, Tiangan.己})],
-      }, tiangan_utils.discover_mutual(bazi.four_tiangans, tuple(gz.tiangan for gz in ganzhis))))
-
-      self.assertTrue(self.__check_dizhi({
-        DizhiRelation.六合 : [frozenset({Dizhi.午, Dizhi.未})],
-        DizhiRelation.三合 : [frozenset({Dizhi.巳, Dizhi.酉, Dizhi.丑})],
-        DizhiRelation.三会 : [frozenset({Dizhi.巳, Dizhi.午, Dizhi.未})],
-        DizhiRelation.刑 : [frozenset({Dizhi.丑, Dizhi.未})], # LOOSE mode is used here...
-        DizhiRelation.冲 : [frozenset({Dizhi.丑, Dizhi.未})],
-        DizhiRelation.破 : [frozenset({Dizhi.丑, Dizhi.辰})],
-      }, dizhi_utils.discover_mutual(bazi.four_dizhis, tuple(gz.dizhi for gz in ganzhis))))
+  assert _check_dizhi({
+    DizhiRelation.六合 : [frozenset({Dizhi.午, Dizhi.未})],
+    DizhiRelation.三合 : [frozenset({Dizhi.巳, Dizhi.酉, Dizhi.丑})],
+    DizhiRelation.三会 : [frozenset({Dizhi.巳, Dizhi.午, Dizhi.未})],
+    DizhiRelation.刑 : [frozenset({Dizhi.丑, Dizhi.未})], # LOOSE mode is used here...
+    DizhiRelation.冲 : [frozenset({Dizhi.丑, Dizhi.未})],
+    DizhiRelation.破 : [frozenset({Dizhi.丑, Dizhi.辰})],
+  }, dizhi_utils.discover_mutual(bazi.four_dizhis, tuple(gz.dizhi for gz in ganzhis)))

--- a/tests/integration/test_relationship_analysis.py
+++ b/tests/integration/test_relationship_analysis.py
@@ -20,8 +20,8 @@ from src.rules import DizhiRules
 pytestmark = pytest.mark.integration
 
 
-DiscoveryType = tiangan_utils.TianganRelationDiscovery | dizhi_utils.DizhiRelationDiscovery
 '''Operand type of `_equal`: either relation-discovery flavor.'''
+DiscoveryType = tiangan_utils.TianganRelationDiscovery | dizhi_utils.DizhiRelationDiscovery
 def _equal(d1: DiscoveryType, d2: DiscoveryType) -> bool:
   assert type(d1) is type(d2)
   if set(d1.keys()) != set(d2.keys()):

--- a/tests/integration/test_relationship_analysis.py
+++ b/tests/integration/test_relationship_analysis.py
@@ -17,6 +17,9 @@ from src.analyzer.relationship import RelationshipAnalyzer, ShenshaAnalysis, Tra
 from src.rules import DizhiRules
 
 
+pytestmark = pytest.mark.integration
+
+
 DiscoveryType = tiangan_utils.TianganRelationDiscovery | dizhi_utils.DizhiRelationDiscovery
 def _equal(d1: DiscoveryType, d2: DiscoveryType) -> bool:
   assert type(d1) is type(d2)
@@ -27,6 +30,7 @@ def _equal(d1: DiscoveryType, d2: DiscoveryType) -> bool:
       return False
   return True
 
+
 def _check_tiangan(expected: dict[TianganRelation, list[tiangan_utils.TianganCombo]], actual: tiangan_utils.TianganRelationDiscovery) -> bool:
   for rel, expected_combos in expected.items():
     if rel not in actual:
@@ -35,6 +39,7 @@ def _check_tiangan(expected: dict[TianganRelation, list[tiangan_utils.TianganCom
       if combo not in actual[rel]:
         return False
   return True
+
 
 def _check_dizhi(expected: dict[DizhiRelation, list[dizhi_utils.DizhiCombo]], actual: dizhi_utils.DizhiRelationDiscovery) -> bool:
   for rel, expected_combos in expected.items():
@@ -45,7 +50,7 @@ def _check_dizhi(expected: dict[DizhiRelation, list[dizhi_utils.DizhiCombo]], ac
         return False
   return True
 
-@pytest.mark.integration
+
 def test_case1() -> None:
   '''From 问真八字 https://pcbz.iwzwh.com/#/paipan/index'''
   bazi: Bazi = Bazi(
@@ -230,7 +235,7 @@ def test_case1() -> None:
   assert not transits.star(2031, TransitOptions.DAYUN_LIUNIAN).tiangan
   assert not transits.star(2031, TransitOptions.DAYUN_LIUNIAN).dizhi
 
-@pytest.mark.integration
+
 def test_case2() -> None:
   '''From 问真八字 https://pcbz.iwzwh.com/#/paipan/index'''
   bazi: Bazi = Bazi(
@@ -471,7 +476,6 @@ def test_case2() -> None:
       assert star_result.dizhi == any(is_star(dz) for dz in transits_dz)
 
 
-@pytest.mark.integration
 @pytest.mark.parametrize('bazi', [Bazi.random() for _ in range(5)])
 def test_random_cases(bazi: Bazi) -> None:
   chart = BaziChart(bazi)
@@ -501,7 +505,7 @@ def test_random_cases(bazi: Bazi) -> None:
 
       def __taohua(dz: Dizhi) -> bool:
         return shensha_utils.taohua(y_dz, dz) or shensha_utils.taohua(d_dz, dz)
-      
+
       def __yima(dz: Dizhi) -> bool:
         return shensha_utils.yima(y_dz, dz) or shensha_utils.yima(d_dz, dz)
 
@@ -554,7 +558,7 @@ def test_random_cases(bazi: Bazi) -> None:
             count = sum(1 if dz in [y_dz, m_dz, h_dz] or dz in transits_dz_set else 0 for dz in other_dz)
             if count == 2:
               assert frozenset(dz_tuple) in dz_relations[DizhiRelation.刑]
-        
+
       for dz_fs in DizhiRules.DIZHI_SANHE: # 三合 cases
         if house in dz_fs:
           other_dz = dz_fs - {house}

--- a/tests/integration/test_relationship_analysis.py
+++ b/tests/integration/test_relationship_analysis.py
@@ -21,6 +21,7 @@ pytestmark = pytest.mark.integration
 
 
 DiscoveryType = tiangan_utils.TianganRelationDiscovery | dizhi_utils.DizhiRelationDiscovery
+'''Operand type of `_equal`: either relation-discovery flavor.'''
 def _equal(d1: DiscoveryType, d2: DiscoveryType) -> bool:
   assert type(d1) is type(d2)
   if set(d1.keys()) != set(d2.keys()):

--- a/tests/integration/test_relationship_analysis.py
+++ b/tests/integration/test_relationship_analysis.py
@@ -2,7 +2,6 @@
 # test_relationship_analysis.py
 
 import pytest
-import unittest
 
 import random
 
@@ -28,453 +27,448 @@ def _equal(d1: DiscoveryType, d2: DiscoveryType) -> bool:
       return False
   return True
 
+def _check_tiangan(expected: dict[TianganRelation, list[tiangan_utils.TianganCombo]], actual: tiangan_utils.TianganRelationDiscovery) -> bool:
+  for rel, expected_combos in expected.items():
+    if rel not in actual:
+      return False
+    for combo in expected_combos:
+      if combo not in actual[rel]:
+        return False
+  return True
+
+def _check_dizhi(expected: dict[DizhiRelation, list[dizhi_utils.DizhiCombo]], actual: dizhi_utils.DizhiRelationDiscovery) -> bool:
+  for rel, expected_combos in expected.items():
+    if rel not in actual:
+      return False
+    for combo in expected_combos:
+      if combo not in actual[rel]:
+        return False
+  return True
+
 @pytest.mark.integration
-class TestRelationshipAnalysis(unittest.TestCase):
-  @staticmethod
-  def __check_tiangan(expected: dict[TianganRelation, list[tiangan_utils.TianganCombo]], actual: tiangan_utils.TianganRelationDiscovery) -> bool:
-    for rel, expected_combos in expected.items():
-      if rel not in actual:
-        return False
-      for combo in expected_combos:
-        if combo not in actual[rel]:
-          return False
-    return True
-
-  @staticmethod
-  def __check_dizhi(expected: dict[DizhiRelation, list[dizhi_utils.DizhiCombo]], actual: dizhi_utils.DizhiRelationDiscovery) -> bool:
-    for rel, expected_combos in expected.items():
-      if rel not in actual:
-        return False
-      for combo in expected_combos:
-        if combo not in actual[rel]:
-          return False
-    return True
-
-  def test_case1(self) -> None:
-    '''From 问真八字 https://pcbz.iwzwh.com/#/paipan/index'''
-    bazi: Bazi = Bazi(
-      birth_time=datetime(1984, 4, 1, 11, 8),
-      gender=BaziGender.MALE,
-      precision=BaziPrecision.DAY,
-    )
-    chart: BaziChart = BaziChart(bazi)
-    db: TransitDatabase = TransitDatabase(chart)
-    analyzer: RelationshipAnalyzer = RelationshipAnalyzer(chart)
-    transits: TransitAnalysis = analyzer.transits
-
-    with self.subTest('basic info correctness'):
-      self.assertEqual(bazi.year_pillar, Ganzhi.from_str('甲子'))
-      self.assertEqual(bazi.month_pillar, Ganzhi.from_str('丁卯'))
-      self.assertEqual(bazi.day_pillar, Ganzhi.from_str('乙丑'))
-      self.assertEqual(bazi.hour_pillar, Ganzhi.from_str('壬午'))
-
-      self.assertEqual(chart.xiaoyun[0].ganzhi, Ganzhi.from_str('癸未'))
-      self.assertEqual(next(chart.dayun).ganzhi, Ganzhi.from_str('戊辰'), 'first dayun Ganzhi')
-      self.assertEqual(next(chart.dayun).ganzhi_year, 1985, 'first dayun year')
-
-      self.assertEqual(chart.relationship_stars.tiangan, Tiangan.戊)
-      self.assertSetEqual(set(chart.relationship_stars.dizhi), {Dizhi.辰, Dizhi.戌})
-
-    with self.subTest('at birth'):
-      at_birth: AtBirthAnalysis = analyzer.at_birth
-
-      self.assertSetEqual(at_birth.shensha['taohua'],   {Dizhi.午})
-      self.assertSetEqual(at_birth.shensha['hongluan'], {Dizhi.卯})
-      # 问真八字以乙日主见午为红艳，但 `ShenshaRules.HONGYAN` 中以乙日主见申为红艳，所以这里为空。
-      self.assertSetEqual(at_birth.shensha['hongyan'],  set()) 
-      self.assertSetEqual(at_birth.shensha['tianxi'],   set())
-      self.assertSetEqual(at_birth.shensha['yima'],     set())
-
-      # 感情分析主要关心日主被合的情况，但原局日主没有被合。
-      # 虽然我们不关心相生关系，但在这里还是检查一下。
-      self.assertTrue(self.__check_tiangan({
-        TianganRelation.生 : [frozenset({Tiangan.乙, Tiangan.丁}),
-                             frozenset({Tiangan.乙, Tiangan.壬})],
-      }, at_birth.day_master_relations))
-
-      self.assertTrue(self.__check_dizhi({
-        DizhiRelation.六合 : [frozenset({Dizhi.子, Dizhi.丑})],
-        DizhiRelation.害 : [frozenset({Dizhi.丑, Dizhi.午})],
-        DizhiRelation.生 : [frozenset({Dizhi.午, Dizhi.丑})],
-        DizhiRelation.克 : [frozenset({Dizhi.丑, Dizhi.子}),
-                           frozenset({Dizhi.卯, Dizhi.丑})],
-      }, at_birth.house_relations))
-
-      # 原局无正财星，所以配偶星的关系分析为空。
-      self.assertEqual(len(at_birth.star_relations.tiangan), 0)
-      self.assertEqual(len(at_birth.star_relations.dizhi), 0)
-
-    with self.subTest('1990'):
-      self.assertSetEqual(set(db.ganzhis(TransitMoment(1990), TransitOptions.DAYUN_LIUNIAN)),
-                          {Ganzhi.from_str('戊辰'), Ganzhi.from_str('庚午')})
-
-      shensha = transits.shensha(1990, TransitOptions.DAYUN_LIUNIAN)
-      self.assertSetEqual(shensha['taohua'],   {Dizhi.午})
-      self.assertSetEqual(shensha['hongluan'], set())
-      self.assertSetEqual(shensha['hongyan'],  set())
-      self.assertSetEqual(shensha['tianxi'],   set())
-      self.assertSetEqual(shensha['yima'],     set())
-
-      self.assertTrue(self.__check_tiangan({
-        TianganRelation.合 : [frozenset({Tiangan.乙, Tiangan.庚})],
-        TianganRelation.克 : [frozenset({Tiangan.庚, Tiangan.乙}),
-                             frozenset({Tiangan.乙, Tiangan.戊})],
-      }, transits.day_master_relations(1990, TransitOptions.DAYUN_LIUNIAN)))
-
-      self.assertTrue(self.__check_dizhi({
-        DizhiRelation.害 : [frozenset({Dizhi.丑, Dizhi.午})],
-        DizhiRelation.破 : [frozenset({Dizhi.辰, Dizhi.丑})],
-        DizhiRelation.生 : [frozenset({Dizhi.午, Dizhi.丑})],
-      }, transits.house_relations(1990, TransitOptions.DAYUN_LIUNIAN)))
-
-      star_relations_all = transits.star_relations(1990, TransitOptions.DAYUN_LIUNIAN) # level is `ALL` by default.
-      
-      self.assertTrue(self.__check_tiangan({
-        TianganRelation.生 : [frozenset({Tiangan.戊, Tiangan.庚}),
-                             frozenset({Tiangan.戊, Tiangan.丁})],
-        TianganRelation.克 : [frozenset({Tiangan.甲, Tiangan.戊}),
-                             frozenset({Tiangan.乙, Tiangan.戊}),
-                             frozenset({Tiangan.壬, Tiangan.戊})],
-      }, star_relations_all.tiangan))
-
-      self.assertTrue(self.__check_dizhi({
-        DizhiRelation.生 : [frozenset({Dizhi.午, Dizhi.辰})],
-        DizhiRelation.克 : [frozenset({Dizhi.辰, Dizhi.子}),
-                           frozenset({Dizhi.卯, Dizhi.辰})],
-        DizhiRelation.破 : [frozenset({Dizhi.辰, Dizhi.丑})],
-        DizhiRelation.害 : [frozenset({Dizhi.辰, Dizhi.卯})],
-        DizhiRelation.半合 : [frozenset({Dizhi.子, Dizhi.辰})],
-      }, star_relations_all.dizhi))
-
-      self.assertFalse(transits.zhengyin(1990, TransitOptions.DAYUN_LIUNIAN).tiangan)
-      self.assertFalse(transits.zhengyin(1990, TransitOptions.DAYUN_LIUNIAN).dizhi)
-
-      self.assertTrue(transits.star(1990, TransitOptions.DAYUN_LIUNIAN).tiangan)
-      self.assertTrue(transits.star(1990, TransitOptions.DAYUN_LIUNIAN).dizhi)
-      self.assertTrue(transits.star(1990, TransitOptions.DAYUN).tiangan)
-      self.assertTrue(transits.star(1990, TransitOptions.DAYUN).dizhi)
-      self.assertFalse(transits.star(1990, TransitOptions.LIUNIAN).tiangan)
-      self.assertFalse(transits.star(1990, TransitOptions.LIUNIAN).dizhi)
-
-    with self.subTest('2018'):
-      self.assertSetEqual(set(db.ganzhis(TransitMoment(2018), TransitOptions.DAYUN_LIUNIAN)),
-                          {Ganzhi.from_str('辛未'), Ganzhi.from_str('戊戌')})
-      
-      shensha = transits.shensha(2018, TransitOptions.DAYUN_LIUNIAN)
-      self.assertSetEqual(shensha['taohua'],   set())
-      self.assertSetEqual(shensha['hongluan'], set())
-      self.assertSetEqual(shensha['hongyan'],  set())
-      self.assertSetEqual(shensha['tianxi'],   set())
-      self.assertSetEqual(shensha['yima'],     set())
-
-      self.assertTrue(self.__check_tiangan({
-        TianganRelation.克 : [frozenset({Tiangan.乙, Tiangan.辛}),
-                             frozenset({Tiangan.乙, Tiangan.戊})],
-      }, transits.day_master_relations(2018, TransitOptions.DAYUN_LIUNIAN)))
-
-      self.assertTrue(self.__check_dizhi({
-        DizhiRelation.刑 : [frozenset({Dizhi.丑, Dizhi.未, Dizhi.戌}),
-                           frozenset({Dizhi.丑, Dizhi.未})],
-        DizhiRelation.冲 : [frozenset({Dizhi.丑, Dizhi.未})],
-      }, transits.house_relations(2018, TransitOptions.DAYUN_LIUNIAN)))
-
-      star_relations_all = transits.star_relations(2018, TransitOptions.DAYUN_LIUNIAN) # level is `ALL` by default.
-      
-      self.assertTrue(self.__check_tiangan({
-        TianganRelation.克 : [frozenset({Tiangan.甲, Tiangan.戊}),
-                             frozenset({Tiangan.壬, Tiangan.戊})],
-      }, star_relations_all.tiangan))
-
-      self.assertTrue(self.__check_dizhi({
-        DizhiRelation.六合 : [frozenset({Dizhi.戌, Dizhi.卯})],
-        DizhiRelation.半合 : [frozenset({Dizhi.戌, Dizhi.午})],
-        DizhiRelation.刑 : [frozenset({Dizhi.丑, Dizhi.未, Dizhi.戌})],
-        DizhiRelation.破 : [frozenset({Dizhi.戌, Dizhi.未})],
-        DizhiRelation.生 : [frozenset({Dizhi.戌, Dizhi.午})],
-        DizhiRelation.克 : [frozenset({Dizhi.戌, Dizhi.卯}),
-                           frozenset({Dizhi.戌, Dizhi.子})],
-      }, star_relations_all.dizhi))
-
-      self.assertFalse(transits.zhengyin(2018, TransitOptions.DAYUN_LIUNIAN).tiangan)
-      self.assertFalse(transits.zhengyin(2018, TransitOptions.DAYUN_LIUNIAN).dizhi)
-
-      self.assertTrue(transits.star(2018, TransitOptions.DAYUN_LIUNIAN).tiangan)
-      self.assertTrue(transits.star(2018, TransitOptions.DAYUN_LIUNIAN).dizhi)
-      self.assertTrue(transits.star(2018, TransitOptions.LIUNIAN).tiangan)
-      self.assertTrue(transits.star(2018, TransitOptions.LIUNIAN).dizhi)
-      self.assertFalse(transits.star(2018, TransitOptions.DAYUN).tiangan)
-      self.assertFalse(transits.star(2018, TransitOptions.DAYUN).dizhi)
-
-    with self.subTest('2031'):
-      self.assertSetEqual(set(db.ganzhis(TransitMoment(2031), TransitOptions.DAYUN_LIUNIAN)),
-                          {Ganzhi.from_str('辛亥'), Ganzhi.from_str('壬申')})
-
-      shensha = transits.shensha(2031, TransitOptions.DAYUN_LIUNIAN)
-      self.assertSetEqual(shensha['taohua'],   set())
-      self.assertSetEqual(shensha['hongluan'], set())
-      self.assertSetEqual(shensha['hongyan'],  {Dizhi.申})
-      self.assertSetEqual(shensha['tianxi'],   set())
-      self.assertSetEqual(shensha['yima'],     {Dizhi.亥})
-
-      self.assertTrue(self.__check_tiangan({
-        TianganRelation.克 : [frozenset({Tiangan.乙, Tiangan.辛})],
-        TianganRelation.生 : [frozenset({Tiangan.乙, Tiangan.壬})],
-      }, transits.day_master_relations(2031, TransitOptions.DAYUN_LIUNIAN)))
-
-      self.assertTrue(self.__check_dizhi({
-        DizhiRelation.生 : [frozenset({Dizhi.申, Dizhi.丑})],
-        DizhiRelation.克 : [frozenset({Dizhi.丑, Dizhi.亥})],
-        DizhiRelation.三会 : [frozenset({Dizhi.亥, Dizhi.子, Dizhi.丑})],
-      }, transits.house_relations(2031, TransitOptions.DAYUN_LIUNIAN)))
-
-      star_relations_all = transits.star_relations(2031, TransitOptions.DAYUN_LIUNIAN) # level is `ALL` by default.
-      self.assertEqual(0, len(star_relations_all.tiangan))
-      self.assertEqual(0, len(star_relations_all.dizhi))
-
-      self.assertTrue(transits.zhengyin(2031, TransitOptions.DAYUN_LIUNIAN).tiangan)
-      self.assertTrue(transits.zhengyin(2031, TransitOptions.DAYUN_LIUNIAN).dizhi)
-
-      self.assertFalse(transits.star(2031, TransitOptions.DAYUN_LIUNIAN).tiangan)
-      self.assertFalse(transits.star(2031, TransitOptions.DAYUN_LIUNIAN).dizhi)
-
-  def test_case2(self) -> None:
-    '''From 问真八字 https://pcbz.iwzwh.com/#/paipan/index'''
-    bazi: Bazi = Bazi(
-      birth_time=datetime(2020, 7, 2, 19, 8),
-      gender=BaziGender.FEMALE,
-      precision=BaziPrecision.DAY,
-    )
-    chart: BaziChart = BaziChart(bazi)
-    birth_gz_year: int = bazi.ganzhi_date.year
-    analyzer: RelationshipAnalyzer = RelationshipAnalyzer(chart)
-    transits: TransitAnalysis = analyzer.transits
-
-    with self.subTest('basic info correctness'):
-      self.assertEqual(bazi.year_pillar, Ganzhi.from_str('庚子'))
-      self.assertEqual(bazi.month_pillar, Ganzhi.from_str('壬午'))
-      self.assertEqual(bazi.day_pillar, Ganzhi.from_str('丙午'))
-      self.assertEqual(bazi.hour_pillar, Ganzhi.from_str('戊戌'))
-
-      self.assertEqual(chart.xiaoyun[0].ganzhi, Ganzhi.from_str('丁酉'))
-      self.assertEqual(next(chart.dayun).ganzhi, Ganzhi.from_str('辛巳'), 'first dayun Ganzhi')
-      self.assertEqual(next(chart.dayun).ganzhi_year, 2029, 'first dayun year')
-
-    with self.subTest('at birth'):
-      at_birth: AtBirthAnalysis = analyzer.at_birth
-
-      self.assertSetEqual(at_birth.shensha['taohua'],   set())
-      self.assertSetEqual(at_birth.shensha['hongluan'], set())
-      self.assertSetEqual(at_birth.shensha['hongyan'],  set()) 
-      self.assertSetEqual(at_birth.shensha['tianxi'],   set())
-      self.assertSetEqual(at_birth.shensha['yima'],     set())
-
-      # 感情分析主要关心日主被合的情况，但原局日主没有被合。
-      # 虽然我们不关心其他关系，但在这里还是检查一下。
-      self.assertTrue(self.__check_tiangan({
-        TianganRelation.生 : [frozenset({Tiangan.丙, Tiangan.戊})],
-        TianganRelation.克 : [frozenset({Tiangan.丙, Tiangan.壬}),
-                             frozenset({Tiangan.丙, Tiangan.庚})],
-      }, at_birth.day_master_relations))
-
-      self.assertTrue(self.__check_dizhi({
-        DizhiRelation.生 : [frozenset({Dizhi.午, Dizhi.戌})],
-        DizhiRelation.克 : [frozenset({Dizhi.午, Dizhi.子})],
-        DizhiRelation.半合 : [frozenset({Dizhi.午, Dizhi.戌})],
-        DizhiRelation.刑 : [frozenset({Dizhi.午})],
-        DizhiRelation.冲 : [frozenset({Dizhi.子, Dizhi.午})],
-      }, at_birth.house_relations))
-
-      self.assertEqual(len(at_birth.star_relations.tiangan), 0)
-
-      self.assertTrue(self.__check_dizhi({
-        DizhiRelation.克 : [frozenset({Dizhi.午, Dizhi.子}),
-                           frozenset({Dizhi.戌, Dizhi.子})],
-        DizhiRelation.冲 : [frozenset({Dizhi.子, Dizhi.午})],
-      }, at_birth.star_relations.dizhi))
-
-    with self.subTest('transits - shensha'):
-      shensha_expected_dz: ShenshaAnalysis = {
-        'taohua'   : frozenset([Dizhi.酉, Dizhi.卯]),
-        'hongyan'  : frozenset([Dizhi.寅]),
-        'hongluan' : frozenset([Dizhi.卯]),
-        'tianxi'   : frozenset([Dizhi.酉]),
-        'yima'     : frozenset([Dizhi.寅, Dizhi.申]),
-      }
-
-      db = TransitDatabase(chart)
-      for _ in range(50):
-        random_year = random.randint(birth_gz_year, birth_gz_year + 200)
-        random_option = TransitOptions.random()
-        if not transits.support(random_year, random_option):
-          continue
-
-        transits_gz = db.ganzhis(TransitMoment(random_year), random_option)
-        transits_dz = {gz.dizhi for gz in transits_gz}
-
-        self.assertDictEqual(transits.shensha(random_year, random_option), {
-          name : cast(frozenset[Dizhi], fs) & transits_dz
-          for name, fs in shensha_expected_dz.items()
-        })
-
-    with self.subTest('transits - day master relations'):
-      dm_relation_expected: dict[TianganRelation, set[Tiangan]] = {
-        TianganRelation.生 : {Tiangan.戊, Tiangan.己, Tiangan.甲, Tiangan.乙},
-        TianganRelation.克 : {Tiangan.壬, Tiangan.癸, Tiangan.庚, Tiangan.辛},
-        TianganRelation.合 : {Tiangan.辛},
-        TianganRelation.冲 : {Tiangan.壬},
-      }
-
-      db = TransitDatabase(chart)
-      for year in random.sample(range(birth_gz_year, birth_gz_year + 600), 100):
-        for option in TransitOptions:
-          if not transits.support(year, option):
-            continue
-
-          transits_gz = db.ganzhis(TransitMoment(year), option)
-          transits_tg = {gz.tiangan for gz in transits_gz}
-
-          for tg_rel, tg_combos in transits.day_master_relations(year, option).items():
-            expected_tg_combos = {
-              frozenset([tg, bazi.day_master])
-              for tg in (dm_relation_expected[tg_rel] & transits_tg)
-            }
-            self.assertSetEqual(set(tg_combos), expected_tg_combos)
-
-    with self.subTest('transits - house relations'):
-      house_relation_expected: dict[DizhiRelation, list[set[Dizhi]]] = {
-        DizhiRelation.三会 : [{Dizhi.巳, Dizhi.未}],
-        DizhiRelation.六合 : [{Dizhi.未}],
-        DizhiRelation.暗合 : [{Dizhi.亥}, {Dizhi.寅}],
-        DizhiRelation.通合 : [{Dizhi.亥}],
-        DizhiRelation.通禄合 : [{Dizhi.亥}, {Dizhi.寅}],
-        DizhiRelation.三合 : [{Dizhi.寅, Dizhi.戌}],
-        DizhiRelation.半合 : [{Dizhi.寅}, {Dizhi.戌}],
-        DizhiRelation.刑 : [{Dizhi.午}],
-        DizhiRelation.冲 : [{Dizhi.子}],
-        DizhiRelation.破 : [{Dizhi.卯}],
-        DizhiRelation.害 : [{Dizhi.丑}],
-        DizhiRelation.生 : [{Dizhi.戌}, {Dizhi.未}, {Dizhi.丑}, {Dizhi.辰}, {Dizhi.寅}, {Dizhi.卯}],
-        DizhiRelation.克 : [{Dizhi.子}, {Dizhi.亥}, {Dizhi.申}, {Dizhi.酉}],
-      }
-
-      db = TransitDatabase(chart)
-      for year in random.sample(range(birth_gz_year, birth_gz_year + 600), 100):
-        for option in TransitOptions:
-          if not transits.support(year, option):
-            continue
-
-          transits_gz = db.ganzhis(TransitMoment(year), option)
-          transits_dz = {gz.dizhi for gz in transits_gz}
-
-          house_dz = chart.house_of_relationship
-          other_dz = {bazi.year_pillar.dizhi, bazi.month_pillar.dizhi, bazi.hour_pillar.dizhi}
-          house_relations = transits.house_relations(year, option)
-          
-          for dz_rel, dz_expected_list in house_relation_expected.items():
-            expected_dz_combos: set[frozenset[Dizhi]] = set()
-            for dz_expected in dz_expected_list:
-              from_transits = dz_expected & transits_dz
-
-              if len(dz_expected) == 1: # Non 三合、三会、三刑 cases
-                if from_transits == dz_expected:
-                  expected_dz_combos.add(frozenset({house_dz} | dz_expected))
-              
-              else: # 三合、三会、三刑 cases
-                assert len(dz_expected) == 2
-                if from_transits == dz_expected:
-                  expected_dz_combos.add(frozenset({house_dz} | dz_expected))
-                elif len(from_transits) == 1:
-                  from_other_dz = dz_expected & other_dz
-                  if from_other_dz | from_transits == dz_expected:
-                    expected_dz_combos.add(frozenset({house_dz} | dz_expected))
-
-            if len(expected_dz_combos) == 0:
-              self.assertNotIn(dz_rel, house_relations)
-            else:
-              self.assertSetEqual(set(house_relations[dz_rel]), expected_dz_combos)
-
-    with self.subTest('transits - star relations'):
-      self.assertEqual(chart.relationship_stars.tiangan, Tiangan.癸)
-      self.assertSetEqual(set(chart.relationship_stars.dizhi), {Dizhi.子})
-
-      db = TransitDatabase(chart)
-      for year in random.sample(range(birth_gz_year, birth_gz_year + 600), 100):
-        for option in TransitOptions:
-          if not transits.support(year, option):
-            continue
-
-          transits_gz = db.ganzhis(TransitMoment(year), option)
-          transits_tg = {gz.tiangan for gz in transits_gz}
-          transits_dz = {gz.dizhi for gz in transits_gz}
-
-          # Test TRANSITS_ONLY
-          transits_only_star_relations = transits.star_relations(year, option, level=TransitAnalysis.Level.TRANSITS_ONLY)
-          expected_transits_only_tg_star_relations = tiangan_utils.discover(list(transits_tg)).filter(
-            lambda _, combo : Tiangan.癸 in combo
-          )
-          expected_transits_only_dz_star_relations = dizhi_utils.discover(list(transits_dz)).filter(
-            lambda _, combo : Dizhi.子 in combo
-          )
-
-          self.assertTrue(_equal(transits_only_star_relations.tiangan, expected_transits_only_tg_star_relations))
-          self.assertTrue(_equal(transits_only_star_relations.dizhi, expected_transits_only_dz_star_relations))
-
-          # Test MUTUAL
-          mutual_star_relations = transits.star_relations(year, option, level=TransitAnalysis.Level.MUTUAL)
-          expected_mutual_tg_star_relations = tiangan_utils.discover_mutual(chart.bazi.four_tiangans, list(transits_tg)).filter(
-            lambda _, combo : Tiangan.癸 in combo
-          )
-          expected_mutual_dz_star_relations = dizhi_utils.discover_mutual(chart.bazi.four_dizhis, list(transits_dz)).filter(
-            lambda _, combo : Dizhi.子 in combo
-          )
-
-          self.assertTrue(_equal(mutual_star_relations.tiangan, expected_mutual_tg_star_relations))
-          self.assertTrue(_equal(mutual_star_relations.dizhi, expected_mutual_dz_star_relations))
-
-          # Test ALL
-          all_star_relations = transits.star_relations(year, option, level=TransitAnalysis.Level.ALL)
-          expected_all_tg_star_relations = expected_transits_only_tg_star_relations.merge(expected_mutual_tg_star_relations)
-          expected_all_dz_star_relations = expected_transits_only_dz_star_relations.merge(expected_mutual_dz_star_relations)
-
-          self.assertTrue(_equal(all_star_relations.tiangan, expected_all_tg_star_relations))
-          self.assertTrue(_equal(all_star_relations.dizhi, expected_all_dz_star_relations))
-
-          self.assertTrue(_equal(all_star_relations.tiangan, tiangan_utils.discover(list(transits_tg) + list(bazi.four_tiangans)).filter(
-            lambda _, combo : Tiangan.癸 in combo and not combo.isdisjoint(transits_tg)
-          )))
-          self.assertTrue(_equal(all_star_relations.dizhi, dizhi_utils.discover(list(transits_dz) + list(bazi.four_dizhis)).filter(
-            lambda _, combo : Dizhi.子 in combo and not combo.isdisjoint(transits_dz)
-          )))
-
-    with self.subTest('transits - zhengyin and star'):
-      def is_zhengyin(tg_or_dz: Tiangan | Dizhi) -> bool:
-        return Shishen.正印 is bazi_utils.shishen(bazi.day_master, tg_or_dz)
-      
-      def is_star(tg_or_dz: Tiangan | Dizhi) -> bool:
-        return Shishen.正官 is bazi_utils.shishen(bazi.day_master, tg_or_dz)
-
-      self.assertTrue(is_star(Tiangan.癸))
-      self.assertTrue(is_star(Dizhi.子))
-      self.assertTrue(is_zhengyin(Tiangan.乙))
-      self.assertTrue(is_zhengyin(Dizhi.卯))      
-
-      db = TransitDatabase(chart)
-      for year in random.sample(range(birth_gz_year, birth_gz_year + 600), 100):
-        for option in TransitOptions:
-          if not transits.support(year, option):
-            continue
-
-          transits_gz = db.ganzhis(TransitMoment(year), option)
-          transits_tg = {gz.tiangan for gz in transits_gz}
-          transits_dz = {gz.dizhi for gz in transits_gz}
-
-          zhengyin_result = transits.zhengyin(year, option)
-          self.assertEqual(zhengyin_result.tiangan, any(is_zhengyin(tg) for tg in transits_tg))
-          self.assertEqual(zhengyin_result.dizhi, any(is_zhengyin(dz) for dz in transits_dz))
-
-          star_result = transits.star(year, option)
-          self.assertEqual(star_result.tiangan, any(is_star(tg) for tg in transits_tg))
-          self.assertEqual(star_result.dizhi, any(is_star(dz) for dz in transits_dz))
+def test_case1() -> None:
+  '''From 问真八字 https://pcbz.iwzwh.com/#/paipan/index'''
+  bazi: Bazi = Bazi(
+    birth_time=datetime(1984, 4, 1, 11, 8),
+    gender=BaziGender.MALE,
+    precision=BaziPrecision.DAY,
+  )
+  chart: BaziChart = BaziChart(bazi)
+  db: TransitDatabase = TransitDatabase(chart)
+  analyzer: RelationshipAnalyzer = RelationshipAnalyzer(chart)
+  transits: TransitAnalysis = analyzer.transits
+
+  # basic info correctness
+  assert bazi.year_pillar == Ganzhi.from_str('甲子')
+  assert bazi.month_pillar == Ganzhi.from_str('丁卯')
+  assert bazi.day_pillar == Ganzhi.from_str('乙丑')
+  assert bazi.hour_pillar == Ganzhi.from_str('壬午')
+
+  assert chart.xiaoyun[0].ganzhi == Ganzhi.from_str('癸未')
+  assert next(chart.dayun).ganzhi == Ganzhi.from_str('戊辰'), 'first dayun Ganzhi'
+  assert next(chart.dayun).ganzhi_year == 1985, 'first dayun year'
+
+  assert chart.relationship_stars.tiangan == Tiangan.戊
+  assert set(chart.relationship_stars.dizhi) == {Dizhi.辰, Dizhi.戌}
+
+  # at birth
+  at_birth: AtBirthAnalysis = analyzer.at_birth
+
+  assert at_birth.shensha['taohua']   == {Dizhi.午}
+  assert at_birth.shensha['hongluan'] == {Dizhi.卯}
+  # 问真八字以乙日主见午为红艳，但 `ShenshaRules.HONGYAN` 中以乙日主见申为红艳，所以这里为空。
+  assert at_birth.shensha['hongyan']  == set()
+  assert at_birth.shensha['tianxi']   == set()
+  assert at_birth.shensha['yima']     == set()
+
+  # 感情分析主要关心日主被合的情况，但原局日主没有被合。
+  # 虽然我们不关心相生关系，但在这里还是检查一下。
+  assert _check_tiangan({
+    TianganRelation.生 : [frozenset({Tiangan.乙, Tiangan.丁}),
+                         frozenset({Tiangan.乙, Tiangan.壬})],
+  }, at_birth.day_master_relations)
+
+  assert _check_dizhi({
+    DizhiRelation.六合 : [frozenset({Dizhi.子, Dizhi.丑})],
+    DizhiRelation.害 : [frozenset({Dizhi.丑, Dizhi.午})],
+    DizhiRelation.生 : [frozenset({Dizhi.午, Dizhi.丑})],
+    DizhiRelation.克 : [frozenset({Dizhi.丑, Dizhi.子}),
+                       frozenset({Dizhi.卯, Dizhi.丑})],
+  }, at_birth.house_relations)
+
+  # 原局无正财星，所以配偶星的关系分析为空。
+  assert len(at_birth.star_relations.tiangan) == 0
+  assert len(at_birth.star_relations.dizhi) == 0
+
+  # 1990
+  assert set(db.ganzhis(TransitMoment(1990), TransitOptions.DAYUN_LIUNIAN)) == {Ganzhi.from_str('戊辰'), Ganzhi.from_str('庚午')}
+
+  shensha = transits.shensha(1990, TransitOptions.DAYUN_LIUNIAN)
+  assert shensha['taohua']   == {Dizhi.午}
+  assert shensha['hongluan'] == set()
+  assert shensha['hongyan']  == set()
+  assert shensha['tianxi']   == set()
+  assert shensha['yima']     == set()
+
+  assert _check_tiangan({
+    TianganRelation.合 : [frozenset({Tiangan.乙, Tiangan.庚})],
+    TianganRelation.克 : [frozenset({Tiangan.庚, Tiangan.乙}),
+                         frozenset({Tiangan.乙, Tiangan.戊})],
+  }, transits.day_master_relations(1990, TransitOptions.DAYUN_LIUNIAN))
+
+  assert _check_dizhi({
+    DizhiRelation.害 : [frozenset({Dizhi.丑, Dizhi.午})],
+    DizhiRelation.破 : [frozenset({Dizhi.辰, Dizhi.丑})],
+    DizhiRelation.生 : [frozenset({Dizhi.午, Dizhi.丑})],
+  }, transits.house_relations(1990, TransitOptions.DAYUN_LIUNIAN))
+
+  star_relations_all = transits.star_relations(1990, TransitOptions.DAYUN_LIUNIAN) # level is `ALL` by default.
+
+  assert _check_tiangan({
+    TianganRelation.生 : [frozenset({Tiangan.戊, Tiangan.庚}),
+                         frozenset({Tiangan.戊, Tiangan.丁})],
+    TianganRelation.克 : [frozenset({Tiangan.甲, Tiangan.戊}),
+                         frozenset({Tiangan.乙, Tiangan.戊}),
+                         frozenset({Tiangan.壬, Tiangan.戊})],
+  }, star_relations_all.tiangan)
+
+  assert _check_dizhi({
+    DizhiRelation.生 : [frozenset({Dizhi.午, Dizhi.辰})],
+    DizhiRelation.克 : [frozenset({Dizhi.辰, Dizhi.子}),
+                       frozenset({Dizhi.卯, Dizhi.辰})],
+    DizhiRelation.破 : [frozenset({Dizhi.辰, Dizhi.丑})],
+    DizhiRelation.害 : [frozenset({Dizhi.辰, Dizhi.卯})],
+    DizhiRelation.半合 : [frozenset({Dizhi.子, Dizhi.辰})],
+  }, star_relations_all.dizhi)
+
+  assert not transits.zhengyin(1990, TransitOptions.DAYUN_LIUNIAN).tiangan
+  assert not transits.zhengyin(1990, TransitOptions.DAYUN_LIUNIAN).dizhi
+
+  assert transits.star(1990, TransitOptions.DAYUN_LIUNIAN).tiangan
+  assert transits.star(1990, TransitOptions.DAYUN_LIUNIAN).dizhi
+  assert transits.star(1990, TransitOptions.DAYUN).tiangan
+  assert transits.star(1990, TransitOptions.DAYUN).dizhi
+  assert not transits.star(1990, TransitOptions.LIUNIAN).tiangan
+  assert not transits.star(1990, TransitOptions.LIUNIAN).dizhi
+
+  # 2018
+  assert set(db.ganzhis(TransitMoment(2018), TransitOptions.DAYUN_LIUNIAN)) == {Ganzhi.from_str('辛未'), Ganzhi.from_str('戊戌')}
+
+  shensha = transits.shensha(2018, TransitOptions.DAYUN_LIUNIAN)
+  assert shensha['taohua']   == set()
+  assert shensha['hongluan'] == set()
+  assert shensha['hongyan']  == set()
+  assert shensha['tianxi']   == set()
+  assert shensha['yima']     == set()
+
+  assert _check_tiangan({
+    TianganRelation.克 : [frozenset({Tiangan.乙, Tiangan.辛}),
+                         frozenset({Tiangan.乙, Tiangan.戊})],
+  }, transits.day_master_relations(2018, TransitOptions.DAYUN_LIUNIAN))
+
+  assert _check_dizhi({
+    DizhiRelation.刑 : [frozenset({Dizhi.丑, Dizhi.未, Dizhi.戌}),
+                       frozenset({Dizhi.丑, Dizhi.未})],
+    DizhiRelation.冲 : [frozenset({Dizhi.丑, Dizhi.未})],
+  }, transits.house_relations(2018, TransitOptions.DAYUN_LIUNIAN))
+
+  star_relations_all = transits.star_relations(2018, TransitOptions.DAYUN_LIUNIAN) # level is `ALL` by default.
+
+  assert _check_tiangan({
+    TianganRelation.克 : [frozenset({Tiangan.甲, Tiangan.戊}),
+                         frozenset({Tiangan.壬, Tiangan.戊})],
+  }, star_relations_all.tiangan)
+
+  assert _check_dizhi({
+    DizhiRelation.六合 : [frozenset({Dizhi.戌, Dizhi.卯})],
+    DizhiRelation.半合 : [frozenset({Dizhi.戌, Dizhi.午})],
+    DizhiRelation.刑 : [frozenset({Dizhi.丑, Dizhi.未, Dizhi.戌})],
+    DizhiRelation.破 : [frozenset({Dizhi.戌, Dizhi.未})],
+    DizhiRelation.生 : [frozenset({Dizhi.戌, Dizhi.午})],
+    DizhiRelation.克 : [frozenset({Dizhi.戌, Dizhi.卯}),
+                       frozenset({Dizhi.戌, Dizhi.子})],
+  }, star_relations_all.dizhi)
+
+  assert not transits.zhengyin(2018, TransitOptions.DAYUN_LIUNIAN).tiangan
+  assert not transits.zhengyin(2018, TransitOptions.DAYUN_LIUNIAN).dizhi
+
+  assert transits.star(2018, TransitOptions.DAYUN_LIUNIAN).tiangan
+  assert transits.star(2018, TransitOptions.DAYUN_LIUNIAN).dizhi
+  assert transits.star(2018, TransitOptions.LIUNIAN).tiangan
+  assert transits.star(2018, TransitOptions.LIUNIAN).dizhi
+  assert not transits.star(2018, TransitOptions.DAYUN).tiangan
+  assert not transits.star(2018, TransitOptions.DAYUN).dizhi
+
+  # 2031
+  assert set(db.ganzhis(TransitMoment(2031), TransitOptions.DAYUN_LIUNIAN)) == {Ganzhi.from_str('辛亥'), Ganzhi.from_str('壬申')}
+
+  shensha = transits.shensha(2031, TransitOptions.DAYUN_LIUNIAN)
+  assert shensha['taohua']   == set()
+  assert shensha['hongluan'] == set()
+  assert shensha['hongyan']  == {Dizhi.申}
+  assert shensha['tianxi']   == set()
+  assert shensha['yima']     == {Dizhi.亥}
+
+  assert _check_tiangan({
+    TianganRelation.克 : [frozenset({Tiangan.乙, Tiangan.辛})],
+    TianganRelation.生 : [frozenset({Tiangan.乙, Tiangan.壬})],
+  }, transits.day_master_relations(2031, TransitOptions.DAYUN_LIUNIAN))
+
+  assert _check_dizhi({
+    DizhiRelation.生 : [frozenset({Dizhi.申, Dizhi.丑})],
+    DizhiRelation.克 : [frozenset({Dizhi.丑, Dizhi.亥})],
+    DizhiRelation.三会 : [frozenset({Dizhi.亥, Dizhi.子, Dizhi.丑})],
+  }, transits.house_relations(2031, TransitOptions.DAYUN_LIUNIAN))
+
+  star_relations_all = transits.star_relations(2031, TransitOptions.DAYUN_LIUNIAN) # level is `ALL` by default.
+  assert 0 == len(star_relations_all.tiangan)
+  assert 0 == len(star_relations_all.dizhi)
+
+  assert transits.zhengyin(2031, TransitOptions.DAYUN_LIUNIAN).tiangan
+  assert transits.zhengyin(2031, TransitOptions.DAYUN_LIUNIAN).dizhi
+
+  assert not transits.star(2031, TransitOptions.DAYUN_LIUNIAN).tiangan
+  assert not transits.star(2031, TransitOptions.DAYUN_LIUNIAN).dizhi
+
+@pytest.mark.integration
+def test_case2() -> None:
+  '''From 问真八字 https://pcbz.iwzwh.com/#/paipan/index'''
+  bazi: Bazi = Bazi(
+    birth_time=datetime(2020, 7, 2, 19, 8),
+    gender=BaziGender.FEMALE,
+    precision=BaziPrecision.DAY,
+  )
+  chart: BaziChart = BaziChart(bazi)
+  birth_gz_year: int = bazi.ganzhi_date.year
+  analyzer: RelationshipAnalyzer = RelationshipAnalyzer(chart)
+  transits: TransitAnalysis = analyzer.transits
+
+  # basic info correctness
+  assert bazi.year_pillar == Ganzhi.from_str('庚子')
+  assert bazi.month_pillar == Ganzhi.from_str('壬午')
+  assert bazi.day_pillar == Ganzhi.from_str('丙午')
+  assert bazi.hour_pillar == Ganzhi.from_str('戊戌')
+
+  assert chart.xiaoyun[0].ganzhi == Ganzhi.from_str('丁酉')
+  assert next(chart.dayun).ganzhi == Ganzhi.from_str('辛巳'), 'first dayun Ganzhi'
+  assert next(chart.dayun).ganzhi_year == 2029, 'first dayun year'
+
+  # at birth
+  at_birth: AtBirthAnalysis = analyzer.at_birth
+
+  assert at_birth.shensha['taohua']   == set()
+  assert at_birth.shensha['hongluan'] == set()
+  assert at_birth.shensha['hongyan']  == set()
+  assert at_birth.shensha['tianxi']   == set()
+  assert at_birth.shensha['yima']     == set()
+
+  # 感情分析主要关心日主被合的情况，但原局日主没有被合。
+  # 虽然我们不关心其他关系，但在这里还是检查一下。
+  assert _check_tiangan({
+    TianganRelation.生 : [frozenset({Tiangan.丙, Tiangan.戊})],
+    TianganRelation.克 : [frozenset({Tiangan.丙, Tiangan.壬}),
+                         frozenset({Tiangan.丙, Tiangan.庚})],
+  }, at_birth.day_master_relations)
+
+  assert _check_dizhi({
+    DizhiRelation.生 : [frozenset({Dizhi.午, Dizhi.戌})],
+    DizhiRelation.克 : [frozenset({Dizhi.午, Dizhi.子})],
+    DizhiRelation.半合 : [frozenset({Dizhi.午, Dizhi.戌})],
+    DizhiRelation.刑 : [frozenset({Dizhi.午})],
+    DizhiRelation.冲 : [frozenset({Dizhi.子, Dizhi.午})],
+  }, at_birth.house_relations)
+
+  assert len(at_birth.star_relations.tiangan) == 0
+
+  assert _check_dizhi({
+    DizhiRelation.克 : [frozenset({Dizhi.午, Dizhi.子}),
+                       frozenset({Dizhi.戌, Dizhi.子})],
+    DizhiRelation.冲 : [frozenset({Dizhi.子, Dizhi.午})],
+  }, at_birth.star_relations.dizhi)
+
+  # transits - shensha
+  shensha_expected_dz: ShenshaAnalysis = {
+    'taohua'   : frozenset([Dizhi.酉, Dizhi.卯]),
+    'hongyan'  : frozenset([Dizhi.寅]),
+    'hongluan' : frozenset([Dizhi.卯]),
+    'tianxi'   : frozenset([Dizhi.酉]),
+    'yima'     : frozenset([Dizhi.寅, Dizhi.申]),
+  }
+
+  db = TransitDatabase(chart)
+  for _ in range(50):
+    random_year = random.randint(birth_gz_year, birth_gz_year + 200)
+    random_option = TransitOptions.random()
+    if not transits.support(random_year, random_option):
+      continue
+
+    transits_gz = db.ganzhis(TransitMoment(random_year), random_option)
+    transits_dz = {gz.dizhi for gz in transits_gz}
+
+    assert transits.shensha(random_year, random_option) == {
+      name : cast(frozenset[Dizhi], fs) & transits_dz
+      for name, fs in shensha_expected_dz.items()
+    }
+
+  # transits - day master relations
+  dm_relation_expected: dict[TianganRelation, set[Tiangan]] = {
+    TianganRelation.生 : {Tiangan.戊, Tiangan.己, Tiangan.甲, Tiangan.乙},
+    TianganRelation.克 : {Tiangan.壬, Tiangan.癸, Tiangan.庚, Tiangan.辛},
+    TianganRelation.合 : {Tiangan.辛},
+    TianganRelation.冲 : {Tiangan.壬},
+  }
+
+  db = TransitDatabase(chart)
+  for year in random.sample(range(birth_gz_year, birth_gz_year + 600), 100):
+    for option in TransitOptions:
+      if not transits.support(year, option):
+        continue
+
+      transits_gz = db.ganzhis(TransitMoment(year), option)
+      transits_tg = {gz.tiangan for gz in transits_gz}
+
+      for tg_rel, tg_combos in transits.day_master_relations(year, option).items():
+        expected_tg_combos = {
+          frozenset([tg, bazi.day_master])
+          for tg in (dm_relation_expected[tg_rel] & transits_tg)
+        }
+        assert set(tg_combos) == expected_tg_combos
+
+  # transits - house relations
+  house_relation_expected: dict[DizhiRelation, list[set[Dizhi]]] = {
+    DizhiRelation.三会 : [{Dizhi.巳, Dizhi.未}],
+    DizhiRelation.六合 : [{Dizhi.未}],
+    DizhiRelation.暗合 : [{Dizhi.亥}, {Dizhi.寅}],
+    DizhiRelation.通合 : [{Dizhi.亥}],
+    DizhiRelation.通禄合 : [{Dizhi.亥}, {Dizhi.寅}],
+    DizhiRelation.三合 : [{Dizhi.寅, Dizhi.戌}],
+    DizhiRelation.半合 : [{Dizhi.寅}, {Dizhi.戌}],
+    DizhiRelation.刑 : [{Dizhi.午}],
+    DizhiRelation.冲 : [{Dizhi.子}],
+    DizhiRelation.破 : [{Dizhi.卯}],
+    DizhiRelation.害 : [{Dizhi.丑}],
+    DizhiRelation.生 : [{Dizhi.戌}, {Dizhi.未}, {Dizhi.丑}, {Dizhi.辰}, {Dizhi.寅}, {Dizhi.卯}],
+    DizhiRelation.克 : [{Dizhi.子}, {Dizhi.亥}, {Dizhi.申}, {Dizhi.酉}],
+  }
+
+  db = TransitDatabase(chart)
+  for year in random.sample(range(birth_gz_year, birth_gz_year + 600), 100):
+    for option in TransitOptions:
+      if not transits.support(year, option):
+        continue
+
+      transits_gz = db.ganzhis(TransitMoment(year), option)
+      transits_dz = {gz.dizhi for gz in transits_gz}
+
+      house_dz = chart.house_of_relationship
+      other_dz = {bazi.year_pillar.dizhi, bazi.month_pillar.dizhi, bazi.hour_pillar.dizhi}
+      house_relations = transits.house_relations(year, option)
+
+      for dz_rel, dz_expected_list in house_relation_expected.items():
+        expected_dz_combos: set[frozenset[Dizhi]] = set()
+        for dz_expected in dz_expected_list:
+          from_transits = dz_expected & transits_dz
+
+          if len(dz_expected) == 1: # Non 三合、三会、三刑 cases
+            if from_transits == dz_expected:
+              expected_dz_combos.add(frozenset({house_dz} | dz_expected))
+
+          else: # 三合、三会、三刑 cases
+            assert len(dz_expected) == 2
+            if from_transits == dz_expected:
+              expected_dz_combos.add(frozenset({house_dz} | dz_expected))
+            elif len(from_transits) == 1:
+              from_other_dz = dz_expected & other_dz
+              if from_other_dz | from_transits == dz_expected:
+                expected_dz_combos.add(frozenset({house_dz} | dz_expected))
+
+        if len(expected_dz_combos) == 0:
+          assert dz_rel not in house_relations
+        else:
+          assert set(house_relations[dz_rel]) == expected_dz_combos
+
+  # transits - star relations
+  assert chart.relationship_stars.tiangan == Tiangan.癸
+  assert set(chart.relationship_stars.dizhi) == {Dizhi.子}
+
+  db = TransitDatabase(chart)
+  for year in random.sample(range(birth_gz_year, birth_gz_year + 600), 100):
+    for option in TransitOptions:
+      if not transits.support(year, option):
+        continue
+
+      transits_gz = db.ganzhis(TransitMoment(year), option)
+      transits_tg = {gz.tiangan for gz in transits_gz}
+      transits_dz = {gz.dizhi for gz in transits_gz}
+
+      # Test TRANSITS_ONLY
+      transits_only_star_relations = transits.star_relations(year, option, level=TransitAnalysis.Level.TRANSITS_ONLY)
+      expected_transits_only_tg_star_relations = tiangan_utils.discover(list(transits_tg)).filter(
+        lambda _, combo : Tiangan.癸 in combo
+      )
+      expected_transits_only_dz_star_relations = dizhi_utils.discover(list(transits_dz)).filter(
+        lambda _, combo : Dizhi.子 in combo
+      )
+
+      assert _equal(transits_only_star_relations.tiangan, expected_transits_only_tg_star_relations)
+      assert _equal(transits_only_star_relations.dizhi, expected_transits_only_dz_star_relations)
+
+      # Test MUTUAL
+      mutual_star_relations = transits.star_relations(year, option, level=TransitAnalysis.Level.MUTUAL)
+      expected_mutual_tg_star_relations = tiangan_utils.discover_mutual(chart.bazi.four_tiangans, list(transits_tg)).filter(
+        lambda _, combo : Tiangan.癸 in combo
+      )
+      expected_mutual_dz_star_relations = dizhi_utils.discover_mutual(chart.bazi.four_dizhis, list(transits_dz)).filter(
+        lambda _, combo : Dizhi.子 in combo
+      )
+
+      assert _equal(mutual_star_relations.tiangan, expected_mutual_tg_star_relations)
+      assert _equal(mutual_star_relations.dizhi, expected_mutual_dz_star_relations)
+
+      # Test ALL
+      all_star_relations = transits.star_relations(year, option, level=TransitAnalysis.Level.ALL)
+      expected_all_tg_star_relations = expected_transits_only_tg_star_relations.merge(expected_mutual_tg_star_relations)
+      expected_all_dz_star_relations = expected_transits_only_dz_star_relations.merge(expected_mutual_dz_star_relations)
+
+      assert _equal(all_star_relations.tiangan, expected_all_tg_star_relations)
+      assert _equal(all_star_relations.dizhi, expected_all_dz_star_relations)
+
+      assert _equal(all_star_relations.tiangan, tiangan_utils.discover(list(transits_tg) + list(bazi.four_tiangans)).filter(
+        lambda _, combo : Tiangan.癸 in combo and not combo.isdisjoint(transits_tg)
+      ))
+      assert _equal(all_star_relations.dizhi, dizhi_utils.discover(list(transits_dz) + list(bazi.four_dizhis)).filter(
+        lambda _, combo : Dizhi.子 in combo and not combo.isdisjoint(transits_dz)
+      ))
+
+  # transits - zhengyin and star
+  def is_zhengyin(tg_or_dz: Tiangan | Dizhi) -> bool:
+    return Shishen.正印 is bazi_utils.shishen(bazi.day_master, tg_or_dz)
+
+  def is_star(tg_or_dz: Tiangan | Dizhi) -> bool:
+    return Shishen.正官 is bazi_utils.shishen(bazi.day_master, tg_or_dz)
+
+  assert is_star(Tiangan.癸)
+  assert is_star(Dizhi.子)
+  assert is_zhengyin(Tiangan.乙)
+  assert is_zhengyin(Dizhi.卯)
+
+  db = TransitDatabase(chart)
+  for year in random.sample(range(birth_gz_year, birth_gz_year + 600), 100):
+    for option in TransitOptions:
+      if not transits.support(year, option):
+        continue
+
+      transits_gz = db.ganzhis(TransitMoment(year), option)
+      transits_tg = {gz.tiangan for gz in transits_gz}
+      transits_dz = {gz.dizhi for gz in transits_gz}
+
+      zhengyin_result = transits.zhengyin(year, option)
+      assert zhengyin_result.tiangan == any(is_zhengyin(tg) for tg in transits_tg)
+      assert zhengyin_result.dizhi == any(is_zhengyin(dz) for dz in transits_dz)
+
+      star_result = transits.star(year, option)
+      assert star_result.tiangan == any(is_star(tg) for tg in transits_tg)
+      assert star_result.dizhi == any(is_star(dz) for dz in transits_dz)
 
 
 @pytest.mark.integration

--- a/tests/test_bazi.py
+++ b/tests/test_bazi.py
@@ -9,11 +9,13 @@ import pytest
 from itertools import product
 from datetime import date, time, datetime, timedelta
 from zoneinfo import ZoneInfo
+from typing import Final
 
 from src.calendar import JieqiTime
 from src.defines import Tiangan, Dizhi, Ganzhi, Jieqi
 from src.bazi import BaziGender, BaziPrecision, Bazi, 八字
 from src.calendar import hko_data_utils, CalendarBackend, calendar_utils_of
+
 
 def test_bazi_gender_basic() -> None:
   assert len(BaziGender) == 2
@@ -28,6 +30,7 @@ def test_bazi_gender_basic() -> None:
   assert BaziGender.YIN is BaziGender.阴
   assert BaziGender.YIN is BaziGender.坤
 
+
 def test_str() -> None:
   assert str(BaziGender.YANG) == 'male'
   assert str(BaziGender.YIN) == 'female'
@@ -41,6 +44,7 @@ def test_bazi_precision_basic() -> None:
   assert str(BaziPrecision.DAY) == 'day'
   assert str(BaziPrecision.HOUR) == 'hour'
   assert str(BaziPrecision.MINUTE) == 'minute'
+
 
 @pytest.mark.parametrize('backend', ('hko', 'celestial'))
 @pytest.mark.parametrize('moment, year_pillar, month_dizhi', [
@@ -66,6 +70,7 @@ def test_day_precision_compares_dates_not_moments(backend: str, moment: str, yea
   assert str(bazi.year_pillar) == year_pillar
   assert bazi.month_commander == month_dizhi
 
+
 @pytest.mark.parametrize('moment, year, month, day', [
   # 1984-02-04 is the 立春 date, so the year/month pillars turn over between these rows while
   # the day pillar turns over an hour earlier, at 23:00.
@@ -90,14 +95,16 @@ def test_the_23_oclock_rollover_moves_only_the_day_pillar(moment: str, year: str
 # HOUR / MINUTE precisions (issue #6): `birth >= jieqi` compared at the known granularity,
 # ties go new. The reference rule text is the `BaziPrecision` docstring.
 
+
 # The jie owning a birth month opens it: 立春 opens 寅月, and so on. Written out as data
 # (not derived from enum order) so the tests share no derivation with `src.Bazi`.
-JIE_MONTH_DIZHI: dict[Jieqi, Dizhi] = {
+JIE_MONTH_DIZHI: Final[dict[Jieqi, Dizhi]] = {
   Jieqi.立春 : Dizhi.寅,  Jieqi.惊蛰 : Dizhi.卯,  Jieqi.清明 : Dizhi.辰,
   Jieqi.立夏 : Dizhi.巳,  Jieqi.芒种 : Dizhi.午,  Jieqi.小暑 : Dizhi.未,
   Jieqi.立秋 : Dizhi.申,  Jieqi.白露 : Dizhi.酉,  Jieqi.寒露 : Dizhi.戌,
   Jieqi.立冬 : Dizhi.亥,  Jieqi.大雪 : Dizhi.子,  Jieqi.小寒 : Dizhi.丑,
 }
+
 
 def _truncated(dt: datetime, precision: BaziPrecision) -> datetime:
   '''
@@ -112,6 +119,7 @@ def _truncated(dt: datetime, precision: BaziPrecision) -> datetime:
   boundaries: list[datetime] = [datetime.combine(dt.date() - timedelta(days=1), time(23))]
   boundaries += [datetime.combine(dt.date(), time(h)) for h in range(1, 24, 2)]
   return max(b for b in boundaries if b <= dt)
+
 
 @pytest.mark.parametrize('moment, precision, year_pillar, month_dizhi', [
   ('2000-02-04 19:30', 'hour',   '庚辰', Dizhi.寅), # 戌时 [19:00, 21:00) holds the jieqi: tie -> new.
@@ -149,6 +157,7 @@ def test_goldens_from_the_docstring(moment: str, precision: str, year_pillar: st
   assert str(bazi.year_pillar) == year_pillar
   assert bazi.month_commander == month_dizhi
 
+
 def test_day_and_hour_pillars_ignore_precision() -> None:
   '''Precision only moves the year/month attribution; the day/hour pillars must not move.'''
   moments: list[str] = ['2009-02-03 23:30', '2017-02-03 23:10', '2000-02-04 20:39', '1984-02-04 12:30']
@@ -159,12 +168,14 @@ def test_day_and_hour_pillars_ignore_precision() -> None:
       assert bazi.day_pillar == day_bazi.day_pillar
       assert bazi.hour_pillar == day_bazi.hour_pillar
 
+
 def test_hko_backend_rejected() -> None:
   '''HOUR / MINUTE need real jieqi moments; the HKO backend's are midnight placeholders.'''
   for precision in (BaziPrecision.HOUR, BaziPrecision.MINUTE):
     with pytest.raises(ValueError):
       Bazi(datetime(2000, 2, 4, 19, 30), BaziGender.MALE, precision, CalendarBackend.HKO)
   assert str(Bazi.create('2000-02-04 19:30', 'male', 'day', backend='hko').year_pillar) == '庚辰'
+
 
 def test_ganzhi_year_and_bracketing_jies_are_the_attribution() -> None:
   '''`ganzhi_year` / `bracketing_jies` expose exactly what the pillars were derived from.'''
@@ -182,6 +193,7 @@ def test_ganzhi_year_and_bracketing_jies_are_the_attribution() -> None:
   advance: Bazi = Bazi.create('2009-02-03 23:30', 'male', 'hour')
   assert advance.ganzhi_year == 2009
   assert advance.ganzhi_date.year == 2008
+
 
 @pytest.mark.slow
 def test_attribution_matches_scan_oracle() -> None:
@@ -259,6 +271,7 @@ def test_attribution_matches_scan_oracle() -> None:
   # The biased sampling must actually have exercised the divergence windows.
   assert divergent > 100
 
+
 def test_minute_vs_moment_level_prev_jie() -> None:
   '''
   MINUTE attribution vs the moment-level `prev_jie`: the two may disagree ONLY at a
@@ -314,6 +327,7 @@ def test_init() -> None:
     assert bazi.gender == BaziGender.男
     assert bazi.precision == BaziPrecision.DAY
 
+
 def test_chinese() -> None:
   assert Bazi is 八字
 
@@ -338,6 +352,7 @@ def test_chinese() -> None:
     assert bazi.minute == random_dt.minute
     assert bazi.gender == BaziGender.男
     assert bazi.precision == BaziPrecision.DAY
+
 
 def test_invalid_arguments() -> None:
   random_dt: datetime = datetime(
@@ -382,6 +397,7 @@ def test_invalid_arguments() -> None:
       precision=BaziPrecision.DAY,
     )
 
+
 def _create_bazi(dt: datetime) -> Bazi:
   return Bazi(
     birth_time=dt,
@@ -389,12 +405,13 @@ def _create_bazi(dt: datetime) -> Bazi:
     precision=BaziPrecision.DAY,
   )
 
+
 def test_four_dizhis_correctness() -> None:
   '''
   Test the correctness of `Bazi` on the given test cases.
   Precision is at `DAY` level.
   '''
-  def __subtest(dt: datetime, dizhi_strs: list[str]) -> None:
+  def __check(dt: datetime, dizhi_strs: list[str]) -> None:
     assert len(dizhi_strs) == 4
 
     bazi = _create_bazi(dt)
@@ -406,37 +423,29 @@ def test_four_dizhis_correctness() -> None:
     )
 
   # Basic cases
-  # Data was collected from "测测" app on my iPhone 15 Pro Max.
-  __subtest(datetime(2024, 2, 6, 11, 55), ['辰', '寅', '子', '午'])
-  __subtest(datetime(1984, 4, 2, 4, 2), ['子', '卯', '寅', '寅'])
+  # Data was collected from the "测测" app.
+  __check(datetime(2024, 2, 6, 11, 55), ['辰', '寅', '子', '午'])
+  __check(datetime(1984, 4, 2, 4, 2), ['子', '卯', '寅', '寅'])
 
-  __subtest(datetime(1998, 3, 17, 13, 0), ['寅', '卯', '亥', '未'])
-  __subtest(datetime(1998, 3, 17, 13, 59), ['寅', '卯', '亥', '未'])
-  __subtest(datetime(1998, 3, 17, 14, 0), ['寅', '卯', '亥', '未'])
-  __subtest(datetime(1998, 3, 17, 14, 59), ['寅', '卯', '亥', '未'])
-  __subtest(datetime(1998, 3, 17, 15, 0), ['寅', '卯', '亥', '申'])
-  __subtest(datetime(1998, 3, 17, 23, 0), ['寅', '卯', '子', '子'])
-  __subtest(datetime(1998, 3, 18, 0, 59), ['寅', '卯', '子', '子'])
-  __subtest(datetime(1998, 3, 18, 1, 0), ['寅', '卯', '子', '丑'])
+  __check(datetime(1998, 3, 17, 13, 0), ['寅', '卯', '亥', '未'])
+  __check(datetime(1998, 3, 17, 13, 59), ['寅', '卯', '亥', '未'])
+  __check(datetime(1998, 3, 17, 14, 0), ['寅', '卯', '亥', '未'])
+  __check(datetime(1998, 3, 17, 14, 59), ['寅', '卯', '亥', '未'])
+  __check(datetime(1998, 3, 17, 15, 0), ['寅', '卯', '亥', '申'])
+  __check(datetime(1998, 3, 17, 23, 0), ['寅', '卯', '子', '子'])
+  __check(datetime(1998, 3, 18, 0, 59), ['寅', '卯', '子', '子'])
+  __check(datetime(1998, 3, 18, 1, 0), ['寅', '卯', '子', '丑'])
 
   # Edge cases
-  __subtest(datetime(1998, 3, 17, 13, 0), ['寅', '卯', '亥', '未'])
-  __subtest(datetime(1998, 3, 17, 13, 59), ['寅', '卯', '亥', '未'])
-  __subtest(datetime(1998, 3, 17, 14, 0), ['寅', '卯', '亥', '未'])
-  __subtest(datetime(1998, 3, 17, 14, 59), ['寅', '卯', '亥', '未'])
-  __subtest(datetime(1998, 3, 17, 15, 0), ['寅', '卯', '亥', '申'])
-  __subtest(datetime(1998, 3, 17, 23, 0), ['寅', '卯', '子', '子'])
-  __subtest(datetime(1998, 3, 18, 0, 59), ['寅', '卯', '子', '子'])
-  __subtest(datetime(1998, 3, 18, 1, 0), ['寅', '卯', '子', '丑'])
+  __check(datetime(2000, 2, 3, 0, 0), ['卯', '丑', '卯', '子'])
+  __check(datetime(2000, 2, 3, 22, 59), ['卯', '丑', '卯', '亥'])
+  __check(datetime(2000, 2, 3, 23, 0), ['卯', '丑', '辰', '子'])
+  __check(datetime(2000, 2, 4, 0, 0), ['辰', '寅', '辰', '子'])
+  __check(datetime(2000, 2, 4, 1, 0), ['辰', '寅', '辰', '丑'])
 
-  __subtest(datetime(2000, 2, 3, 0, 0), ['卯', '丑', '卯', '子'])
-  __subtest(datetime(2000, 2, 3, 22, 59), ['卯', '丑', '卯', '亥'])
-  __subtest(datetime(2000, 2, 3, 23, 0), ['卯', '丑', '辰', '子'])
-  __subtest(datetime(2000, 2, 4, 0, 0), ['辰', '寅', '辰', '子'])
-  __subtest(datetime(2000, 2, 4, 1, 0), ['辰', '寅', '辰', '丑'])
 
 def test_four_tiangans_correctness() -> None:
-  def __subtest(dt: datetime, tiangan_strs: list[str]) -> None:
+  def __check(dt: datetime, tiangan_strs: list[str]) -> None:
     assert len(tiangan_strs) == 4
 
     bazi = _create_bazi(dt)
@@ -447,9 +456,10 @@ def test_four_tiangans_correctness() -> None:
       Tiangan.from_str(tiangan_strs[3]),
     )
 
-  __subtest(datetime(1984, 4, 2, 4, 2), ['甲', '丁', '丙', '庚'])
-  __subtest(datetime(2000, 2, 4, 22, 1), ['庚', '戊', '壬', '辛'])
-  __subtest(datetime(2001, 10, 20, 19, 0), ['辛', '戊', '丙', '戊'])
+  __check(datetime(1984, 4, 2, 4, 2), ['甲', '丁', '丙', '庚'])
+  __check(datetime(2000, 2, 4, 22, 1), ['庚', '戊', '壬', '辛'])
+  __check(datetime(2001, 10, 20, 19, 0), ['辛', '戊', '丙', '戊'])
+
 
 def test_ganzhi_date() -> None:
   bazi: Bazi = _create_bazi(datetime(1984, 4, 2, 4, 2))
@@ -458,6 +468,7 @@ def test_ganzhi_date() -> None:
   for _ in range(10):
     bazi = Bazi.random()
     assert bazi.ganzhi_date == hko_data_utils.to_ganzhi(bazi.solar_date)
+
 
 def test_date_time() -> None:
   bazi: Bazi = _create_bazi(datetime(1984, 4, 2, 4, 2))
@@ -476,23 +487,25 @@ def test_date_time() -> None:
   with pytest.raises(AttributeError):
     random_bazi.solar_datetime = datetime(1984, 4, 3, 9, 8) # type: ignore
 
+
 def test_pillars() -> None:
-  def __subtest(dt: datetime, ganzhi_strs: list[str]) -> None:
+  def __check(dt: datetime, ganzhi_strs: list[str]) -> None:
     assert len(ganzhi_strs) == 4
 
     bazi = _create_bazi(dt)
     pillars: list[Ganzhi] = list(bazi.pillars)
-    assert pillars[0] == Ganzhi.from_str(ganzhi_strs[0]), 'Year Pillar'
-    assert pillars[1] == Ganzhi.from_str(ganzhi_strs[1]), 'Month Pillar'
-    assert pillars[2] == Ganzhi.from_str(ganzhi_strs[2]), 'Day Pillar'
-    assert pillars[3] == Ganzhi.from_str(ganzhi_strs[3]), 'Hour Pillar'
+    assert pillars[0] == Ganzhi.from_str(ganzhi_strs[0])
+    assert pillars[1] == Ganzhi.from_str(ganzhi_strs[1])
+    assert pillars[2] == Ganzhi.from_str(ganzhi_strs[2])
+    assert pillars[3] == Ganzhi.from_str(ganzhi_strs[3])
 
-  __subtest(datetime(1984, 4, 2, 4, 2), ['甲子', '丁卯', '丙寅', '庚寅'])
-  __subtest(datetime(2000, 2, 4, 22, 1), ['庚辰', '戊寅', '壬辰', '辛亥'])
-  __subtest(datetime(2001, 10, 20, 19, 0), ['辛巳', '戊戌', '丙辰', '戊戌'])
+  __check(datetime(1984, 4, 2, 4, 2), ['甲子', '丁卯', '丙寅', '庚寅'])
+  __check(datetime(2000, 2, 4, 22, 1), ['庚辰', '戊寅', '壬辰', '辛亥'])
+  __check(datetime(2001, 10, 20, 19, 0), ['辛巳', '戊戌', '丙辰', '戊戌'])
+
 
 def test_consistency() -> None:
-  def __subtest(dt: datetime, ganzhi_strs: list[str]) -> None:
+  def __check(dt: datetime, ganzhi_strs: list[str]) -> None:
     assert len(ganzhi_strs) == 4
 
     bazi = _create_bazi(dt)
@@ -509,9 +522,10 @@ def test_consistency() -> None:
     assert bazi.four_tiangans == tuple([tg for tg, _ in pillars])
     assert bazi.four_dizhis == tuple([dz for _, dz in pillars])
 
-  __subtest(datetime(1984, 4, 2, 4, 2), ['甲子', '丁卯', '丙寅', '庚寅'])
-  __subtest(datetime(2000, 2, 4, 22, 1), ['庚辰', '戊寅', '壬辰', '辛亥'])
-  __subtest(datetime(2001, 10, 20, 19, 0), ['辛巳', '戊戌', '丙辰', '戊戌'])
+  __check(datetime(1984, 4, 2, 4, 2), ['甲子', '丁卯', '丙寅', '庚寅'])
+  __check(datetime(2000, 2, 4, 22, 1), ['庚辰', '戊寅', '壬辰', '辛亥'])
+  __check(datetime(2001, 10, 20, 19, 0), ['辛巳', '戊戌', '丙辰', '戊戌'])
+
 
 def test_deepcopy() -> None:
   bazi: Bazi = Bazi(
@@ -531,6 +545,7 @@ def test_deepcopy() -> None:
   next_day_pillar: Ganzhi = cycle[(cycle.index(bazi._day_pillar) + 1) % len(cycle)]
   bazi._day_pillar = next_day_pillar # type: ignore
   assert bazi._day_pillar != bazi2._day_pillar
+
 
 def test_create() -> None:
   with pytest.raises(ValueError):
@@ -581,6 +596,7 @@ def test_create() -> None:
     with pytest.raises(ValueError):
       Bazi.create(dt, g, p, backend='hko') # HKO has no real jieqi moments.
 
+
 def test_eq_ne() -> None:
   def __random_info() -> tuple[datetime, BaziGender, BaziPrecision]:
     return (datetime(
@@ -612,6 +628,7 @@ def test_eq_ne() -> None:
     bazi_hacked._precision = BaziPrecision.HOUR # type: ignore # Intended for testing only.
     assert bazi != bazi_hacked
 
+
 def test_hash() -> None:
   dt: datetime = datetime(2000, 2, 4, 22, 1)
   bazi: Bazi = Bazi.create(dt, BaziGender.MALE, BaziPrecision.DAY)
@@ -621,6 +638,7 @@ def test_hash() -> None:
 
   other: Bazi = Bazi.create(dt, BaziGender.FEMALE, BaziPrecision.DAY)
   assert len({bazi, same, other}) == 2
+
 
 def test_sub_minute_truncation() -> None:
   # Two births in the same minute are the same Bazi -- `Bazi.solar_datetime` is the

--- a/tests/test_bazi.py
+++ b/tests/test_bazi.py
@@ -1,7 +1,6 @@
 # Copyright (C) 2024 Ningqi Wang (0xf3cd) <https://github.com/0xf3cd>
 # test_bazi.py
 
-import unittest
 import random
 import copy
 
@@ -9,7 +8,6 @@ import pytest
 
 from itertools import product
 from datetime import date, time, datetime, timedelta
-from typing import ClassVar
 from zoneinfo import ZoneInfo
 
 from src.calendar import JieqiTime
@@ -17,347 +15,284 @@ from src.defines import Tiangan, Dizhi, Ganzhi, Jieqi
 from src.bazi import BaziGender, BaziPrecision, Bazi, 八字
 from src.calendar import hko_data_utils, CalendarBackend, calendar_utils_of
 
-class TestBaziGender(unittest.TestCase):
-  def test_basic(self) -> None:
-    self.assertEqual(len(BaziGender), 2)
+def test_bazi_gender_basic() -> None:
+  assert len(BaziGender) == 2
 
-    self.assertIs(BaziGender.YANG, BaziGender.MALE)
-    self.assertIs(BaziGender.YANG, BaziGender.男)
-    self.assertIs(BaziGender.YANG, BaziGender.阳)
-    self.assertIs(BaziGender.YANG, BaziGender.乾)
+  assert BaziGender.YANG is BaziGender.MALE
+  assert BaziGender.YANG is BaziGender.男
+  assert BaziGender.YANG is BaziGender.阳
+  assert BaziGender.YANG is BaziGender.乾
 
-    self.assertIs(BaziGender.YIN, BaziGender.FEMALE)
-    self.assertIs(BaziGender.YIN, BaziGender.女)
-    self.assertIs(BaziGender.YIN, BaziGender.阴)
-    self.assertIs(BaziGender.YIN, BaziGender.坤)
+  assert BaziGender.YIN is BaziGender.FEMALE
+  assert BaziGender.YIN is BaziGender.女
+  assert BaziGender.YIN is BaziGender.阴
+  assert BaziGender.YIN is BaziGender.坤
 
-  def test_str(self) -> None:
-    self.assertEqual(str(BaziGender.YANG), 'male')
-    self.assertEqual(str(BaziGender.YIN), 'female')
-    self.assertIs(BaziGender.YANG, BaziGender('男'))
-    self.assertIs(BaziGender.YIN, BaziGender('女'))
-
-
-class TestBaziPrecision(unittest.TestCase):
-  def test_basic(self) -> None:
-    self.assertEqual(len(BaziPrecision), 3)
-
-    self.assertEqual(str(BaziPrecision.DAY), 'day')
-    self.assertEqual(str(BaziPrecision.HOUR), 'hour')
-    self.assertEqual(str(BaziPrecision.MINUTE), 'minute')
-
-  def test_day_precision_compares_dates_not_moments(self) -> None:
-    '''
-    `DAY` compares dates, so the whole of a jieqi's day falls on the new side of it -- the tie
-    at day granularity resolves to the new pillar, as `BaziPrecision` documents.
-
-    Pinned because nothing else would notice it changing. The behaviour rests on `datetime`
-    being a `date` subclass, so `to_ganzhi` accepts it and drops the time; anyone "fixing" that
-    to honour the moment would silently move ~1.6% of charts, which is exactly how the question
-    stayed open long enough to become issue #72. Changing the rule should mean deleting this
-    test on purpose.
-    '''
-    # 立春 2000 is 02-04 20:40:23 (celestial); the HKO almanac publishes 02-04.  So every
-    # moment of 02-04 gives 庚辰/寅 -- including 00:00, which precedes the jieqi by 20 hours.
-    expected: list[tuple[str, str, Dizhi]] = [
-      ('2000-02-03 12:00', '己卯', Dizhi.丑),
-      ('2000-02-04 00:00', '庚辰', Dizhi.寅), # 20h40m before the jieqi, still the new pillar.
-      ('2000-02-04 20:40', '庚辰', Dizhi.寅),
-      ('2000-02-04 23:59', '庚辰', Dizhi.寅),
-    ]
-    for backend in ('hko', 'celestial'):
-      for moment, year_pillar, month_dizhi in expected:
-        with self.subTest(backend=backend, moment=moment):
-          bazi: Bazi = Bazi.create(moment, 'male', 'day', backend=backend)
-          self.assertEqual(str(bazi.year_pillar), year_pillar)
-          self.assertEqual(bazi.month_commander, month_dizhi)
-
-  def test_the_23_oclock_rollover_moves_only_the_day_pillar(self) -> None:
-    '''
-    晚子时换日 moves the day pillar to the next day, while the year and month pillars keep
-    comparing dates -- so a 23:30 birth carries the next day's day pillar and the current
-    date's year/month pillars. Both halves are 流派 variants tracked in issue #69; this pins
-    which answer is today's default, so that making it configurable is a deliberate carry-over
-    rather than whatever the code happened to do.
-    '''
-    # 1984-02-04 is the 立春 date, so the year/month pillars turn over between these rows while
-    # the day pillar turns over an hour earlier, at 23:00.
-    expected: list[tuple[str, str, str, str]] = [
-      ('1984-02-03 22:30', '癸亥', '乙丑', '丁卯'),
-      ('1984-02-03 23:30', '癸亥', '乙丑', '戊辰'), # Day pillar already rolled, year/month not.
-      ('1984-02-04 00:30', '甲子', '丙寅', '戊辰'), # Year/month rolled, day pillar unchanged.
-    ]
-    for moment, year, month, day in expected:
-      with self.subTest(moment=moment):
-        bazi: Bazi = Bazi.create(moment, 'male', 'day')
-        self.assertEqual(str(bazi.year_pillar), year)
-        self.assertEqual(str(bazi.month_pillar), month)
-        self.assertEqual(str(bazi.day_pillar), day)
+def test_str() -> None:
+  assert str(BaziGender.YANG) == 'male'
+  assert str(BaziGender.YIN) == 'female'
+  assert BaziGender.YANG is BaziGender('男')
+  assert BaziGender.YIN is BaziGender('女')
 
 
-class TestBaziHourMinutePrecisions(unittest.TestCase):
+def test_bazi_precision_basic() -> None:
+  assert len(BaziPrecision) == 3
+
+  assert str(BaziPrecision.DAY) == 'day'
+  assert str(BaziPrecision.HOUR) == 'hour'
+  assert str(BaziPrecision.MINUTE) == 'minute'
+
+@pytest.mark.parametrize('backend', ('hko', 'celestial'))
+@pytest.mark.parametrize('moment, year_pillar, month_dizhi', [
+  # 立春 2000 is 02-04 20:40:23 (celestial); the HKO almanac publishes 02-04.  So every
+  # moment of 02-04 gives 庚辰/寅 -- including 00:00, which precedes the jieqi by 20 hours.
+  ('2000-02-03 12:00', '己卯', Dizhi.丑),
+  ('2000-02-04 00:00', '庚辰', Dizhi.寅), # 20h40m before the jieqi, still the new pillar.
+  ('2000-02-04 20:40', '庚辰', Dizhi.寅),
+  ('2000-02-04 23:59', '庚辰', Dizhi.寅),
+])
+def test_day_precision_compares_dates_not_moments(backend: str, moment: str, year_pillar: str, month_dizhi: Dizhi) -> None:
   '''
-  HOUR / MINUTE precisions (issue #6): `birth >= jieqi` compared at the known granularity,
-  ties go new. The reference rule text is the `BaziPrecision` docstring.
+  `DAY` compares dates, so the whole of a jieqi's day falls on the new side of it -- the tie
+  at day granularity resolves to the new pillar, as `BaziPrecision` documents.
+
+  Pinned because nothing else would notice it changing. The behaviour rests on `datetime`
+  being a `date` subclass, so `to_ganzhi` accepts it and drops the time; anyone "fixing" that
+  to honour the moment would silently move ~1.6% of charts, which is exactly how the question
+  stayed open long enough to become issue #72. Changing the rule should mean deleting this
+  test on purpose.
   '''
+  bazi: Bazi = Bazi.create(moment, 'male', 'day', backend=backend)
+  assert str(bazi.year_pillar) == year_pillar
+  assert bazi.month_commander == month_dizhi
 
-  # The jie owning a birth month opens it: 立春 opens 寅月, and so on. Written out as data
-  # (not derived from enum order) so the tests share no derivation with `src.Bazi`.
-  JIE_MONTH_DIZHI: ClassVar[dict[Jieqi, Dizhi]] = {
-    Jieqi.立春 : Dizhi.寅,  Jieqi.惊蛰 : Dizhi.卯,  Jieqi.清明 : Dizhi.辰,
-    Jieqi.立夏 : Dizhi.巳,  Jieqi.芒种 : Dizhi.午,  Jieqi.小暑 : Dizhi.未,
-    Jieqi.立秋 : Dizhi.申,  Jieqi.白露 : Dizhi.酉,  Jieqi.寒露 : Dizhi.戌,
-    Jieqi.立冬 : Dizhi.亥,  Jieqi.大雪 : Dizhi.子,  Jieqi.小寒 : Dizhi.丑,
-  }
+@pytest.mark.parametrize('moment, year, month, day', [
+  # 1984-02-04 is the 立春 date, so the year/month pillars turn over between these rows while
+  # the day pillar turns over an hour earlier, at 23:00.
+  ('1984-02-03 22:30', '癸亥', '乙丑', '丁卯'),
+  ('1984-02-03 23:30', '癸亥', '乙丑', '戊辰'), # Day pillar already rolled, year/month not.
+  ('1984-02-04 00:30', '甲子', '丙寅', '戊辰'), # Year/month rolled, day pillar unchanged.
+])
+def test_the_23_oclock_rollover_moves_only_the_day_pillar(moment: str, year: str, month: str, day: str) -> None:
+  '''
+  晚子时换日 moves the day pillar to the next day, while the year and month pillars keep
+  comparing dates -- so a 23:30 birth carries the next day's day pillar and the current
+  date's year/month pillars. Both halves are 流派 variants tracked in issue #69; this pins
+  which answer is today's default, so that making it configurable is a deliberate carry-over
+  rather than whatever the code happened to do.
+  '''
+  bazi: Bazi = Bazi.create(moment, 'male', 'day')
+  assert str(bazi.year_pillar) == year
+  assert str(bazi.month_pillar) == month
+  assert str(bazi.day_pillar) == day
 
-  @staticmethod
-  def __truncated(dt: datetime, precision: BaziPrecision) -> datetime:
-    '''
-    Independent re-statement of the granularity truncation, for oracle use. HOUR scans the
-    时辰 boundaries (the odd clock hours, plus the previous day's 23:00) and takes the latest
-    one at or before `dt` -- deliberately NOT the shift-floor-shift formula `src.Bazi` uses,
-    so the oracle and the implementation cannot share a truncation error.
-    '''
-    if precision is BaziPrecision.MINUTE:
-      return dt.replace(second=0, microsecond=0)
-    assert precision is BaziPrecision.HOUR
-    boundaries: list[datetime] = [datetime.combine(dt.date() - timedelta(days=1), time(23))]
-    boundaries += [datetime.combine(dt.date(), time(h)) for h in range(1, 24, 2)]
-    return max(b for b in boundaries if b <= dt)
 
-  def test_goldens_from_the_docstring(self) -> None:
-    '''
-    The `BaziPrecision` docstring's worked examples, pinned:
-    - 立春 2000 = 02-04 20:40:23 -- the same-day 时辰 tie (戌时) and the minute tie.
-    - 立春 2017 = 02-03 23:34:03 -- the tie 时辰 (子时) starts at 23:00 of the jieqi's own day.
-    - 立春 2009 = 02-04 00:49:48 -- the tie 时辰 starts on the PREVIOUS civil day, so HOUR
-      attributes a 02-03 23:30 birth to the new year on a day DAY assigns to the old side.
-      The granularities are three readings of one rule, not nested refinements.
-    '''
-    expected: list[tuple[str, str, str, Dizhi]] = [
-      ('2000-02-04 19:30', 'hour',   '庚辰', Dizhi.寅), # 戌时 [19:00, 21:00) holds the jieqi: tie -> new.
-      ('2000-02-04 20:59', 'hour',   '庚辰', Dizhi.寅),
-      ('2000-02-04 18:59', 'hour',   '己卯', Dizhi.丑), # 酉时: before the jieqi's 时辰 -> old.
-      ('2000-02-04 20:40', 'minute', '庚辰', Dizhi.寅), # Same minute as the jieqi: tie -> new.
-      ('2000-02-04 20:41', 'minute', '庚辰', Dizhi.寅),
-      ('2000-02-04 20:39', 'minute', '己卯', Dizhi.丑),
-      ('2000-02-05 04:00', 'hour',   '庚辰', Dizhi.寅), # Plain interior moments, both sides.
-      ('2000-02-03 12:00', 'minute', '己卯', Dizhi.丑),
+# HOUR / MINUTE precisions (issue #6): `birth >= jieqi` compared at the known granularity,
+# ties go new. The reference rule text is the `BaziPrecision` docstring.
 
-      ('2017-02-03 23:10', 'hour',   '丁酉', Dizhi.寅), # 子时 starts 23:00, holds 立春 23:34:03: tie.
-      ('2017-02-04 00:30', 'hour',   '丁酉', Dizhi.寅), # Still the same 子时, next civil day.
-      ('2017-02-03 22:30', 'hour',   '丙申', Dizhi.丑), # 亥时 -> old, on a day DAY assigns new.
-      ('2017-02-03 23:10', 'minute', '丙申', Dizhi.丑), # At minute granularity 23:10 < 23:34.
-      ('2017-02-03 23:34', 'minute', '丁酉', Dizhi.寅),
+# The jie owning a birth month opens it: 立春 opens 寅月, and so on. Written out as data
+# (not derived from enum order) so the tests share no derivation with `src.Bazi`.
+JIE_MONTH_DIZHI: dict[Jieqi, Dizhi] = {
+  Jieqi.立春 : Dizhi.寅,  Jieqi.惊蛰 : Dizhi.卯,  Jieqi.清明 : Dizhi.辰,
+  Jieqi.立夏 : Dizhi.巳,  Jieqi.芒种 : Dizhi.午,  Jieqi.小暑 : Dizhi.未,
+  Jieqi.立秋 : Dizhi.申,  Jieqi.白露 : Dizhi.酉,  Jieqi.寒露 : Dizhi.戌,
+  Jieqi.立冬 : Dizhi.亥,  Jieqi.大雪 : Dizhi.子,  Jieqi.小寒 : Dizhi.丑,
+}
 
-      ('2009-02-03 23:30', 'hour',   '己丑', Dizhi.寅), # Cross-midnight tie: 立春 02-04 00:49:48.
-      ('2009-02-04 00:30', 'hour',   '己丑', Dizhi.寅), # The tie seen from the jieqi's own day.
-      ('2009-02-03 22:59', 'hour',   '戊子', Dizhi.丑), # 亥时, right before the tie window opens.
-      ('2009-02-04 00:49', 'minute', '己丑', Dizhi.寅),
-      ('2009-02-04 00:48', 'minute', '戊子', Dizhi.丑),
-      ('2009-01-10 12:00', 'minute', '戊子', Dizhi.丑), # 丑月 interior: owned by 小寒 of 2009.
-    ]
-    for moment, precision, year_pillar, month_dizhi in expected:
-      with self.subTest(moment=moment, precision=precision):
-        bazi: Bazi = Bazi.create(moment, 'male', precision)
-        self.assertEqual(str(bazi.year_pillar), year_pillar)
-        self.assertEqual(bazi.month_commander, month_dizhi)
+def _truncated(dt: datetime, precision: BaziPrecision) -> datetime:
+  '''
+  Independent re-statement of the granularity truncation, for oracle use. HOUR scans the
+  时辰 boundaries (the odd clock hours, plus the previous day's 23:00) and takes the latest
+  one at or before `dt` -- deliberately NOT the shift-floor-shift formula `src.Bazi` uses,
+  so the oracle and the implementation cannot share a truncation error.
+  '''
+  if precision is BaziPrecision.MINUTE:
+    return dt.replace(second=0, microsecond=0)
+  assert precision is BaziPrecision.HOUR
+  boundaries: list[datetime] = [datetime.combine(dt.date() - timedelta(days=1), time(23))]
+  boundaries += [datetime.combine(dt.date(), time(h)) for h in range(1, 24, 2)]
+  return max(b for b in boundaries if b <= dt)
 
-  def test_day_and_hour_pillars_ignore_precision(self) -> None:
-    '''Precision only moves the year/month attribution; the day/hour pillars must not move.'''
-    moments: list[str] = ['2009-02-03 23:30', '2017-02-03 23:10', '2000-02-04 20:39', '1984-02-04 12:30']
-    for moment in moments:
-      day_bazi: Bazi = Bazi.create(moment, 'female', 'day')
-      for precision in ('hour', 'minute'):
-        with self.subTest(moment=moment, precision=precision):
-          bazi: Bazi = Bazi.create(moment, 'female', precision)
-          self.assertEqual(bazi.day_pillar, day_bazi.day_pillar)
-          self.assertEqual(bazi.hour_pillar, day_bazi.hour_pillar)
+@pytest.mark.parametrize('moment, precision, year_pillar, month_dizhi', [
+  ('2000-02-04 19:30', 'hour',   '庚辰', Dizhi.寅), # 戌时 [19:00, 21:00) holds the jieqi: tie -> new.
+  ('2000-02-04 20:59', 'hour',   '庚辰', Dizhi.寅),
+  ('2000-02-04 18:59', 'hour',   '己卯', Dizhi.丑), # 酉时: before the jieqi's 时辰 -> old.
+  ('2000-02-04 20:40', 'minute', '庚辰', Dizhi.寅), # Same minute as the jieqi: tie -> new.
+  ('2000-02-04 20:41', 'minute', '庚辰', Dizhi.寅),
+  ('2000-02-04 20:39', 'minute', '己卯', Dizhi.丑),
+  ('2000-02-05 04:00', 'hour',   '庚辰', Dizhi.寅), # Plain interior moments, both sides.
+  ('2000-02-03 12:00', 'minute', '己卯', Dizhi.丑),
 
-  def test_hko_backend_rejected(self) -> None:
-    '''HOUR / MINUTE need real jieqi moments; the HKO backend's are midnight placeholders.'''
+  ('2017-02-03 23:10', 'hour',   '丁酉', Dizhi.寅), # 子时 starts 23:00, holds 立春 23:34:03: tie.
+  ('2017-02-04 00:30', 'hour',   '丁酉', Dizhi.寅), # Still the same 子时, next civil day.
+  ('2017-02-03 22:30', 'hour',   '丙申', Dizhi.丑), # 亥时 -> old, on a day DAY assigns new.
+  ('2017-02-03 23:10', 'minute', '丙申', Dizhi.丑), # At minute granularity 23:10 < 23:34.
+  ('2017-02-03 23:34', 'minute', '丁酉', Dizhi.寅),
+
+  ('2009-02-03 23:30', 'hour',   '己丑', Dizhi.寅), # Cross-midnight tie: 立春 02-04 00:49:48.
+  ('2009-02-04 00:30', 'hour',   '己丑', Dizhi.寅), # The tie seen from the jieqi's own day.
+  ('2009-02-03 22:59', 'hour',   '戊子', Dizhi.丑), # 亥时, right before the tie window opens.
+  ('2009-02-04 00:49', 'minute', '己丑', Dizhi.寅),
+  ('2009-02-04 00:48', 'minute', '戊子', Dizhi.丑),
+  ('2009-01-10 12:00', 'minute', '戊子', Dizhi.丑), # 丑月 interior: owned by 小寒 of 2009.
+])
+def test_goldens_from_the_docstring(moment: str, precision: str, year_pillar: str, month_dizhi: Dizhi) -> None:
+  '''
+  The `BaziPrecision` docstring's worked examples, pinned:
+  - 立春 2000 = 02-04 20:40:23 -- the same-day 时辰 tie (戌时) and the minute tie.
+  - 立春 2017 = 02-03 23:34:03 -- the tie 时辰 (子时) starts at 23:00 of the jieqi's own day.
+  - 立春 2009 = 02-04 00:49:48 -- the tie 时辰 starts on the PREVIOUS civil day, so HOUR
+    attributes a 02-03 23:30 birth to the new year on a day DAY assigns to the old side.
+    The granularities are three readings of one rule, not nested refinements.
+  '''
+  bazi: Bazi = Bazi.create(moment, 'male', precision)
+  assert str(bazi.year_pillar) == year_pillar
+  assert bazi.month_commander == month_dizhi
+
+def test_day_and_hour_pillars_ignore_precision() -> None:
+  '''Precision only moves the year/month attribution; the day/hour pillars must not move.'''
+  moments: list[str] = ['2009-02-03 23:30', '2017-02-03 23:10', '2000-02-04 20:39', '1984-02-04 12:30']
+  for moment in moments:
+    day_bazi: Bazi = Bazi.create(moment, 'female', 'day')
+    for precision in ('hour', 'minute'):
+      bazi: Bazi = Bazi.create(moment, 'female', precision)
+      assert bazi.day_pillar == day_bazi.day_pillar
+      assert bazi.hour_pillar == day_bazi.hour_pillar
+
+def test_hko_backend_rejected() -> None:
+  '''HOUR / MINUTE need real jieqi moments; the HKO backend's are midnight placeholders.'''
+  for precision in (BaziPrecision.HOUR, BaziPrecision.MINUTE):
+    with pytest.raises(ValueError):
+      Bazi(datetime(2000, 2, 4, 19, 30), BaziGender.MALE, precision, CalendarBackend.HKO)
+  assert str(Bazi.create('2000-02-04 19:30', 'male', 'day', backend='hko').year_pillar) == '庚辰'
+
+def test_ganzhi_year_and_bracketing_jies_are_the_attribution() -> None:
+  '''`ganzhi_year` / `bracketing_jies` expose exactly what the pillars were derived from.'''
+  bazi: Bazi = Bazi.create('2009-02-04 00:30', 'male', 'hour')
+  assert bazi.ganzhi_year == 2009
+  owning, following = bazi.bracketing_jies
+  assert owning == JieqiTime(Jieqi.立春, datetime(2009, 2, 4, 0, 49, 48))
+  assert following.jieqi == Jieqi.惊蛰
+  # The owning jie's true moment lies AFTER the birth -- that is what a tie looks like.
+  assert owning.moment > bazi.solar_datetime
+  # `ganzhi_date` stays a day-level channel: on the jieqi's own day the two channels agree
+  # (DAY gives the whole day to the new side), but for the cross-midnight tie birth on the
+  # PREVIOUS day they legitimately disagree.
+  assert bazi.ganzhi_date.year == 2009
+  advance: Bazi = Bazi.create('2009-02-03 23:30', 'male', 'hour')
+  assert advance.ganzhi_year == 2009
+  assert advance.ganzhi_date.year == 2008
+
+@pytest.mark.slow
+def test_attribution_matches_scan_oracle() -> None:
+  '''
+  Independent oracle, two derivations compared:
+  - Year: compare the truncated birth against the truncated 立春 of its solar year directly.
+  - Month: linearly scan all nearby Jies and take the LAST one whose truncated moment is
+    <= the truncated birth (ties go new), then map it to a month via literal data.
+  The scan shares none of `Bazi.__init__`'s bracketing/tie-flip shortcut, so a bug in
+  either derivation shows up as a mismatch.
+
+  Also pins the divergence-from-DAY shape: a finer granularity may disagree with DAY only
+  around a jie's own day -- retreating (jieqi-day birth before the jie's truncated moment)
+  or advancing (previous-day 晚子时 birth tying a 00:xx jie across midnight). Both windows
+  are sampled densely by biasing half the moments to fall near a jie.
+  '''
+  utils = calendar_utils_of(CalendarBackend.CELESTIAL)
+  rng = random.Random(6) # Deterministic sampling; seeded with the issue number.
+
+  all_jies: list[Jieqi] = Jieqi.as_list(ganzhi_year=False)[::2]
+
+  def __random_moment() -> datetime:
+    uniform: datetime = datetime(
+      rng.randint(1902, 2080), rng.randint(1, 12), rng.randint(1, 28),
+      rng.randint(0, 23), rng.randint(0, 59),
+    )
+    if rng.random() < 0.5:
+      return uniform
+    # Bias near a jie so tie windows (rare under uniform sampling) are exercised densely.
+    jie_moment: datetime = utils.jieqi_moment(uniform.year, rng.choice(all_jies))
+    biased: datetime = jie_moment + timedelta(minutes=rng.randint(-180, 180))
+    return biased.replace(second=0, microsecond=0)
+
+  total: int = 30_000
+  divergent: int = 0
+  for _ in range(total):
+    birth: datetime = __random_moment()
+    day_bazi: Bazi = Bazi(birth, BaziGender.女, BaziPrecision.DAY)
+
+    candidates: list[JieqiTime] = sorted(
+      (JieqiTime(jie, utils.jieqi_moment(year, jie))
+       for year in (birth.year - 1, birth.year) for jie in all_jies),
+      key=lambda jt: jt.moment,
+    )
+
     for precision in (BaziPrecision.HOUR, BaziPrecision.MINUTE):
-      with self.subTest(precision=precision), self.assertRaises(ValueError):
-        Bazi(datetime(2000, 2, 4, 19, 30), BaziGender.MALE, precision, CalendarBackend.HKO)
-    self.assertEqual(str(Bazi.create('2000-02-04 19:30', 'male', 'day', backend='hko').year_pillar), '庚辰')
+      bazi: Bazi = Bazi(birth, BaziGender.女, precision)
 
-  def test_ganzhi_year_and_bracketing_jies_are_the_attribution(self) -> None:
-    '''`ganzhi_year` / `bracketing_jies` expose exactly what the pillars were derived from.'''
-    bazi: Bazi = Bazi.create('2009-02-04 00:30', 'male', 'hour')
-    self.assertEqual(bazi.ganzhi_year, 2009)
-    owning, following = bazi.bracketing_jies
-    self.assertEqual(owning, JieqiTime(Jieqi.立春, datetime(2009, 2, 4, 0, 49, 48)))
-    self.assertEqual(following.jieqi, Jieqi.惊蛰)
-    # The owning jie's true moment lies AFTER the birth -- that is what a tie looks like.
-    self.assertGreater(owning.moment, bazi.solar_datetime)
-    # `ganzhi_date` stays a day-level channel: on the jieqi's own day the two channels agree
-    # (DAY gives the whole day to the new side), but for the cross-midnight tie birth on the
-    # PREVIOUS day they legitimately disagree.
-    self.assertEqual(bazi.ganzhi_date.year, 2009)
-    advance: Bazi = Bazi.create('2009-02-03 23:30', 'male', 'hour')
-    self.assertEqual(advance.ganzhi_year, 2009)
-    self.assertEqual(advance.ganzhi_date.year, 2008)
+      trunc_birth: datetime = _truncated(birth, precision)
+      lichun: datetime = utils.jieqi_moment(birth.year, Jieqi.立春)
+      expected_year: int = birth.year if trunc_birth >= _truncated(lichun, precision) else birth.year - 1
+      assert bazi.ganzhi_year == expected_year
 
-  @pytest.mark.slow
-  def test_attribution_matches_scan_oracle(self) -> None:
-    '''
-    Independent oracle, two derivations compared:
-    - Year: compare the truncated birth against the truncated 立春 of its solar year directly.
-    - Month: linearly scan all nearby Jies and take the LAST one whose truncated moment is
-      <= the truncated birth (ties go new), then map it to a month via literal data.
-    The scan shares none of `Bazi.__init__`'s bracketing/tie-flip shortcut, so a bug in
-    either derivation shows up as a mismatch.
-
-    Also pins the divergence-from-DAY shape: a finer granularity may disagree with DAY only
-    around a jie's own day -- retreating (jieqi-day birth before the jie's truncated moment)
-    or advancing (previous-day 晚子时 birth tying a 00:xx jie across midnight). Both windows
-    are sampled densely by biasing half the moments to fall near a jie.
-    '''
-    utils = calendar_utils_of(CalendarBackend.CELESTIAL)
-    rng = random.Random(6) # Deterministic sampling; seeded with the issue number.
-
-    all_jies: list[Jieqi] = Jieqi.as_list(ganzhi_year=False)[::2]
-
-    def __random_moment() -> datetime:
-      uniform: datetime = datetime(
-        rng.randint(1902, 2080), rng.randint(1, 12), rng.randint(1, 28),
-        rng.randint(0, 23), rng.randint(0, 59),
-      )
-      if rng.random() < 0.5:
-        return uniform
-      # Bias near a jie so tie windows (rare under uniform sampling) are exercised densely.
-      jie_moment: datetime = utils.jieqi_moment(uniform.year, rng.choice(all_jies))
-      biased: datetime = jie_moment + timedelta(minutes=rng.randint(-180, 180))
-      return biased.replace(second=0, microsecond=0)
-
-    total: int = 30_000
-    divergent: int = 0
-    for _ in range(total):
-      birth: datetime = __random_moment()
-      day_bazi: Bazi = Bazi(birth, BaziGender.女, BaziPrecision.DAY)
-
-      candidates: list[JieqiTime] = sorted(
-        (JieqiTime(jie, utils.jieqi_moment(year, jie))
-         for year in (birth.year - 1, birth.year) for jie in all_jies),
+      owning: JieqiTime = max(
+        (jt for jt in candidates if _truncated(jt.moment, precision) <= trunc_birth),
         key=lambda jt: jt.moment,
       )
+      assert bazi.month_commander == JIE_MONTH_DIZHI[owning.jieqi]
 
-      for precision in (BaziPrecision.HOUR, BaziPrecision.MINUTE):
-        with self.subTest(birth=birth, precision=precision):
-          bazi: Bazi = Bazi(birth, BaziGender.女, precision)
+      # Divergence-from-DAY shape: only inside a tie window around a jie's own day.
+      if (bazi.year_pillar, bazi.month_commander) != (day_bazi.year_pillar, day_bazi.month_commander):
+        divergent += 1
+        day_owning: JieqiTime = max(
+          (jt for jt in candidates if jt.moment.date() <= birth.date()),
+          key=lambda jt: jt.moment,
+        )
+        if owning.moment > day_owning.moment:  # Advance: cross-midnight 晚子时 tie.
+          assert precision is BaziPrecision.HOUR
+          assert _truncated(owning.moment, precision) == trunc_birth
+          assert birth.date() < owning.moment.date()
+        else:                                  # Retreat: jieqi-day birth before the moment.
+          assert birth.date() == day_owning.moment.date()
+          assert trunc_birth < _truncated(day_owning.moment, precision)
 
-          trunc_birth: datetime = self.__truncated(birth, precision)
-          lichun: datetime = utils.jieqi_moment(birth.year, Jieqi.立春)
-          expected_year: int = birth.year if trunc_birth >= self.__truncated(lichun, precision) else birth.year - 1
-          self.assertEqual(bazi.ganzhi_year, expected_year)
+  # The biased sampling must actually have exercised the divergence windows.
+  assert divergent > 100
 
-          owning: JieqiTime = max(
-            (jt for jt in candidates if self.__truncated(jt.moment, precision) <= trunc_birth),
-            key=lambda jt: jt.moment,
-          )
-          self.assertEqual(bazi.month_commander, self.JIE_MONTH_DIZHI[owning.jieqi])
+def test_minute_vs_moment_level_prev_jie() -> None:
+  '''
+  MINUTE attribution vs the moment-level `prev_jie`: the two may disagree ONLY at a
+  same-minute tie (birth in the same minute as the jieqi but before its true second --
+  ties go new, `prev_jie` stays old). At any other moment they must agree, and the
+  sampling must actually produce ties -- without the floor assertion, an implementation
+  degenerated to pure moment-level `prev_jie` would sail through green.
+  '''
+  utils = calendar_utils_of(CalendarBackend.CELESTIAL)
+  rng = random.Random(72) # Seeded with the issue this rule closes.
 
-          # Divergence-from-DAY shape: only inside a tie window around a jie's own day.
-          if (bazi.year_pillar, bazi.month_commander) != (day_bazi.year_pillar, day_bazi.month_commander):
-            divergent += 1
-            day_owning: JieqiTime = max(
-              (jt for jt in candidates if jt.moment.date() <= birth.date()),
-              key=lambda jt: jt.moment,
-            )
-            if owning.moment > day_owning.moment:  # Advance: cross-midnight 晚子时 tie.
-              self.assertIs(precision, BaziPrecision.HOUR)
-              self.assertEqual(self.__truncated(owning.moment, precision), trunc_birth)
-              self.assertLess(birth.date(), owning.moment.date())
-            else:                                  # Retreat: jieqi-day birth before the moment.
-              self.assertEqual(birth.date(), day_owning.moment.date())
-              self.assertLess(trunc_birth, self.__truncated(day_owning.moment, precision))
+  all_jies: list[Jieqi] = Jieqi.as_list(ganzhi_year=False)[::2]
+  disagree: int = 0
+  for _ in range(2_000):
+    jie_moment: datetime = utils.jieqi_moment(rng.randint(1902, 2080), rng.choice(all_jies))
+    birth: datetime = (jie_moment + timedelta(seconds=rng.randint(-90, 90))).replace(second=0, microsecond=0)
 
-    # The biased sampling must actually have exercised the divergence windows.
-    self.assertGreater(divergent, 100)
+    bazi: Bazi = Bazi(birth, BaziGender.男, BaziPrecision.MINUTE)
+    moment_owning: JieqiTime = utils.prev_jie(birth)
+    attribution_owning: JieqiTime = bazi.bracketing_jies[0]
 
-  def test_minute_vs_moment_level_prev_jie(self) -> None:
-    '''
-    MINUTE attribution vs the moment-level `prev_jie`: the two may disagree ONLY at a
-    same-minute tie (birth in the same minute as the jieqi but before its true second --
-    ties go new, `prev_jie` stays old). At any other moment they must agree, and the
-    sampling must actually produce ties -- without the floor assertion, an implementation
-    degenerated to pure moment-level `prev_jie` would sail through green.
-    '''
-    utils = calendar_utils_of(CalendarBackend.CELESTIAL)
-    rng = random.Random(72) # Seeded with the issue this rule closes.
+    if attribution_owning != moment_owning:
+      disagree += 1
+      next_j: JieqiTime = utils.next_jie(birth)
+      assert attribution_owning == next_j
+      assert next_j.moment.replace(second=0, microsecond=0) == birth # Same minute.
+      assert birth < next_j.moment                                   # Before the true second.
+    assert bazi.month_commander == JIE_MONTH_DIZHI[attribution_owning.jieqi]
 
-    all_jies: list[Jieqi] = Jieqi.as_list(ganzhi_year=False)[::2]
-    disagree: int = 0
-    for _ in range(2_000):
-      jie_moment: datetime = utils.jieqi_moment(rng.randint(1902, 2080), rng.choice(all_jies))
-      birth: datetime = (jie_moment + timedelta(seconds=rng.randint(-90, 90))).replace(second=0, microsecond=0)
-
-      bazi: Bazi = Bazi(birth, BaziGender.男, BaziPrecision.MINUTE)
-      moment_owning: JieqiTime = utils.prev_jie(birth)
-      attribution_owning: JieqiTime = bazi.bracketing_jies[0]
-
-      with self.subTest(birth=birth):
-        if attribution_owning != moment_owning:
-          disagree += 1
-          next_j: JieqiTime = utils.next_jie(birth)
-          self.assertEqual(attribution_owning, next_j)
-          self.assertEqual(next_j.moment.replace(second=0, microsecond=0), birth) # Same minute.
-          self.assertLess(birth, next_j.moment)                                   # Before the true second.
-        self.assertEqual(bazi.month_commander, self.JIE_MONTH_DIZHI[attribution_owning.jieqi])
-
-    self.assertGreater(disagree, 0) # At seed 72 the ties number in the hundreds.
+  assert disagree > 0 # At seed 72 the ties number in the hundreds.
 
 
-class TestBazi(unittest.TestCase):
-  def test_init(self) -> None:
-    for _ in range(128):
-      random_dt: datetime = datetime(
-        year=random.randint(1950, 2000),
-        month=random.randint(1, 12),
-        day=random.randint(1, 28),
-        hour=random.randint(0, 23),
-        minute=random.randint(0, 59),
-        second=random.randint(0, 59)
-      )
-
-      bazi: Bazi = Bazi(
-        birth_time=random_dt,
-        gender=BaziGender.男,
-        precision=BaziPrecision.DAY,
-      )
-
-      self.assertEqual(bazi.solar_date, date(random_dt.year, random_dt.month, random_dt.day))
-      self.assertEqual(bazi.hour, random_dt.hour)
-      self.assertEqual(bazi.minute, random_dt.minute)
-      self.assertEqual(bazi.gender, BaziGender.男)
-      self.assertEqual(bazi.precision, BaziPrecision.DAY)
-
-  def test_chinese(self) -> None:
-    self.assertIs(Bazi, 八字)
-
-    for _ in range(128):
-      random_dt: datetime = datetime(
-        year=random.randint(1950, 2000),
-        month=random.randint(1, 12),
-        day=random.randint(1, 28),
-        hour=random.randint(0, 23),
-        minute=random.randint(0, 59),
-        second=random.randint(0, 59)
-      )
-
-      bazi: 八字 = 八字(
-        birth_time=random_dt,
-        gender=BaziGender.男,
-        precision=BaziPrecision.DAY,
-      )
-
-      self.assertEqual(bazi.solar_date, date(random_dt.year, random_dt.month, random_dt.day))
-      self.assertEqual(bazi.hour, random_dt.hour)
-      self.assertEqual(bazi.minute, random_dt.minute)
-      self.assertEqual(bazi.gender, BaziGender.男)
-      self.assertEqual(bazi.precision, BaziPrecision.DAY)
-
-  def test_invalid_arguments(self) -> None:
+def test_init() -> None:
+  for _ in range(128):
     random_dt: datetime = datetime(
       year=random.randint(1950, 2000),
       month=random.randint(1, 12),
@@ -367,289 +302,335 @@ class TestBazi(unittest.TestCase):
       second=random.randint(0, 59)
     )
 
-    with self.assertRaises(TypeError):
-      Bazi(birth_time=random_dt, gender=BaziGender.男) # type: ignore # Missing `precision`
-    with self.assertRaises(TypeError):
-      Bazi(birth_time=random_dt, precision=BaziPrecision.DAY) # type: ignore # Missing `gender`
-    with self.assertRaises(AssertionError):
-      Bazi(birth_time='2024-03-03', gender=BaziGender.男, precision=BaziPrecision.DAY) # type: ignore # Currently doesn't take string as input
-    with self.assertRaises(AssertionError):
-      Bazi(birth_time=date(9999, 1, 1), gender=BaziGender.男, precision=BaziPrecision.DAY) # type: ignore
-    with self.assertRaises(AssertionError):
-      dt: datetime = datetime(
-        year=9999, # Out of supported range.
-        month=random.randint(1, 12),
-        day=random.randint(1, 28),
-        hour=random.randint(0, 23),
-        minute=random.randint(0, 59),
-        second=random.randint(0, 59)
-      )
-      Bazi(birth_time=dt, gender=BaziGender.男, precision=BaziPrecision.DAY)
-    with self.assertRaises(AssertionError):
-      Bazi(
-        birth_time=datetime(
-          year=2000,
-          month=1,
-          day=1,
-          hour=7,
-          minute=0,
-          second=0,
-          tzinfo=ZoneInfo('Asia/Shanghai') # Doesn't support timezone.
-        ),
-        gender=BaziGender.男,
-        precision=BaziPrecision.DAY,
-      )
-
-  @staticmethod
-  def __create_bazi(dt: datetime) -> Bazi:
-    return Bazi(
-      birth_time=dt,
-      gender=BaziGender.男,
-      precision=BaziPrecision.DAY,
-    )
-
-  def test_four_dizhis_correctness(self) -> None:
-    '''
-    Test the correctness of `Bazi` on the given test cases.
-    Precision is at `DAY` level.
-    '''
-    def __subtest(dt: datetime, dizhi_strs: list[str]) -> None:
-      assert len(dizhi_strs) == 4
-
-      bazi = self.__create_bazi(dt)
-      self.assertEqual(bazi.four_dizhis, (
-        Dizhi.from_str(dizhi_strs[0]),
-        Dizhi.from_str(dizhi_strs[1]),
-        Dizhi.from_str(dizhi_strs[2]),
-        Dizhi.from_str(dizhi_strs[3]),
-      ))
-
-    with self.subTest('Basic cases'):
-      # Data was collected from "测测" app on my iPhone 15 Pro Max.
-      __subtest(datetime(2024, 2, 6, 11, 55), ['辰', '寅', '子', '午'])
-      __subtest(datetime(1984, 4, 2, 4, 2), ['子', '卯', '寅', '寅'])
-
-      __subtest(datetime(1998, 3, 17, 13, 0), ['寅', '卯', '亥', '未'])
-      __subtest(datetime(1998, 3, 17, 13, 59), ['寅', '卯', '亥', '未'])
-      __subtest(datetime(1998, 3, 17, 14, 0), ['寅', '卯', '亥', '未'])
-      __subtest(datetime(1998, 3, 17, 14, 59), ['寅', '卯', '亥', '未'])
-      __subtest(datetime(1998, 3, 17, 15, 0), ['寅', '卯', '亥', '申'])
-      __subtest(datetime(1998, 3, 17, 23, 0), ['寅', '卯', '子', '子'])
-      __subtest(datetime(1998, 3, 18, 0, 59), ['寅', '卯', '子', '子'])
-      __subtest(datetime(1998, 3, 18, 1, 0), ['寅', '卯', '子', '丑'])
-
-    with self.subTest('Edge cases'):
-      __subtest(datetime(1998, 3, 17, 13, 0), ['寅', '卯', '亥', '未'])
-      __subtest(datetime(1998, 3, 17, 13, 59), ['寅', '卯', '亥', '未'])
-      __subtest(datetime(1998, 3, 17, 14, 0), ['寅', '卯', '亥', '未'])
-      __subtest(datetime(1998, 3, 17, 14, 59), ['寅', '卯', '亥', '未'])
-      __subtest(datetime(1998, 3, 17, 15, 0), ['寅', '卯', '亥', '申'])
-      __subtest(datetime(1998, 3, 17, 23, 0), ['寅', '卯', '子', '子'])
-      __subtest(datetime(1998, 3, 18, 0, 59), ['寅', '卯', '子', '子'])
-      __subtest(datetime(1998, 3, 18, 1, 0), ['寅', '卯', '子', '丑'])
-
-      __subtest(datetime(2000, 2, 3, 0, 0), ['卯', '丑', '卯', '子'])
-      __subtest(datetime(2000, 2, 3, 22, 59), ['卯', '丑', '卯', '亥'])
-      __subtest(datetime(2000, 2, 3, 23, 0), ['卯', '丑', '辰', '子'])
-      __subtest(datetime(2000, 2, 4, 0, 0), ['辰', '寅', '辰', '子'])
-      __subtest(datetime(2000, 2, 4, 1, 0), ['辰', '寅', '辰', '丑'])
-
-  def test_four_tiangans_correctness(self) -> None:
-    def __subtest(dt: datetime, tiangan_strs: list[str]) -> None:
-      assert len(tiangan_strs) == 4
-
-      bazi = self.__create_bazi(dt)
-      self.assertEqual(bazi.four_tiangans, (
-        Tiangan.from_str(tiangan_strs[0]),
-        Tiangan.from_str(tiangan_strs[1]),
-        Tiangan.from_str(tiangan_strs[2]),
-        Tiangan.from_str(tiangan_strs[3]),
-      ))
-
-    __subtest(datetime(1984, 4, 2, 4, 2), ['甲', '丁', '丙', '庚'])
-    __subtest(datetime(2000, 2, 4, 22, 1), ['庚', '戊', '壬', '辛'])
-    __subtest(datetime(2001, 10, 20, 19, 0), ['辛', '戊', '丙', '戊'])
-
-  def test_ganzhi_date(self) -> None:
-    bazi: Bazi = self.__create_bazi(datetime(1984, 4, 2, 4, 2))
-    self.assertEqual(bazi.ganzhi_date, hko_data_utils.to_ganzhi(date(1984, 4, 2)))
-    
-    for _ in range(10):
-      bazi = Bazi.random()
-      self.assertEqual(bazi.ganzhi_date, hko_data_utils.to_ganzhi(bazi.solar_date))
-
-  def test_date_time(self) -> None:
-    bazi: Bazi = self.__create_bazi(datetime(1984, 4, 2, 4, 2))
-    self.assertEqual(bazi.solar_date, date(1984, 4, 2))
-    self.assertEqual(bazi.hour, 4)
-    self.assertEqual(bazi.minute, 2)
-    self.assertEqual(bazi.solar_datetime, datetime(1984, 4, 2, 4, 2))
-
-    random_bazi: Bazi = Bazi.random()
-    with self.assertRaises(AttributeError):
-      random_bazi.solar_date = date(1984, 4, 3) # type: ignore
-    with self.assertRaises(AttributeError):
-      random_bazi.hour = 9 # type: ignore
-    with self.assertRaises(AttributeError):
-      random_bazi.minute = 8 # type: ignore
-    with self.assertRaises(AttributeError):
-      random_bazi.solar_datetime = datetime(1984, 4, 3, 9, 8) # type: ignore
-  
-  def test_pillars(self) -> None:
-    def __subtest(dt: datetime, ganzhi_strs: list[str]) -> None:
-      assert len(ganzhi_strs) == 4
-
-      bazi = self.__create_bazi(dt)
-      pillars: list[Ganzhi] = list(bazi.pillars)
-      self.assertEqual(pillars[0], Ganzhi.from_str(ganzhi_strs[0]), 'Year Pillar')
-      self.assertEqual(pillars[1], Ganzhi.from_str(ganzhi_strs[1]), 'Month Pillar')
-      self.assertEqual(pillars[2], Ganzhi.from_str(ganzhi_strs[2]), 'Day Pillar')
-      self.assertEqual(pillars[3], Ganzhi.from_str(ganzhi_strs[3]), 'Hour Pillar')
-
-    __subtest(datetime(1984, 4, 2, 4, 2), ['甲子', '丁卯', '丙寅', '庚寅'])
-    __subtest(datetime(2000, 2, 4, 22, 1), ['庚辰', '戊寅', '壬辰', '辛亥'])
-    __subtest(datetime(2001, 10, 20, 19, 0), ['辛巳', '戊戌', '丙辰', '戊戌'])
-
-  def test_consistency(self) -> None:
-    def __subtest(dt: datetime, ganzhi_strs: list[str]) -> None:
-      assert len(ganzhi_strs) == 4
-
-      bazi = self.__create_bazi(dt)
-      pillars: list[Ganzhi] = list(bazi.pillars)
-
-      self.assertEqual(bazi.day_master, pillars[2].tiangan)
-      self.assertEqual(bazi.month_commander, pillars[1].dizhi)
-
-      self.assertEqual(bazi.year_pillar, pillars[0])
-      self.assertEqual(bazi.month_pillar, pillars[1])
-      self.assertEqual(bazi.day_pillar, pillars[2])
-      self.assertEqual(bazi.hour_pillar, pillars[3])
-
-      self.assertEqual(bazi.four_tiangans, tuple([tg for tg, _ in pillars]))
-      self.assertEqual(bazi.four_dizhis, tuple([dz for _, dz in pillars]))
-
-    __subtest(datetime(1984, 4, 2, 4, 2), ['甲子', '丁卯', '丙寅', '庚寅'])
-    __subtest(datetime(2000, 2, 4, 22, 1), ['庚辰', '戊寅', '壬辰', '辛亥'])
-    __subtest(datetime(2001, 10, 20, 19, 0), ['辛巳', '戊戌', '丙辰', '戊戌'])
-
-  def test_deepcopy(self) -> None:
     bazi: Bazi = Bazi(
-      birth_time=datetime(1984, 4, 2, 4, 2),
+      birth_time=random_dt,
       gender=BaziGender.男,
       precision=BaziPrecision.DAY,
     )
-    bazi2: Bazi = copy.deepcopy(bazi)
 
-    self.assertIsNot(bazi._solar_date, bazi2._solar_date)
-    self.assertIsNot(bazi._year_pillar, bazi2._year_pillar)
+    assert bazi.solar_date == date(random_dt.year, random_dt.month, random_dt.day)
+    assert bazi.hour == random_dt.hour
+    assert bazi.minute == random_dt.minute
+    assert bazi.gender == BaziGender.男
+    assert bazi.precision == BaziPrecision.DAY
 
-    self.assertIsNot(bazi._day_pillar, bazi2._day_pillar)
-    self.assertEqual(bazi._day_pillar, bazi2._day_pillar)
+def test_chinese() -> None:
+  assert Bazi is 八字
 
-    cycle: list[Ganzhi] = Ganzhi.list_sexagenary_cycle()
-    next_day_pillar: Ganzhi = cycle[(cycle.index(bazi._day_pillar) + 1) % len(cycle)]
-    bazi._day_pillar = next_day_pillar # type: ignore
-    self.assertNotEqual(bazi._day_pillar, bazi2._day_pillar)
+  for _ in range(128):
+    random_dt: datetime = datetime(
+      year=random.randint(1950, 2000),
+      month=random.randint(1, 12),
+      day=random.randint(1, 28),
+      hour=random.randint(0, 23),
+      minute=random.randint(0, 59),
+      second=random.randint(0, 59)
+    )
 
-  def test_create(self) -> None:
-    with self.assertRaises(ValueError):
-      Bazi.create('WrongDatetimeFormat', BaziGender.FEMALE, BaziPrecision.DAY)
-    with self.assertRaises(ValueError):
-      Bazi.create(datetime.now(), 'femal', BaziPrecision.DAY)
-    with self.assertRaises(ValueError):
-      Bazi.create(datetime.now(), BaziGender.FEMALE, 'dya')
+    bazi: 八字 = 八字(
+      birth_time=random_dt,
+      gender=BaziGender.男,
+      precision=BaziPrecision.DAY,
+    )
 
-    # Create a datetime and set its timezone to Asia/Shanghai.
-    _dt: datetime = datetime.now()
-    _dt = _dt.replace(tzinfo=ZoneInfo('Asia/Shanghai'))
-    with self.assertRaises(AssertionError):
-      Bazi.create(_dt, BaziGender.FEMALE, BaziPrecision.DAY)
-    with self.assertRaises(AssertionError):
-      Bazi.create(_dt.isoformat(), BaziGender.FEMALE, BaziPrecision.DAY)
+    assert bazi.solar_date == date(random_dt.year, random_dt.month, random_dt.day)
+    assert bazi.hour == random_dt.hour
+    assert bazi.minute == random_dt.minute
+    assert bazi.gender == BaziGender.男
+    assert bazi.precision == BaziPrecision.DAY
 
-    now: datetime = datetime.now()
-    dt_options: list[str | datetime] = [now, now.isoformat()]
-    male_options: list[str | BaziGender] = [BaziGender.男, BaziGender.YANG, BaziGender.阳, 'Male', '男', 'MALE']
-    female_options: list[str | BaziGender] = [BaziGender.YIN, BaziGender.FEMALE, '女', 'FEMALE', 'female']
-    day_precision_options: list[str | BaziPrecision] = [BaziPrecision.DAY, 'day', 'DAY', 'Day', '日', '天', 'd', 'D']
+def test_invalid_arguments() -> None:
+  random_dt: datetime = datetime(
+    year=random.randint(1950, 2000),
+    month=random.randint(1, 12),
+    day=random.randint(1, 28),
+    hour=random.randint(0, 23),
+    minute=random.randint(0, 59),
+    second=random.randint(0, 59)
+  )
 
-    expected_bazi: Bazi = Bazi.create(now, BaziGender.FEMALE, BaziPrecision.DAY)
-    for dt, g, p in product(dt_options, female_options, day_precision_options):
-      bazi = Bazi.create(dt, g, p)
-      self.assertListEqual(list(bazi.pillars), list(expected_bazi.pillars))
-      self.assertEqual(bazi.gender, expected_bazi.gender)
-      self.assertEqual(bazi.precision, expected_bazi.precision)
-      self.assertEqual(bazi.solar_date, expected_bazi.solar_date)
-      self.assertEqual(bazi.hour, expected_bazi.hour)
-      self.assertEqual(bazi.minute, expected_bazi.minute)
-    
-    expected_bazi = Bazi.create(now, BaziGender.MALE, BaziPrecision.DAY)
-    for dt, g, p in product(dt_options, male_options, day_precision_options):
-      bazi = Bazi.create(dt, g, p)
-      self.assertListEqual(list(bazi.pillars), list(expected_bazi.pillars))
-      self.assertEqual(bazi.gender, expected_bazi.gender)
-      self.assertEqual(bazi.precision, expected_bazi.precision)
-      self.assertEqual(bazi.solar_date, expected_bazi.solar_date)
-      self.assertEqual(bazi.hour, expected_bazi.hour)
-      self.assertEqual(bazi.minute, expected_bazi.minute)
+  with pytest.raises(TypeError):
+    Bazi(birth_time=random_dt, gender=BaziGender.男) # type: ignore # Missing `precision`
+  with pytest.raises(TypeError):
+    Bazi(birth_time=random_dt, precision=BaziPrecision.DAY) # type: ignore # Missing `gender`
+  with pytest.raises(AssertionError):
+    Bazi(birth_time='2024-03-03', gender=BaziGender.男, precision=BaziPrecision.DAY) # type: ignore # Currently doesn't take string as input
+  with pytest.raises(AssertionError):
+    Bazi(birth_time=date(9999, 1, 1), gender=BaziGender.男, precision=BaziPrecision.DAY) # type: ignore
+  with pytest.raises(AssertionError):
+    dt: datetime = datetime(
+      year=9999, # Out of supported range.
+      month=random.randint(1, 12),
+      day=random.randint(1, 28),
+      hour=random.randint(0, 23),
+      minute=random.randint(0, 59),
+      second=random.randint(0, 59)
+    )
+    Bazi(birth_time=dt, gender=BaziGender.男, precision=BaziPrecision.DAY)
+  with pytest.raises(AssertionError):
+    Bazi(
+      birth_time=datetime(
+        year=2000,
+        month=1,
+        day=1,
+        hour=7,
+        minute=0,
+        second=0,
+        tzinfo=ZoneInfo('Asia/Shanghai') # Doesn't support timezone.
+      ),
+      gender=BaziGender.男,
+      precision=BaziPrecision.DAY,
+    )
 
-    finer_precision_options: list = [BaziPrecision.HOUR, BaziPrecision.MINUTE, 'hour', 'minute', 'H', 'm', '时', '小时', '分', '分钟']
-    for dt, g, p in product(dt_options, male_options + female_options, finer_precision_options):
-      bazi = Bazi.create(dt, g, p) # Supported since issue #6 -- on the celestial backend only.
-      self.assertIn(bazi.precision, (BaziPrecision.HOUR, BaziPrecision.MINUTE))
-      with self.assertRaises(ValueError):
-        Bazi.create(dt, g, p, backend='hko') # HKO has no real jieqi moments.
+def _create_bazi(dt: datetime) -> Bazi:
+  return Bazi(
+    birth_time=dt,
+    gender=BaziGender.男,
+    precision=BaziPrecision.DAY,
+  )
 
-  def test_eq_ne(self) -> None:
-    def __random_info() -> tuple[datetime, BaziGender, BaziPrecision]:
-      return (datetime(
-        year=random.randint(1950, 2000),
-        month=random.randint(1, 12),
-        day=random.randint(1, 28),
-        hour=random.randint(0, 23),
-        minute=random.randint(0, 59),
-        second=random.randint(0, 59)
-      ), random.choice(list(BaziGender)), BaziPrecision.DAY)
-    
-    def __toggle_gender(g: BaziGender) -> BaziGender:
-      return BaziGender.MALE if g is BaziGender.FEMALE else BaziGender.FEMALE
-    
-    def __inc_datetime(dt: datetime) -> datetime:
-      return dt + timedelta(days=1)
+def test_four_dizhis_correctness() -> None:
+  '''
+  Test the correctness of `Bazi` on the given test cases.
+  Precision is at `DAY` level.
+  '''
+  def __subtest(dt: datetime, dizhi_strs: list[str]) -> None:
+    assert len(dizhi_strs) == 4
 
-    for _ in range(64):
-      dt, gender, precision = __random_info()
+    bazi = _create_bazi(dt)
+    assert bazi.four_dizhis == (
+      Dizhi.from_str(dizhi_strs[0]),
+      Dizhi.from_str(dizhi_strs[1]),
+      Dizhi.from_str(dizhi_strs[2]),
+      Dizhi.from_str(dizhi_strs[3]),
+    )
 
-      bazi: Bazi = Bazi.create(dt, gender, precision)
-      self.assertEqual(bazi, Bazi.create(dt, gender, precision))
-      self.assertNotEqual(bazi, Bazi.create(dt, __toggle_gender(gender), precision))
-      self.assertNotEqual(bazi, Bazi.create(__inc_datetime(dt), gender, precision))
+  # Basic cases
+  # Data was collected from "测测" app on my iPhone 15 Pro Max.
+  __subtest(datetime(2024, 2, 6, 11, 55), ['辰', '寅', '子', '午'])
+  __subtest(datetime(1984, 4, 2, 4, 2), ['子', '卯', '寅', '寅'])
 
-      self.assertNotEqual(bazi, 0)
+  __subtest(datetime(1998, 3, 17, 13, 0), ['寅', '卯', '亥', '未'])
+  __subtest(datetime(1998, 3, 17, 13, 59), ['寅', '卯', '亥', '未'])
+  __subtest(datetime(1998, 3, 17, 14, 0), ['寅', '卯', '亥', '未'])
+  __subtest(datetime(1998, 3, 17, 14, 59), ['寅', '卯', '亥', '未'])
+  __subtest(datetime(1998, 3, 17, 15, 0), ['寅', '卯', '亥', '申'])
+  __subtest(datetime(1998, 3, 17, 23, 0), ['寅', '卯', '子', '子'])
+  __subtest(datetime(1998, 3, 18, 0, 59), ['寅', '卯', '子', '子'])
+  __subtest(datetime(1998, 3, 18, 1, 0), ['寅', '卯', '子', '丑'])
 
-      bazi_hacked: Bazi = Bazi.create(dt, gender, precision)
-      bazi_hacked._precision = BaziPrecision.HOUR # type: ignore # Intended for testing only.
-      self.assertNotEqual(bazi, bazi_hacked)
+  # Edge cases
+  __subtest(datetime(1998, 3, 17, 13, 0), ['寅', '卯', '亥', '未'])
+  __subtest(datetime(1998, 3, 17, 13, 59), ['寅', '卯', '亥', '未'])
+  __subtest(datetime(1998, 3, 17, 14, 0), ['寅', '卯', '亥', '未'])
+  __subtest(datetime(1998, 3, 17, 14, 59), ['寅', '卯', '亥', '未'])
+  __subtest(datetime(1998, 3, 17, 15, 0), ['寅', '卯', '亥', '申'])
+  __subtest(datetime(1998, 3, 17, 23, 0), ['寅', '卯', '子', '子'])
+  __subtest(datetime(1998, 3, 18, 0, 59), ['寅', '卯', '子', '子'])
+  __subtest(datetime(1998, 3, 18, 1, 0), ['寅', '卯', '子', '丑'])
 
-  def test_hash(self) -> None:
-    dt: datetime = datetime(2000, 2, 4, 22, 1)
-    bazi: Bazi = Bazi.create(dt, BaziGender.MALE, BaziPrecision.DAY)
-    same: Bazi = Bazi.create(dt, BaziGender.MALE, BaziPrecision.DAY)
-    self.assertEqual(hash(bazi), hash(same))
-    self.assertEqual(len({bazi, same}), 1) # In sync with `__eq__`: usable for set dedup.
+  __subtest(datetime(2000, 2, 3, 0, 0), ['卯', '丑', '卯', '子'])
+  __subtest(datetime(2000, 2, 3, 22, 59), ['卯', '丑', '卯', '亥'])
+  __subtest(datetime(2000, 2, 3, 23, 0), ['卯', '丑', '辰', '子'])
+  __subtest(datetime(2000, 2, 4, 0, 0), ['辰', '寅', '辰', '子'])
+  __subtest(datetime(2000, 2, 4, 1, 0), ['辰', '寅', '辰', '丑'])
 
-    other: Bazi = Bazi.create(dt, BaziGender.FEMALE, BaziPrecision.DAY)
-    self.assertEqual(len({bazi, same, other}), 2)
+def test_four_tiangans_correctness() -> None:
+  def __subtest(dt: datetime, tiangan_strs: list[str]) -> None:
+    assert len(tiangan_strs) == 4
 
-  def test_sub_minute_truncation(self) -> None:
-    # Two births in the same minute are the same Bazi -- `Bazi.solar_datetime` is the
-    # SSOT on why sub-minute parts are dropped.
-    dt: datetime = datetime(2000, 2, 4, 22, 1)
-    bazi: Bazi = Bazi.create(dt, BaziGender.MALE, BaziPrecision.DAY)
-    sub_minute: Bazi = Bazi.create(dt.replace(second=37, microsecond=999999),
-                                   BaziGender.MALE, BaziPrecision.DAY)
-    self.assertEqual(sub_minute.solar_datetime, dt)
-    self.assertEqual(sub_minute.hour, 22)
-    self.assertEqual(sub_minute.minute, 1)
-    self.assertEqual(bazi, sub_minute)
-    self.assertEqual(hash(bazi), hash(sub_minute))
+    bazi = _create_bazi(dt)
+    assert bazi.four_tiangans == (
+      Tiangan.from_str(tiangan_strs[0]),
+      Tiangan.from_str(tiangan_strs[1]),
+      Tiangan.from_str(tiangan_strs[2]),
+      Tiangan.from_str(tiangan_strs[3]),
+    )
+
+  __subtest(datetime(1984, 4, 2, 4, 2), ['甲', '丁', '丙', '庚'])
+  __subtest(datetime(2000, 2, 4, 22, 1), ['庚', '戊', '壬', '辛'])
+  __subtest(datetime(2001, 10, 20, 19, 0), ['辛', '戊', '丙', '戊'])
+
+def test_ganzhi_date() -> None:
+  bazi: Bazi = _create_bazi(datetime(1984, 4, 2, 4, 2))
+  assert bazi.ganzhi_date == hko_data_utils.to_ganzhi(date(1984, 4, 2))
+
+  for _ in range(10):
+    bazi = Bazi.random()
+    assert bazi.ganzhi_date == hko_data_utils.to_ganzhi(bazi.solar_date)
+
+def test_date_time() -> None:
+  bazi: Bazi = _create_bazi(datetime(1984, 4, 2, 4, 2))
+  assert bazi.solar_date == date(1984, 4, 2)
+  assert bazi.hour == 4
+  assert bazi.minute == 2
+  assert bazi.solar_datetime == datetime(1984, 4, 2, 4, 2)
+
+  random_bazi: Bazi = Bazi.random()
+  with pytest.raises(AttributeError):
+    random_bazi.solar_date = date(1984, 4, 3) # type: ignore
+  with pytest.raises(AttributeError):
+    random_bazi.hour = 9 # type: ignore
+  with pytest.raises(AttributeError):
+    random_bazi.minute = 8 # type: ignore
+  with pytest.raises(AttributeError):
+    random_bazi.solar_datetime = datetime(1984, 4, 3, 9, 8) # type: ignore
+
+def test_pillars() -> None:
+  def __subtest(dt: datetime, ganzhi_strs: list[str]) -> None:
+    assert len(ganzhi_strs) == 4
+
+    bazi = _create_bazi(dt)
+    pillars: list[Ganzhi] = list(bazi.pillars)
+    assert pillars[0] == Ganzhi.from_str(ganzhi_strs[0]), 'Year Pillar'
+    assert pillars[1] == Ganzhi.from_str(ganzhi_strs[1]), 'Month Pillar'
+    assert pillars[2] == Ganzhi.from_str(ganzhi_strs[2]), 'Day Pillar'
+    assert pillars[3] == Ganzhi.from_str(ganzhi_strs[3]), 'Hour Pillar'
+
+  __subtest(datetime(1984, 4, 2, 4, 2), ['甲子', '丁卯', '丙寅', '庚寅'])
+  __subtest(datetime(2000, 2, 4, 22, 1), ['庚辰', '戊寅', '壬辰', '辛亥'])
+  __subtest(datetime(2001, 10, 20, 19, 0), ['辛巳', '戊戌', '丙辰', '戊戌'])
+
+def test_consistency() -> None:
+  def __subtest(dt: datetime, ganzhi_strs: list[str]) -> None:
+    assert len(ganzhi_strs) == 4
+
+    bazi = _create_bazi(dt)
+    pillars: list[Ganzhi] = list(bazi.pillars)
+
+    assert bazi.day_master == pillars[2].tiangan
+    assert bazi.month_commander == pillars[1].dizhi
+
+    assert bazi.year_pillar == pillars[0]
+    assert bazi.month_pillar == pillars[1]
+    assert bazi.day_pillar == pillars[2]
+    assert bazi.hour_pillar == pillars[3]
+
+    assert bazi.four_tiangans == tuple([tg for tg, _ in pillars])
+    assert bazi.four_dizhis == tuple([dz for _, dz in pillars])
+
+  __subtest(datetime(1984, 4, 2, 4, 2), ['甲子', '丁卯', '丙寅', '庚寅'])
+  __subtest(datetime(2000, 2, 4, 22, 1), ['庚辰', '戊寅', '壬辰', '辛亥'])
+  __subtest(datetime(2001, 10, 20, 19, 0), ['辛巳', '戊戌', '丙辰', '戊戌'])
+
+def test_deepcopy() -> None:
+  bazi: Bazi = Bazi(
+    birth_time=datetime(1984, 4, 2, 4, 2),
+    gender=BaziGender.男,
+    precision=BaziPrecision.DAY,
+  )
+  bazi2: Bazi = copy.deepcopy(bazi)
+
+  assert bazi._solar_date is not bazi2._solar_date
+  assert bazi._year_pillar is not bazi2._year_pillar
+
+  assert bazi._day_pillar is not bazi2._day_pillar
+  assert bazi._day_pillar == bazi2._day_pillar
+
+  cycle: list[Ganzhi] = Ganzhi.list_sexagenary_cycle()
+  next_day_pillar: Ganzhi = cycle[(cycle.index(bazi._day_pillar) + 1) % len(cycle)]
+  bazi._day_pillar = next_day_pillar # type: ignore
+  assert bazi._day_pillar != bazi2._day_pillar
+
+def test_create() -> None:
+  with pytest.raises(ValueError):
+    Bazi.create('WrongDatetimeFormat', BaziGender.FEMALE, BaziPrecision.DAY)
+  with pytest.raises(ValueError):
+    Bazi.create(datetime.now(), 'femal', BaziPrecision.DAY)
+  with pytest.raises(ValueError):
+    Bazi.create(datetime.now(), BaziGender.FEMALE, 'dya')
+
+  # Create a datetime and set its timezone to Asia/Shanghai.
+  _dt: datetime = datetime.now()
+  _dt = _dt.replace(tzinfo=ZoneInfo('Asia/Shanghai'))
+  with pytest.raises(AssertionError):
+    Bazi.create(_dt, BaziGender.FEMALE, BaziPrecision.DAY)
+  with pytest.raises(AssertionError):
+    Bazi.create(_dt.isoformat(), BaziGender.FEMALE, BaziPrecision.DAY)
+
+  now: datetime = datetime.now()
+  dt_options: list[str | datetime] = [now, now.isoformat()]
+  male_options: list[str | BaziGender] = [BaziGender.男, BaziGender.YANG, BaziGender.阳, 'Male', '男', 'MALE']
+  female_options: list[str | BaziGender] = [BaziGender.YIN, BaziGender.FEMALE, '女', 'FEMALE', 'female']
+  day_precision_options: list[str | BaziPrecision] = [BaziPrecision.DAY, 'day', 'DAY', 'Day', '日', '天', 'd', 'D']
+
+  expected_bazi: Bazi = Bazi.create(now, BaziGender.FEMALE, BaziPrecision.DAY)
+  for dt, g, p in product(dt_options, female_options, day_precision_options):
+    bazi = Bazi.create(dt, g, p)
+    assert list(bazi.pillars) == list(expected_bazi.pillars)
+    assert bazi.gender == expected_bazi.gender
+    assert bazi.precision == expected_bazi.precision
+    assert bazi.solar_date == expected_bazi.solar_date
+    assert bazi.hour == expected_bazi.hour
+    assert bazi.minute == expected_bazi.minute
+
+  expected_bazi = Bazi.create(now, BaziGender.MALE, BaziPrecision.DAY)
+  for dt, g, p in product(dt_options, male_options, day_precision_options):
+    bazi = Bazi.create(dt, g, p)
+    assert list(bazi.pillars) == list(expected_bazi.pillars)
+    assert bazi.gender == expected_bazi.gender
+    assert bazi.precision == expected_bazi.precision
+    assert bazi.solar_date == expected_bazi.solar_date
+    assert bazi.hour == expected_bazi.hour
+    assert bazi.minute == expected_bazi.minute
+
+  finer_precision_options: list = [BaziPrecision.HOUR, BaziPrecision.MINUTE, 'hour', 'minute', 'H', 'm', '时', '小时', '分', '分钟']
+  for dt, g, p in product(dt_options, male_options + female_options, finer_precision_options):
+    bazi = Bazi.create(dt, g, p) # Supported since issue #6 -- on the celestial backend only.
+    assert bazi.precision in (BaziPrecision.HOUR, BaziPrecision.MINUTE)
+    with pytest.raises(ValueError):
+      Bazi.create(dt, g, p, backend='hko') # HKO has no real jieqi moments.
+
+def test_eq_ne() -> None:
+  def __random_info() -> tuple[datetime, BaziGender, BaziPrecision]:
+    return (datetime(
+      year=random.randint(1950, 2000),
+      month=random.randint(1, 12),
+      day=random.randint(1, 28),
+      hour=random.randint(0, 23),
+      minute=random.randint(0, 59),
+      second=random.randint(0, 59)
+    ), random.choice(list(BaziGender)), BaziPrecision.DAY)
+
+  def __toggle_gender(g: BaziGender) -> BaziGender:
+    return BaziGender.MALE if g is BaziGender.FEMALE else BaziGender.FEMALE
+
+  def __inc_datetime(dt: datetime) -> datetime:
+    return dt + timedelta(days=1)
+
+  for _ in range(64):
+    dt, gender, precision = __random_info()
+
+    bazi: Bazi = Bazi.create(dt, gender, precision)
+    assert bazi == Bazi.create(dt, gender, precision)
+    assert bazi != Bazi.create(dt, __toggle_gender(gender), precision)
+    assert bazi != Bazi.create(__inc_datetime(dt), gender, precision)
+
+    assert bazi != 0
+
+    bazi_hacked: Bazi = Bazi.create(dt, gender, precision)
+    bazi_hacked._precision = BaziPrecision.HOUR # type: ignore # Intended for testing only.
+    assert bazi != bazi_hacked
+
+def test_hash() -> None:
+  dt: datetime = datetime(2000, 2, 4, 22, 1)
+  bazi: Bazi = Bazi.create(dt, BaziGender.MALE, BaziPrecision.DAY)
+  same: Bazi = Bazi.create(dt, BaziGender.MALE, BaziPrecision.DAY)
+  assert hash(bazi) == hash(same)
+  assert len({bazi, same}) == 1 # In sync with `__eq__`: usable for set dedup.
+
+  other: Bazi = Bazi.create(dt, BaziGender.FEMALE, BaziPrecision.DAY)
+  assert len({bazi, same, other}) == 2
+
+def test_sub_minute_truncation() -> None:
+  # Two births in the same minute are the same Bazi -- `Bazi.solar_datetime` is the
+  # SSOT on why sub-minute parts are dropped.
+  dt: datetime = datetime(2000, 2, 4, 22, 1)
+  bazi: Bazi = Bazi.create(dt, BaziGender.MALE, BaziPrecision.DAY)
+  sub_minute: Bazi = Bazi.create(dt.replace(second=37, microsecond=999999),
+                                 BaziGender.MALE, BaziPrecision.DAY)
+  assert sub_minute.solar_datetime == dt
+  assert sub_minute.hour == 22
+  assert sub_minute.minute == 1
+  assert bazi == sub_minute
+  assert hash(bazi) == hash(sub_minute)

--- a/tests/test_bazi_chart.py
+++ b/tests/test_bazi_chart.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2024 Ningqi Wang (0xf3cd) <https://github.com/0xf3cd>
-# test_bazichart.py
+# test_bazi_chart.py
 
 import json
 import copy
@@ -40,8 +40,9 @@ def test_basic() -> None:
   with pytest.raises(AssertionError):
     BaziChart(date(2024, 1, 1))  # type: ignore
 
+
 def test_malicious() -> None:
-  # Modification attemp
+  # Modification attempt
   bazi: Bazi = Bazi(
     birth_time=datetime(1984, 4, 2, 4, 2),
     gender=BaziGender.男,
@@ -62,11 +63,13 @@ def test_malicious() -> None:
   with pytest.raises(TypeError):
     BaziChart(datetime(1984, 4, 2, 4, 2), BaziGender.男, BaziPrecision.DAY) # type: ignore
 
+
 def test_house_of_relationship() -> None:
   for _ in range(5):
     bazi = Bazi.random()
     chart = BaziChart(bazi)
     assert chart.house_of_relationship == bazi.four_dizhis[2]
+
 
 def test_relationship_stars() -> None:
   for _ in range(5):
@@ -82,6 +85,7 @@ def test_relationship_stars() -> None:
     if len(stars.dizhi) != 1:
       assert 2 == len(stars.dizhi)
       assert all(bazi_utils.traits(dz).wuxing is Wuxing.土 for dz in stars.dizhi)
+
 
 def test_traits() -> None:
   bazi: Bazi = Bazi(
@@ -110,6 +114,7 @@ def test_traits() -> None:
     assert bazi_utils.tiangan_traits(pillar.tiangan) == pillar_traits.tiangan
     assert bazi_utils.dizhi_traits(pillar.dizhi) == pillar_traits.dizhi
 
+
 def test_hidden_tiangans() -> None:
   bazi: Bazi = Bazi(
     birth_time=datetime(1984, 4, 2, 4, 2),
@@ -133,6 +138,7 @@ def test_hidden_tiangans() -> None:
   assert dict(hidden_tiangans.hour) == {  # 寅
     Tiangan.甲 : 60, Tiangan.丙 : 30, Tiangan.戊 : 10,
   }
+
 
 def test_shishens() -> None:
   chart: BaziChart = BaziChart(Bazi.create(
@@ -160,6 +166,7 @@ def test_shishens() -> None:
   assert shishens.hour.tiangan == Shishen.偏财
   assert shishens.hour.dizhi == Shishen.偏印
 
+
 def test_nayin() -> None:
   chart: BaziChart = BaziChart(Bazi.create(
     birth_time=datetime(1984, 4, 2, 4, 2),
@@ -179,6 +186,7 @@ def test_nayin() -> None:
   assert nayin.day == '炉中火'
   assert nayin.hour == '松柏木'
 
+
 def test_shier_zhangsheng() -> None:
   chart: BaziChart = BaziChart(Bazi.create(
     birth_time=datetime(1984, 4, 2, 4, 2),
@@ -197,6 +205,7 @@ def test_shier_zhangsheng() -> None:
   assert zhangshengs.month == ShierZhangsheng.沐浴
   assert zhangshengs.day == ShierZhangsheng.长生
   assert zhangshengs.hour == ShierZhangsheng.长生
+
 
 @pytest.mark.slow
 def test_basic_info_correctness() -> None:
@@ -237,6 +246,7 @@ def test_basic_info_correctness() -> None:
       assert tg_shishen == bazi_utils.shishen(day_master, pillar.tiangan)
       assert tg_traits == bazi_utils.tiangan_traits(pillar.tiangan)
 
+
 def test_dayun_sexagenary_cycle() -> None:
   for _ in range(10):
     random_bazi: Bazi = Bazi.random()
@@ -248,6 +258,7 @@ def test_dayun_sexagenary_cycle() -> None:
 
     assert first_60_dayuns == next_60_dayuns
     assert set(first_60_dayuns) == set(Ganzhi.list_sexagenary_cycle())
+
 
 def test_dayun_order() -> None:
   for _ in range(10):
@@ -272,6 +283,7 @@ def test_dayun_order() -> None:
 
     assert first_dayun.ganzhi == expected_first_dayun_gz
     assert chart.dayun_order == expected_order
+
 
 def test_dayun_start_moment() -> None:
   # Golden values from 测测, kept as provenance: 2009-12-30 / 1985-03-05 / 1993-05-25.
@@ -298,6 +310,7 @@ def test_dayun_start_moment() -> None:
     abs=delta,
   )
 
+
 def test_dayun_ganzhi() -> None:
   bazi1: Bazi = Bazi.create(datetime(2000, 2, 4, 22, 1), BaziGender.MALE, BaziPrecision.DAY)
   bazi1_dayun_gen = BaziChart(bazi1).dayun
@@ -316,6 +329,7 @@ def test_dayun_ganzhi() -> None:
   assert next(bazi3_dayun_gen).ganzhi == Ganzhi.from_str('丙寅')
   assert next(bazi3_dayun_gen).ganzhi == Ganzhi.from_str('乙丑')
   assert next(bazi3_dayun_gen).ganzhi == Ganzhi.from_str('甲子')
+
 
 def test_dayun_ganzhi_year() -> None:
   bazi1: Bazi = Bazi.create(datetime(2000, 2, 4, 22, 1), BaziGender.MALE, BaziPrecision.DAY)
@@ -337,8 +351,9 @@ def test_dayun_ganzhi_year() -> None:
     for dayun1, dayun2 in itertools.pairwise(dayun_start_times):
       assert dayun2.ganzhi_year - dayun1.ganzhi_year == 10
 
+
 def test_xiaoyun() -> None:
-  def __subtest(bazi: Bazi, expected_xiaoyun_str: str) -> None:
+  def __check(bazi: Bazi, expected_xiaoyun_str: str) -> None:
     xiaoyuns: tuple[XiaoyunTuple, ...] = BaziChart(bazi).xiaoyun
     expected: list[Ganzhi] = [Ganzhi.from_str(s) for s in expected_xiaoyun_str.split()]
     assert len(xiaoyuns) == len(expected)
@@ -347,19 +362,20 @@ def test_xiaoyun() -> None:
       assert xiaoyuns[age-1].ganzhi == gz
 
   # Data collected from https://p.china95.net/paipan/bazi/
-  __subtest(Bazi.create(datetime(2017, 8, 17, 2, 23), BaziGender.MALE, BaziPrecision.DAY),
+  __check(Bazi.create(datetime(2017, 8, 17, 2, 23), BaziGender.MALE, BaziPrecision.DAY),
             '戊子 丁亥 丙戌 乙酉')
-  __subtest(Bazi.create(datetime(2017, 8, 17, 2, 23), BaziGender.FEMALE, BaziPrecision.DAY),
+  __check(Bazi.create(datetime(2017, 8, 17, 2, 23), BaziGender.FEMALE, BaziPrecision.DAY),
             '庚寅 辛卯 壬辰 癸巳 甲午 乙未 丙申 丁酉')
-  __subtest(Bazi.create(datetime(2017, 8, 16, 2, 23), BaziGender.MALE, BaziPrecision.DAY),
+  __check(Bazi.create(datetime(2017, 8, 16, 2, 23), BaziGender.MALE, BaziPrecision.DAY),
             '丙子 乙亥 甲戌 癸酉')
-  __subtest(Bazi.create(datetime(2017, 4, 16, 2, 23), BaziGender.FEMALE, BaziPrecision.DAY),
+  __check(Bazi.create(datetime(2017, 4, 16, 2, 23), BaziGender.FEMALE, BaziPrecision.DAY),
             '甲寅 乙卯 丙辰 丁巳 戊午 己未 庚申')
 
   # Directed: celestial moves this man's dayun start past 立春 1985, so xiaoyun gains a year
   # (HKO gives '辛卯' alone); china95 lists exactly '辛卯 壬辰' for the same birth.
-  __subtest(Bazi.create(datetime(1984, 4, 2, 4, 2), BaziGender.MALE, BaziPrecision.DAY),
+  __check(Bazi.create(datetime(1984, 4, 2, 4, 2), BaziGender.MALE, BaziPrecision.DAY),
             '辛卯 壬辰')
+
 
 def test_liunian() -> None:
   cycle: list[Ganzhi] = Ganzhi.list_sexagenary_cycle()
@@ -372,6 +388,7 @@ def test_liunian() -> None:
 
     # The first liunian is also the birth ganzhi year.
     assert next(chart.liunian).ganzhi_year == random_bazi.ganzhi_date.year
+
 
 @pytest.mark.slow
 def test_consistency() -> None:
@@ -398,6 +415,7 @@ def test_consistency() -> None:
       assert list(itertools.islice(chart.dayun, 100)) == list(itertools.islice(expected.dayun, 100))
 
       assert chart.json == expected.json
+
 
 @pytest.mark.slow
 def test_json() -> None:
@@ -452,6 +470,7 @@ def test_json() -> None:
     )
 
     assert j == __chart.json
+
 
 def test_json_correctness() -> None:
   chart: BaziChart = BaziChart(Bazi.create(
@@ -526,6 +545,7 @@ def test_json_correctness() -> None:
     'hour': '长生',
   }
 
+
 def test_deepcopy() -> None:
   chart: BaziChart = BaziChart(Bazi.random())
 
@@ -545,6 +565,7 @@ def test_deepcopy() -> None:
 # same attribution source as the pillars (`Bazi.bracketing_jies` / `Bazi.ganzhi_year`), so
 # a chart cannot contradict itself about which jie owns the birth month.
 
+
 def test_backward_dayun_counts_from_the_month_owning_jie() -> None:
   '''
   立春 2009 = 02-04 00:49:48. A HOUR birth at 02-04 00:30 ties into the new year (己丑, 阴),
@@ -558,6 +579,7 @@ def test_backward_dayun_counts_from_the_month_owning_jie() -> None:
   assert not chart.dayun_order
   assert chart.dayun_start_moment == chart.bazi.solar_datetime
 
+
 def test_forward_dayun_skips_the_tie_jie() -> None:
   '''
   Same tie birth, female -> forward. The "next" jie must be the one AFTER the owning 立春,
@@ -569,6 +591,7 @@ def test_forward_dayun_skips_the_tie_jie() -> None:
   birth: datetime = chart.bazi.solar_datetime
   gap: timedelta = datetime(2009, 3, 5, 18, 47, 32) - birth
   assert chart.dayun_start_moment == birth + (gap / timedelta(days=3)) * timedelta(days=365)
+
 
 def test_minute_precision_counts_to_the_true_moment() -> None:
   '''
@@ -582,14 +605,15 @@ def test_minute_precision_counts_to_the_true_moment() -> None:
   gap: timedelta = datetime(2009, 2, 4, 0, 49, 48) - birth
   assert chart.dayun_start_moment == birth + (gap / timedelta(days=3)) * timedelta(days=365)
 
+
 def test_backward_clamp_across_midnight_matches_the_same_shichen() -> None:
   '''
-  R1 convergence find (grok / fable / kimi independently): the cross-midnight tie birth
-  (2009-02-03 23:30, male -> backward, clamp) must produce the SAME xiaoyun and dayun-year
-  face as its same-子时 sibling on the jieqi's own day (02-04 00:30) -- the four pillars
-  are identical, so the charts must be too. Before the fix, the day-level relabel of the
-  clamped start (= the birth itself, whose civil day still carries the OLD year) emptied
-  the xiaoyun and put the first dayun in 2008, contradicting the 己丑 2009 year pillar.
+  The cross-midnight tie birth (2009-02-03 23:30, male -> backward, clamp) must produce
+  the SAME xiaoyun and dayun-year face as its same-子时 sibling on the jieqi's own day
+  (02-04 00:30) -- the four pillars are identical, so the charts must be too. The clamped
+  start (= the birth itself, whose civil day still carries the OLD year) must keep its
+  year-level attribution: the xiaoyun stays populated and the first dayun lands in 2009,
+  agreeing with the 己丑 year pillar.
   '''
   across: BaziChart = BaziChart(Bazi.create('2009-02-03 23:30', 'male', 'hour'))
   same_day: BaziChart = BaziChart(Bazi.create('2009-02-04 00:30', 'male', 'hour'))
@@ -602,6 +626,7 @@ def test_backward_clamp_across_midnight_matches_the_same_shichen() -> None:
   assert len(across.xiaoyun) == 1
   assert next(across.dayun).ganzhi_year == 2009   # == the year pillar's year,
   assert next(same_day.dayun).ganzhi_year == 2009 # on both sides of midnight.
+
 
 @pytest.mark.parametrize('precision, first_year, year_pillar, xiaoyun_len', [
   ('hour', 2009, '己丑', 10),

--- a/tests/test_bazi_chart.py
+++ b/tests/test_bazi_chart.py
@@ -7,7 +7,6 @@ import random
 import itertools
 
 import pytest
-import unittest
 
 from datetime import datetime, date, timedelta
 
@@ -23,614 +22,604 @@ from src.data_types import (
 from src.bazi_chart import BaziChart, BaziJson, 命盘
 
 
-class TestBaziChart(unittest.TestCase):
-  def test_basic(self) -> None:
-    self.assertIs(BaziChart, 命盘)
+def test_basic() -> None:
+  assert BaziChart is 命盘
 
-    bazi: Bazi = Bazi(
-      birth_time=datetime(1984, 4, 2, 4, 2),
-      gender=BaziGender.男,
-      precision=BaziPrecision.DAY,
-    )
-    chart: BaziChart = BaziChart(bazi)
+  bazi: Bazi = Bazi(
+    birth_time=datetime(1984, 4, 2, 4, 2),
+    gender=BaziGender.男,
+    precision=BaziPrecision.DAY,
+  )
+  chart: BaziChart = BaziChart(bazi)
 
-    self.assertEqual(chart.bazi.day_master, bazi.day_master)
-    for tg in Tiangan:
-      if tg is not bazi.day_master:
-        self.assertNotEqual(chart.bazi.day_master, tg)
+  assert chart.bazi.day_master == bazi.day_master
+  for tg in Tiangan:
+    if tg is not bazi.day_master:
+      assert chart.bazi.day_master != tg
 
-    self.assertRaises(AssertionError, lambda: BaziChart(date(2024, 1, 1)))  # type: ignore
+  with pytest.raises(AssertionError):
+    BaziChart(date(2024, 1, 1))  # type: ignore
 
-  def test_malicious(self) -> None:
-    with self.subTest('Modification attemp'):
-      bazi: Bazi = Bazi(
-        birth_time=datetime(1984, 4, 2, 4, 2),
-        gender=BaziGender.男,
-        precision=BaziPrecision.DAY,
-      )
-      chart: BaziChart = BaziChart(bazi)
+def test_malicious() -> None:
+  # Modification attemp
+  bazi: Bazi = Bazi(
+    birth_time=datetime(1984, 4, 2, 4, 2),
+    gender=BaziGender.男,
+    precision=BaziPrecision.DAY,
+  )
+  chart: BaziChart = BaziChart(bazi)
 
-      bazi._day_pillar = Ganzhi.from_str('甲子') # type: ignore
-      self.assertEqual(chart.bazi._day_pillar, Ganzhi.from_str('丙寅'))
-      self.assertEqual(bazi._day_pillar, Ganzhi.from_str('甲子'))
+  bazi._day_pillar = Ganzhi.from_str('甲子') # type: ignore
+  assert chart.bazi._day_pillar == Ganzhi.from_str('丙寅')
+  assert bazi._day_pillar == Ganzhi.from_str('甲子')
 
-    with self.assertRaises(AttributeError):
-      BaziChart(Bazi.random()).bazi = Bazi.random()  # type: ignore
+  with pytest.raises(AttributeError):
+    BaziChart(Bazi.random()).bazi = Bazi.random()  # type: ignore
 
-    with self.subTest('Invalid __init__ parameters'):
-      with self.assertRaises(AssertionError):
-        BaziChart('1984-04-02 04:02:00') # type: ignore
-      with self.assertRaises(TypeError):
-        BaziChart(datetime(1984, 4, 2, 4, 2), BaziGender.男, BaziPrecision.DAY) # type: ignore
+  # Invalid __init__ parameters
+  with pytest.raises(AssertionError):
+    BaziChart('1984-04-02 04:02:00') # type: ignore
+  with pytest.raises(TypeError):
+    BaziChart(datetime(1984, 4, 2, 4, 2), BaziGender.男, BaziPrecision.DAY) # type: ignore
 
-  def test_house_of_relationship(self) -> None:
-    for _ in range(5):
-      bazi = Bazi.random()
-      chart = BaziChart(bazi)
-      self.assertEqual(chart.house_of_relationship, bazi.four_dizhis[2])
+def test_house_of_relationship() -> None:
+  for _ in range(5):
+    bazi = Bazi.random()
+    chart = BaziChart(bazi)
+    assert chart.house_of_relationship == bazi.four_dizhis[2]
 
-  def test_relationship_stars(self) -> None:
-    for _ in range(5):
-      bazi = Bazi.random()
-      chart = BaziChart(bazi)
-      stars = chart.relationship_stars
+def test_relationship_stars() -> None:
+  for _ in range(5):
+    bazi = Bazi.random()
+    chart = BaziChart(bazi)
+    stars = chart.relationship_stars
 
-      expected = Shishen.正财 if bazi.gender is BaziGender.男 else Shishen.正官
-      self.assertEqual(expected, bazi_utils.shishen(bazi.day_master, stars.tiangan))
-      for dz in stars.dizhi:
-        self.assertEqual(expected, bazi_utils.shishen(bazi.day_master, dz))
+    expected = Shishen.正财 if bazi.gender is BaziGender.男 else Shishen.正官
+    assert expected == bazi_utils.shishen(bazi.day_master, stars.tiangan)
+    for dz in stars.dizhi:
+      assert expected == bazi_utils.shishen(bazi.day_master, dz)
 
-      if len(stars.dizhi) != 1:
-        self.assertEqual(2, len(stars.dizhi))
-        self.assertTrue(all(bazi_utils.traits(dz).wuxing is Wuxing.土 for dz in stars.dizhi))
+    if len(stars.dizhi) != 1:
+      assert 2 == len(stars.dizhi)
+      assert all(bazi_utils.traits(dz).wuxing is Wuxing.土 for dz in stars.dizhi)
 
-  def test_traits(self) -> None:
-    bazi: Bazi = Bazi(
-      birth_time=datetime(1984, 4, 2, 4, 2),
-      gender=BaziGender.男,
-      precision=BaziPrecision.DAY,
-    )
-    chart: BaziChart = BaziChart(bazi)
+def test_traits() -> None:
+  bazi: Bazi = Bazi(
+    birth_time=datetime(1984, 4, 2, 4, 2),
+    gender=BaziGender.男,
+    precision=BaziPrecision.DAY,
+  )
+  chart: BaziChart = BaziChart(bazi)
+  traits: BaziData[BaziChart.PillarTraits] = chart.traits
+
+  assert len(list(traits)) == 4
+
+  assert traits.year.tiangan == TraitTuple(Wuxing.木, Yinyang.阳)  # 甲
+  assert traits.year.dizhi == TraitTuple(Wuxing.水, Yinyang.阳)    # 子
+
+  assert traits.month.tiangan == TraitTuple(Wuxing.火, Yinyang.阴) # 丁
+  assert traits.month.dizhi == TraitTuple(Wuxing.木, Yinyang.阴)   # 卯
+
+  assert traits.day.tiangan == TraitTuple(Wuxing.火, Yinyang.阳)   # 丙
+  assert traits.day.dizhi == TraitTuple(Wuxing.木, Yinyang.阳)     # 寅
+
+  assert traits.hour.tiangan == TraitTuple(Wuxing.金, Yinyang.阳)  # 庚
+  assert traits.hour.dizhi == TraitTuple(Wuxing.木, Yinyang.阳)    # 寅
+
+  for pillar, pillar_traits in zip(bazi.pillars, traits):
+    assert bazi_utils.tiangan_traits(pillar.tiangan) == pillar_traits.tiangan
+    assert bazi_utils.dizhi_traits(pillar.dizhi) == pillar_traits.dizhi
+
+def test_hidden_tiangans() -> None:
+  bazi: Bazi = Bazi(
+    birth_time=datetime(1984, 4, 2, 4, 2),
+    gender=BaziGender.男,
+    precision=BaziPrecision.DAY,
+  )
+  chart: BaziChart = BaziChart(bazi)
+  hidden_tiangans: BaziData[HiddenTianganDict] = chart.hidden_tiangan
+
+  assert len(list(hidden_tiangans)) == 4
+
+  assert dict(hidden_tiangans.year) == {  # 子
+    Tiangan.癸 : 100,
+  }
+  assert dict(hidden_tiangans.month) == { # 卯
+    Tiangan.乙 : 100,
+  }
+  assert dict(hidden_tiangans.day) == {   # 寅
+    Tiangan.甲 : 60, Tiangan.丙 : 30, Tiangan.戊 : 10,
+  }
+  assert dict(hidden_tiangans.hour) == {  # 寅
+    Tiangan.甲 : 60, Tiangan.丙 : 30, Tiangan.戊 : 10,
+  }
+
+def test_shishens() -> None:
+  chart: BaziChart = BaziChart(Bazi.create(
+    birth_time=datetime(1984, 4, 2, 4, 2),
+    gender=BaziGender.男,
+    precision=BaziPrecision.DAY,
+  ))
+  shishens: BaziData[BaziChart.PillarShishens] = chart.shishen
+
+  assert len(list(shishens)) == 4
+
+  #           Year    Month     Day     Hour
+  # Tiangan    甲       丁       丙       庚
+  #   Dizhi    子       卯       寅       寅
+
+  assert shishens.year.tiangan == Shishen.偏印
+  assert shishens.year.dizhi == Shishen.正官
+
+  assert shishens.month.tiangan == Shishen.劫财
+  assert shishens.month.dizhi == Shishen.正印
+
+  assert shishens.day.tiangan is None # Day master's shishen is None.
+  assert shishens.day.dizhi == Shishen.偏印
+
+  assert shishens.hour.tiangan == Shishen.偏财
+  assert shishens.hour.dizhi == Shishen.偏印
+
+def test_nayin() -> None:
+  chart: BaziChart = BaziChart(Bazi.create(
+    birth_time=datetime(1984, 4, 2, 4, 2),
+    gender=BaziGender.男,
+    precision=BaziPrecision.DAY,
+  ))
+  nayin: BaziData[str] = chart.nayin
+
+  assert len(list(nayin)) == 4
+
+  #           Year    Month     Day     Hour
+  # Tiangan    甲       丁       丙       庚
+  #   Dizhi    子       卯       寅       寅
+
+  assert nayin.year == '海中金'
+  assert nayin.month == '炉中火'
+  assert nayin.day == '炉中火'
+  assert nayin.hour == '松柏木'
+
+def test_shier_zhangsheng() -> None:
+  chart: BaziChart = BaziChart(Bazi.create(
+    birth_time=datetime(1984, 4, 2, 4, 2),
+    gender=BaziGender.男,
+    precision=BaziPrecision.DAY,
+  ))
+  zhangshengs: BaziData[ShierZhangsheng] = chart.shier_zhangsheng
+
+  assert len(list(zhangshengs)) == 4
+
+  #           Year    Month     Day     Hour
+  # Tiangan    甲       丁       丙       庚
+  #   Dizhi    子       卯       寅       寅
+
+  assert zhangshengs.year == ShierZhangsheng.胎
+  assert zhangshengs.month == ShierZhangsheng.沐浴
+  assert zhangshengs.day == ShierZhangsheng.长生
+  assert zhangshengs.hour == ShierZhangsheng.长生
+
+@pytest.mark.slow
+def test_basic_info_correctness() -> None:
+  '''
+  Test that the results provided by `traits`, `hidden_tiangans`, and `shishens` are correct.
+  '''
+  for _ in range(128):
+    chart: BaziChart = BaziChart(Bazi.random())
+
+    day_master: Tiangan = chart.bazi.day_master
+    pillars: list[Ganzhi] = list(chart.bazi.pillars)
     traits: BaziData[BaziChart.PillarTraits] = chart.traits
-
-    self.assertEqual(len(list(traits)), 4)
-
-    self.assertEqual(traits.year.tiangan, TraitTuple(Wuxing.木, Yinyang.阳))  # 甲
-    self.assertEqual(traits.year.dizhi, TraitTuple(Wuxing.水, Yinyang.阳))    # 子
-
-    self.assertEqual(traits.month.tiangan, TraitTuple(Wuxing.火, Yinyang.阴)) # 丁
-    self.assertEqual(traits.month.dizhi, TraitTuple(Wuxing.木, Yinyang.阴))   # 卯
-
-    self.assertEqual(traits.day.tiangan, TraitTuple(Wuxing.火, Yinyang.阳))   # 丙
-    self.assertEqual(traits.day.dizhi, TraitTuple(Wuxing.木, Yinyang.阳))     # 寅
-
-    self.assertEqual(traits.hour.tiangan, TraitTuple(Wuxing.金, Yinyang.阳))  # 庚
-    self.assertEqual(traits.hour.dizhi, TraitTuple(Wuxing.木, Yinyang.阳))    # 寅
-
-    for pillar, pillar_traits in zip(bazi.pillars, traits):
-      self.assertEqual(bazi_utils.tiangan_traits(pillar.tiangan), pillar_traits.tiangan)
-      self.assertEqual(bazi_utils.dizhi_traits(pillar.dizhi), pillar_traits.dizhi)
-
-  def test_hidden_tiangans(self) -> None:
-    bazi: Bazi = Bazi(
-      birth_time=datetime(1984, 4, 2, 4, 2),
-      gender=BaziGender.男,
-      precision=BaziPrecision.DAY,
-    )
-    chart: BaziChart = BaziChart(bazi)
     hidden_tiangans: BaziData[HiddenTianganDict] = chart.hidden_tiangan
-
-    self.assertEqual(len(list(hidden_tiangans)), 4)
-
-    self.assertDictEqual(dict(hidden_tiangans.year), {  # 子
-      Tiangan.癸 : 100,
-    })
-    self.assertDictEqual(dict(hidden_tiangans.month), { # 卯
-      Tiangan.乙 : 100,
-    })
-    self.assertDictEqual(dict(hidden_tiangans.day), {   # 寅
-      Tiangan.甲 : 60, Tiangan.丙 : 30, Tiangan.戊 : 10,
-    })
-    self.assertDictEqual(dict(hidden_tiangans.hour), {  # 寅
-      Tiangan.甲 : 60, Tiangan.丙 : 30, Tiangan.戊 : 10,
-    })
-
-  def test_shishens(self) -> None:
-    chart: BaziChart = BaziChart(Bazi.create(
-      birth_time=datetime(1984, 4, 2, 4, 2),
-      gender=BaziGender.男,
-      precision=BaziPrecision.DAY,
-    ))
     shishens: BaziData[BaziChart.PillarShishens] = chart.shishen
 
-    self.assertEqual(len(list(shishens)), 4)
+    # The major component in hidden Tiangans of a Dizhi is expected to be of the same Wuxing as the Dizhi.
+    # 地支中的主气（即本气）应该和地支本身的五行一致。
+    for pillar_traits, pillar_hidden_tiangans in zip(traits, hidden_tiangans):
+      major_tiangan: Tiangan = max(pillar_hidden_tiangans.items(), key=lambda pair: pair[1])[0]
+      assert pillar_traits.dizhi.wuxing == bazi_utils.tiangan_traits(major_tiangan).wuxing
 
-    #           Year    Month     Day     Hour
-    # Tiangan    甲       丁       丙       庚
-    #   Dizhi    子       卯       寅       寅
+    # Double-check that the shishens are correct.
+    # 确保各个天干地支的十神准确。
+    for pillar_idx, (pillar, pillar_traits, pillar_shishens) in enumerate(zip(pillars, traits, shishens)):
+      # Check Dizhi.
+      dz_shishen: Shishen = pillar_shishens.dizhi
+      dz_traits: TraitTuple = pillar_traits.dizhi
+      assert dz_shishen == bazi_utils.shishen(day_master, pillar.dizhi)
+      assert dz_traits == bazi_utils.dizhi_traits(pillar.dizhi)
 
-    self.assertEqual(shishens.year.tiangan, Shishen.偏印)
-    self.assertEqual(shishens.year.dizhi, Shishen.正官)
+      # Check Tiangan.
+      tg_shishen: Shishen | None = pillar_shishens.tiangan
+      if pillar_idx == 2: # Day master.
+        assert tg_shishen is None
+        continue
 
-    self.assertEqual(shishens.month.tiangan, Shishen.劫财)
-    self.assertEqual(shishens.month.dizhi, Shishen.正印)
+      tg_traits: TraitTuple = pillar_traits.tiangan
+      assert tg_shishen == bazi_utils.shishen(day_master, pillar.tiangan)
+      assert tg_traits == bazi_utils.tiangan_traits(pillar.tiangan)
 
-    self.assertEqual(shishens.day.tiangan, None) # Day master's shishen is None.
-    self.assertEqual(shishens.day.dizhi, Shishen.偏印)
+def test_dayun_sexagenary_cycle() -> None:
+  for _ in range(10):
+    random_bazi: Bazi = Bazi.random()
+    chart: BaziChart = BaziChart(random_bazi)
 
-    self.assertEqual(shishens.hour.tiangan, Shishen.偏财)
-    self.assertEqual(shishens.hour.dizhi, Shishen.偏印)
+    dayun_gen = chart.dayun
+    first_60_dayuns: list[Ganzhi] = [next(dayun_gen).ganzhi for _ in range(60)]
+    next_60_dayuns: list[Ganzhi] = [next(dayun_gen).ganzhi for _ in range(60)]
 
-  def test_nayin(self) -> None:
-    chart: BaziChart = BaziChart(Bazi.create(
-      birth_time=datetime(1984, 4, 2, 4, 2),
-      gender=BaziGender.男,
-      precision=BaziPrecision.DAY,
-    ))
-    nayin: BaziData[str] = chart.nayin
+    assert first_60_dayuns == next_60_dayuns
+    assert set(first_60_dayuns) == set(Ganzhi.list_sexagenary_cycle())
 
-    self.assertEqual(len(list(nayin)), 4)
+def test_dayun_order() -> None:
+  for _ in range(10):
+    random_bazi: Bazi = Bazi.random()
 
-    #           Year    Month     Day     Hour
-    # Tiangan    甲       丁       丙       庚
-    #   Dizhi    子       卯       寅       寅
+    month_gz: Ganzhi = random_bazi.month_pillar
+    year_dz_yinyaang: Yinyang = bazi_utils.dizhi_traits(random_bazi.year_pillar.dizhi).yinyang
 
-    self.assertEqual(nayin.year, '海中金')
-    self.assertEqual(nayin.month, '炉中火')
-    self.assertEqual(nayin.day, '炉中火')
-    self.assertEqual(nayin.hour, '松柏木')
-
-  def test_shier_zhangsheng(self) -> None:
-    chart: BaziChart = BaziChart(Bazi.create(
-      birth_time=datetime(1984, 4, 2, 4, 2),
-      gender=BaziGender.男,
-      precision=BaziPrecision.DAY,
-    ))
-    zhangshengs: BaziData[ShierZhangsheng] = chart.shier_zhangsheng
-
-    self.assertEqual(len(list(zhangshengs)), 4)
-
-    #           Year    Month     Day     Hour
-    # Tiangan    甲       丁       丙       庚
-    #   Dizhi    子       卯       寅       寅
-
-    self.assertEqual(zhangshengs.year, ShierZhangsheng.胎)
-    self.assertEqual(zhangshengs.month, ShierZhangsheng.沐浴)
-    self.assertEqual(zhangshengs.day, ShierZhangsheng.长生)
-    self.assertEqual(zhangshengs.hour, ShierZhangsheng.长生)
-
-  @pytest.mark.slow
-  def test_basic_info_correctness(self) -> None:
-    '''
-    Test that the results provided by `traits`, `hidden_tiangans`, and `shishens` are correct.
-    '''
-    for _ in range(128):
-      chart: BaziChart = BaziChart(Bazi.random())
-
-      day_master: Tiangan = chart.bazi.day_master
-      pillars: list[Ganzhi] = list(chart.bazi.pillars)
-      traits: BaziData[BaziChart.PillarTraits] = chart.traits
-      hidden_tiangans: BaziData[HiddenTianganDict] = chart.hidden_tiangan
-      shishens: BaziData[BaziChart.PillarShishens] = chart.shishen
-
-      # The major component in hidden Tiangans of a Dizhi is expected to be of the same Wuxing as the Dizhi.
-      # 地支中的主气（即本气）应该和地支本身的五行一致。
-      for pillar_traits, pillar_hidden_tiangans in zip(traits, hidden_tiangans):
-        major_tiangan: Tiangan = max(pillar_hidden_tiangans.items(), key=lambda pair: pair[1])[0]
-        self.assertEqual(pillar_traits.dizhi.wuxing, bazi_utils.tiangan_traits(major_tiangan).wuxing)
-
-      # Double-check that the shishens are correct.
-      # 确保各个天干地支的十神准确。
-      for pillar_idx, (pillar, pillar_traits, pillar_shishens) in enumerate(zip(pillars, traits, shishens)):
-        # Check Dizhi.
-        dz_shishen: Shishen = pillar_shishens.dizhi
-        dz_traits: TraitTuple = pillar_traits.dizhi
-        self.assertEqual(dz_shishen, bazi_utils.shishen(day_master, pillar.dizhi))
-        self.assertEqual(dz_traits, bazi_utils.dizhi_traits(pillar.dizhi))
-
-        # Check Tiangan.
-        tg_shishen: Shishen | None = pillar_shishens.tiangan
-        if pillar_idx == 2: # Day master.
-          self.assertIsNone(tg_shishen)
-          continue
-
-        tg_traits: TraitTuple = pillar_traits.tiangan
-        self.assertEqual(tg_shishen, bazi_utils.shishen(day_master, pillar.tiangan))
-        self.assertEqual(tg_traits, bazi_utils.tiangan_traits(pillar.tiangan))
-
-  def test_dayun_sexagenary_cycle(self) -> None:
-    for _ in range(10):
-      random_bazi: Bazi = Bazi.random()
-      chart: BaziChart = BaziChart(random_bazi)
-
-      dayun_gen = chart.dayun
-      first_60_dayuns: list[Ganzhi] = [next(dayun_gen).ganzhi for _ in range(60)]
-      next_60_dayuns: list[Ganzhi] = [next(dayun_gen).ganzhi for _ in range(60)]
-
-      self.assertListEqual(first_60_dayuns, next_60_dayuns)
-      self.assertSetEqual(set(first_60_dayuns), set(Ganzhi.list_sexagenary_cycle()))
-
-  def test_dayun_order(self) -> None:
-    for _ in range(10):
-      random_bazi: Bazi = Bazi.random()
-      
-      month_gz: Ganzhi = random_bazi.month_pillar
-      year_dz_yinyaang: Yinyang = bazi_utils.dizhi_traits(random_bazi.year_pillar.dizhi).yinyang
-
-      cycle: list[Ganzhi] = Ganzhi.list_sexagenary_cycle()
-      expected_first_dayun_gz: Ganzhi = cycle[(cycle.index(month_gz) + 1) % 60]
-      expected_order: bool = True
-      reverse: bool = (
-        ((random_bazi.gender is BaziGender.男) and (year_dz_yinyaang is Yinyang.阴)) or
-        ((random_bazi.gender is BaziGender.女) and (year_dz_yinyaang is Yinyang.阳))
-      )
-      if reverse:
-        expected_first_dayun_gz = cycle[(cycle.index(month_gz) - 1) % 60]
-        expected_order = False
-      
-      chart: BaziChart = BaziChart(random_bazi)
-      first_dayun = next(chart.dayun)
-
-      self.assertEqual(first_dayun.ganzhi, expected_first_dayun_gz)
-      self.assertEqual(chart.dayun_order, expected_order)
-
-  def test_dayun_start_moment(self) -> None:
-    # Golden values from 测测, kept as provenance: 2009-12-30 / 1985-03-05 / 1993-05-25.
-    # The expectations are the celestial backend's answers, pinned to the shipped tables:
-    # the 3-days-to-1-year rule amplifies jieqi-moment drift ~122x (1s -> ~2min), so any
-    # re-bake that moves a jieqi goes red here -- and trips the frozen table hash first.
-    delta: timedelta = timedelta(seconds=1)
-
-    bazi1: Bazi = Bazi.create(datetime(2000, 2, 4, 22, 1), BaziGender.MALE, BaziPrecision.DAY)
-    self.assertAlmostEqual(
-      BaziChart(bazi1).dayun_start_moment,
-      datetime(2009, 12, 26, 21, 8, 25),
-      delta=delta,
-    )
-
-    bazi2: Bazi = Bazi.create(datetime(1984, 4, 2, 4, 2), BaziGender.MALE, BaziPrecision.DAY)
-    self.assertAlmostEqual(
-      BaziChart(bazi2).dayun_start_moment,
-      datetime(1985, 3, 4, 11, 17, 55),
-      delta=delta,
-    )
-
-    bazi3: Bazi = Bazi.create(datetime(1984, 4, 2, 4, 2), BaziGender.FEMALE, BaziPrecision.DAY)
-    self.assertAlmostEqual(
-      BaziChart(bazi3).dayun_start_moment,
-      datetime(1993, 5, 24, 0, 24, 13, 333333),
-      delta=delta,
-    )
-
-  def test_dayun_ganzhi(self) -> None:
-    bazi1: Bazi = Bazi.create(datetime(2000, 2, 4, 22, 1), BaziGender.MALE, BaziPrecision.DAY)
-    bazi1_dayun_gen = BaziChart(bazi1).dayun
-    self.assertEqual(next(bazi1_dayun_gen).ganzhi, Ganzhi.from_str('己卯'))
-    self.assertEqual(next(bazi1_dayun_gen).ganzhi, Ganzhi.from_str('庚辰'))
-    self.assertEqual(next(bazi1_dayun_gen).ganzhi, Ganzhi.from_str('辛巳'))
-
-    bazi2: Bazi = Bazi.create(datetime(1984, 4, 2, 4, 2), BaziGender.MALE, BaziPrecision.DAY)
-    bazi2_dayun_gen = BaziChart(bazi2).dayun
-    self.assertEqual(next(bazi2_dayun_gen).ganzhi, Ganzhi.from_str('戊辰'))
-    self.assertEqual(next(bazi2_dayun_gen).ganzhi, Ganzhi.from_str('己巳'))
-    self.assertEqual(next(bazi2_dayun_gen).ganzhi, Ganzhi.from_str('庚午'))
-
-    bazi3: Bazi = Bazi.create(datetime(1984, 4, 2, 4, 2), BaziGender.FEMALE, BaziPrecision.DAY)
-    bazi3_dayun_gen = BaziChart(bazi3).dayun
-    self.assertEqual(next(bazi3_dayun_gen).ganzhi, Ganzhi.from_str('丙寅'))
-    self.assertEqual(next(bazi3_dayun_gen).ganzhi, Ganzhi.from_str('乙丑'))
-    self.assertEqual(next(bazi3_dayun_gen).ganzhi, Ganzhi.from_str('甲子'))
-
-  def test_dayun_ganzhi_year(self) -> None:
-    bazi1: Bazi = Bazi.create(datetime(2000, 2, 4, 22, 1), BaziGender.MALE, BaziPrecision.DAY)
-    first_dayun1: DayunTuple = next(BaziChart(bazi1).dayun)
-    self.assertEqual(first_dayun1.ganzhi_year, 2009)
-
-    bazi2: Bazi = Bazi.create(datetime(1984, 4, 2, 4, 2), BaziGender.MALE, BaziPrecision.DAY)
-    first_dayun2: DayunTuple = next(BaziChart(bazi2).dayun)
-    # celestial start 1985-03-04 is past 立春 1985; lunar_python / china95 / 测测 all agree.
-    self.assertEqual(first_dayun2.ganzhi_year, 1985)
-
-    bazi3: Bazi = Bazi.create(datetime(1984, 4, 2, 4, 2), BaziGender.FEMALE, BaziPrecision.DAY)
-    first_dayun3: DayunTuple = next(BaziChart(bazi3).dayun)
-    self.assertEqual(first_dayun3.ganzhi_year, 1993)
-
-    for _ in range(10):
-      random_bazi: Bazi = Bazi.random()
-      dayun_start_times: list[DayunTuple] = list(itertools.islice(BaziChart(random_bazi).dayun, 10))
-      for dayun1, dayun2 in itertools.pairwise(dayun_start_times):
-        self.assertEqual(dayun2.ganzhi_year - dayun1.ganzhi_year, 10)
-
-  def test_xiaoyun(self) -> None:
-    def __subtest(bazi: Bazi, expected_xiaoyun_str: str) -> None:
-      xiaoyuns: tuple[XiaoyunTuple, ...] = BaziChart(bazi).xiaoyun
-      expected: list[Ganzhi] = [Ganzhi.from_str(s) for s in expected_xiaoyun_str.split()]
-      self.assertEqual(len(xiaoyuns), len(expected))
-      for age, gz in enumerate(expected, start=1):
-        self.assertEqual(xiaoyuns[age-1].xusui, age)
-        self.assertEqual(xiaoyuns[age-1].ganzhi, gz)
-    
-    # Data collected from https://p.china95.net/paipan/bazi/
-    __subtest(Bazi.create(datetime(2017, 8, 17, 2, 23), BaziGender.MALE, BaziPrecision.DAY), 
-              '戊子 丁亥 丙戌 乙酉')
-    __subtest(Bazi.create(datetime(2017, 8, 17, 2, 23), BaziGender.FEMALE, BaziPrecision.DAY), 
-              '庚寅 辛卯 壬辰 癸巳 甲午 乙未 丙申 丁酉')
-    __subtest(Bazi.create(datetime(2017, 8, 16, 2, 23), BaziGender.MALE, BaziPrecision.DAY),
-              '丙子 乙亥 甲戌 癸酉')
-    __subtest(Bazi.create(datetime(2017, 4, 16, 2, 23), BaziGender.FEMALE, BaziPrecision.DAY),
-              '甲寅 乙卯 丙辰 丁巳 戊午 己未 庚申')
-
-    # Directed: celestial moves this man's dayun start past 立春 1985, so xiaoyun gains a year
-    # (HKO gives '辛卯' alone); china95 lists exactly '辛卯 壬辰' for the same birth.
-    __subtest(Bazi.create(datetime(1984, 4, 2, 4, 2), BaziGender.MALE, BaziPrecision.DAY),
-              '辛卯 壬辰')
-
-  def test_liunian(self) -> None:
     cycle: list[Ganzhi] = Ganzhi.list_sexagenary_cycle()
-    for _ in range(16):
-      random_bazi: Bazi = Bazi.random()
+    expected_first_dayun_gz: Ganzhi = cycle[(cycle.index(month_gz) + 1) % 60]
+    expected_order: bool = True
+    reverse: bool = (
+      ((random_bazi.gender is BaziGender.男) and (year_dz_yinyaang is Yinyang.阴)) or
+      ((random_bazi.gender is BaziGender.女) and (year_dz_yinyaang is Yinyang.阳))
+    )
+    if reverse:
+      expected_first_dayun_gz = cycle[(cycle.index(month_gz) - 1) % 60]
+      expected_order = False
+
+    chart: BaziChart = BaziChart(random_bazi)
+    first_dayun = next(chart.dayun)
+
+    assert first_dayun.ganzhi == expected_first_dayun_gz
+    assert chart.dayun_order == expected_order
+
+def test_dayun_start_moment() -> None:
+  # Golden values from 测测, kept as provenance: 2009-12-30 / 1985-03-05 / 1993-05-25.
+  # The expectations are the celestial backend's answers, pinned to the shipped tables:
+  # the 3-days-to-1-year rule amplifies jieqi-moment drift ~122x (1s -> ~2min), so any
+  # re-bake that moves a jieqi goes red here -- and trips the frozen table hash first.
+  delta: timedelta = timedelta(seconds=1)
+
+  bazi1: Bazi = Bazi.create(datetime(2000, 2, 4, 22, 1), BaziGender.MALE, BaziPrecision.DAY)
+  assert BaziChart(bazi1).dayun_start_moment == pytest.approx(
+    datetime(2009, 12, 26, 21, 8, 25),
+    abs=delta,
+  )
+
+  bazi2: Bazi = Bazi.create(datetime(1984, 4, 2, 4, 2), BaziGender.MALE, BaziPrecision.DAY)
+  assert BaziChart(bazi2).dayun_start_moment == pytest.approx(
+    datetime(1985, 3, 4, 11, 17, 55),
+    abs=delta,
+  )
+
+  bazi3: Bazi = Bazi.create(datetime(1984, 4, 2, 4, 2), BaziGender.FEMALE, BaziPrecision.DAY)
+  assert BaziChart(bazi3).dayun_start_moment == pytest.approx(
+    datetime(1993, 5, 24, 0, 24, 13, 333333),
+    abs=delta,
+  )
+
+def test_dayun_ganzhi() -> None:
+  bazi1: Bazi = Bazi.create(datetime(2000, 2, 4, 22, 1), BaziGender.MALE, BaziPrecision.DAY)
+  bazi1_dayun_gen = BaziChart(bazi1).dayun
+  assert next(bazi1_dayun_gen).ganzhi == Ganzhi.from_str('己卯')
+  assert next(bazi1_dayun_gen).ganzhi == Ganzhi.from_str('庚辰')
+  assert next(bazi1_dayun_gen).ganzhi == Ganzhi.from_str('辛巳')
+
+  bazi2: Bazi = Bazi.create(datetime(1984, 4, 2, 4, 2), BaziGender.MALE, BaziPrecision.DAY)
+  bazi2_dayun_gen = BaziChart(bazi2).dayun
+  assert next(bazi2_dayun_gen).ganzhi == Ganzhi.from_str('戊辰')
+  assert next(bazi2_dayun_gen).ganzhi == Ganzhi.from_str('己巳')
+  assert next(bazi2_dayun_gen).ganzhi == Ganzhi.from_str('庚午')
+
+  bazi3: Bazi = Bazi.create(datetime(1984, 4, 2, 4, 2), BaziGender.FEMALE, BaziPrecision.DAY)
+  bazi3_dayun_gen = BaziChart(bazi3).dayun
+  assert next(bazi3_dayun_gen).ganzhi == Ganzhi.from_str('丙寅')
+  assert next(bazi3_dayun_gen).ganzhi == Ganzhi.from_str('乙丑')
+  assert next(bazi3_dayun_gen).ganzhi == Ganzhi.from_str('甲子')
+
+def test_dayun_ganzhi_year() -> None:
+  bazi1: Bazi = Bazi.create(datetime(2000, 2, 4, 22, 1), BaziGender.MALE, BaziPrecision.DAY)
+  first_dayun1: DayunTuple = next(BaziChart(bazi1).dayun)
+  assert first_dayun1.ganzhi_year == 2009
+
+  bazi2: Bazi = Bazi.create(datetime(1984, 4, 2, 4, 2), BaziGender.MALE, BaziPrecision.DAY)
+  first_dayun2: DayunTuple = next(BaziChart(bazi2).dayun)
+  # celestial start 1985-03-04 is past 立春 1985; lunar_python / china95 / 测测 all agree.
+  assert first_dayun2.ganzhi_year == 1985
+
+  bazi3: Bazi = Bazi.create(datetime(1984, 4, 2, 4, 2), BaziGender.FEMALE, BaziPrecision.DAY)
+  first_dayun3: DayunTuple = next(BaziChart(bazi3).dayun)
+  assert first_dayun3.ganzhi_year == 1993
+
+  for _ in range(10):
+    random_bazi: Bazi = Bazi.random()
+    dayun_start_times: list[DayunTuple] = list(itertools.islice(BaziChart(random_bazi).dayun, 10))
+    for dayun1, dayun2 in itertools.pairwise(dayun_start_times):
+      assert dayun2.ganzhi_year - dayun1.ganzhi_year == 10
+
+def test_xiaoyun() -> None:
+  def __subtest(bazi: Bazi, expected_xiaoyun_str: str) -> None:
+    xiaoyuns: tuple[XiaoyunTuple, ...] = BaziChart(bazi).xiaoyun
+    expected: list[Ganzhi] = [Ganzhi.from_str(s) for s in expected_xiaoyun_str.split()]
+    assert len(xiaoyuns) == len(expected)
+    for age, gz in enumerate(expected, start=1):
+      assert xiaoyuns[age-1].xusui == age
+      assert xiaoyuns[age-1].ganzhi == gz
+
+  # Data collected from https://p.china95.net/paipan/bazi/
+  __subtest(Bazi.create(datetime(2017, 8, 17, 2, 23), BaziGender.MALE, BaziPrecision.DAY),
+            '戊子 丁亥 丙戌 乙酉')
+  __subtest(Bazi.create(datetime(2017, 8, 17, 2, 23), BaziGender.FEMALE, BaziPrecision.DAY),
+            '庚寅 辛卯 壬辰 癸巳 甲午 乙未 丙申 丁酉')
+  __subtest(Bazi.create(datetime(2017, 8, 16, 2, 23), BaziGender.MALE, BaziPrecision.DAY),
+            '丙子 乙亥 甲戌 癸酉')
+  __subtest(Bazi.create(datetime(2017, 4, 16, 2, 23), BaziGender.FEMALE, BaziPrecision.DAY),
+            '甲寅 乙卯 丙辰 丁巳 戊午 己未 庚申')
+
+  # Directed: celestial moves this man's dayun start past 立春 1985, so xiaoyun gains a year
+  # (HKO gives '辛卯' alone); china95 lists exactly '辛卯 壬辰' for the same birth.
+  __subtest(Bazi.create(datetime(1984, 4, 2, 4, 2), BaziGender.MALE, BaziPrecision.DAY),
+            '辛卯 壬辰')
+
+def test_liunian() -> None:
+  cycle: list[Ganzhi] = Ganzhi.list_sexagenary_cycle()
+  for _ in range(16):
+    random_bazi: Bazi = Bazi.random()
+    chart: BaziChart = BaziChart(random_bazi)
+    for year, ganzhi in itertools.islice(chart.liunian, 80):
+      expected_ganzhi: Ganzhi = cycle[(year - 1924) % 60] # 1924 is a year of "甲子"
+      assert ganzhi == expected_ganzhi
+
+    # The first liunian is also the birth ganzhi year.
+    assert next(chart.liunian).ganzhi_year == random_bazi.ganzhi_date.year
+
+@pytest.mark.slow
+def test_consistency() -> None:
+  '''Ensure every run gives the consistent results...'''
+  for _ in range(64):
+    random_bazi: Bazi = Bazi.random()
+    expected: BaziChart = BaziChart(random_bazi)
+
+    for __ in range(5):
       chart: BaziChart = BaziChart(random_bazi)
-      for year, ganzhi in itertools.islice(chart.liunian, 80):
-        expected_ganzhi: Ganzhi = cycle[(year - 1924) % 60] # 1924 is a year of "甲子"
-        self.assertEqual(ganzhi, expected_ganzhi)
+      assert chart.bazi == expected.bazi
 
-      # The first liunian is also the birth ganzhi year.
-      self.assertEqual(next(chart.liunian).ganzhi_year, random_bazi.ganzhi_date.year)
+      assert list(chart.traits) == list(expected.traits)
+      assert list(chart.hidden_tiangan) == list(expected.hidden_tiangan)
+      assert list(chart.shishen) == list(expected.shishen)
+      assert list(chart.nayin) == list(expected.nayin)
+      assert list(chart.shier_zhangsheng) == list(expected.shier_zhangsheng)
 
-  @pytest.mark.slow
-  def test_consistency(self) -> None:
-    '''Ensure every run gives the consistent results...'''
-    for _ in range(64):
-      random_bazi: Bazi = Bazi.random()
-      expected: BaziChart = BaziChart(random_bazi)
+      assert chart.dayun_order == expected.dayun_order
+      assert chart.dayun_start_moment == expected.dayun_start_moment
+      assert chart.xiaoyun == expected.xiaoyun
 
-      for __ in range(5):
-        chart: BaziChart = BaziChart(random_bazi)
-        self.assertEqual(chart.bazi, expected.bazi)
+      assert list(itertools.islice(chart.liunian, 100)) == list(itertools.islice(expected.liunian, 100))
+      assert list(itertools.islice(chart.dayun, 100)) == list(itertools.islice(expected.dayun, 100))
 
-        self.assertListEqual(list(chart.traits), list(expected.traits))
-        self.assertListEqual(list(chart.hidden_tiangan), list(expected.hidden_tiangan))
-        self.assertListEqual(list(chart.shishen), list(expected.shishen))
-        self.assertListEqual(list(chart.nayin), list(expected.nayin))
-        self.assertListEqual(list(chart.shier_zhangsheng), list(expected.shier_zhangsheng))
+      assert chart.json == expected.json
 
-        self.assertEqual(chart.dayun_order, expected.dayun_order)
-        self.assertEqual(chart.dayun_start_moment, expected.dayun_start_moment)
-        self.assertEqual(chart.xiaoyun, expected.xiaoyun)
-
-        self.assertEqual(list(itertools.islice(chart.liunian, 100)), 
-                         list(itertools.islice(expected.liunian, 100)))
-        self.assertEqual(list(itertools.islice(chart.dayun, 100)), 
-                         list(itertools.islice(expected.dayun, 100)))
-
-        self.assertDictEqual(chart.json, expected.json)
-
-  @pytest.mark.slow
-  def test_json(self) -> None:
-    def __random_chart() -> BaziChart:
-      # `Bazi.random()` is DAY-only; HOUR / MINUTE roundtrips are covered here too (issue #6).
-      precision: BaziPrecision = random.choice(list(BaziPrecision))
-      if precision is BaziPrecision.DAY:
-        return BaziChart(Bazi.random())
-      return BaziChart(Bazi.create(
-        birth_time=datetime(
-          year=random.randint(1902, 2080),
-          month=random.randint(1, 12),
-          day=random.randint(1, 28),
-          hour=random.randint(0, 23),
-          minute=random.randint(0, 59),
-        ),
-        gender=random.choice(list(BaziGender)),
-        precision=precision,
-      ))
-
-    for _ in range(32):
-      chart: BaziChart = __random_chart()
-      dt: datetime = chart.bazi.solar_datetime
-
-      j: BaziJson.BaziChartJsonDict = chart.json
-      j_str: str = json.dumps(j)
-      __j: dict = json.loads(j_str)
-
-      self.assertEqual(j, __j)
-
-      # Do something bad on the JSON object `__j`.
-      # This shouldn't have any effect on `chart`.
-      __j['datetime'] = datetime.now().isoformat()
-      __j['gender'] = 'male'
-      __j['tiangan_traits'], __j['dizhi_traits'] = __j['dizhi_traits'], __j['tiangan_traits']
-      __j['tiangan_shishen'], __j['dizhi_shishen'] = __j['dizhi_shishen'], __j['tiangan_shishen']
-      self.assertEqual(chart.json, j)
-      self.assertNotEqual(chart.json, __j)
-
-      self.assertEqual(datetime.fromisoformat(j['birth_time']), dt)
-      self.assertEqual(j['precision'], str(chart.bazi.precision))
-
-      j_gender: BaziGender = BaziGender.MALE
-      if j['gender'] == 'female':
-        j_gender = BaziGender.FEMALE
-      self.assertEqual(j_gender, chart.bazi.gender)
-
-      # The rebuild parses everything -- precision included -- from the json itself.
-      __chart: BaziChart = BaziChart(
-        Bazi.create(datetime.fromisoformat(j['birth_time']), j_gender, j['precision'],
-                    backend=j['backend'])
-      )
-
-      self.assertEqual(j, __chart.json)
-
-  def test_json_correctness(self) -> None:
-    chart: BaziChart = BaziChart(Bazi.create(
-      birth_time=datetime(1984, 4, 2, 4, 2),
-      gender=BaziGender.男,
-      precision=BaziPrecision.DAY,
+@pytest.mark.slow
+def test_json() -> None:
+  def __random_chart() -> BaziChart:
+    # `Bazi.random()` is DAY-only; HOUR / MINUTE roundtrips are covered here too (issue #6).
+    precision: BaziPrecision = random.choice(list(BaziPrecision))
+    if precision is BaziPrecision.DAY:
+      return BaziChart(Bazi.random())
+    return BaziChart(Bazi.create(
+      birth_time=datetime(
+        year=random.randint(1902, 2080),
+        month=random.randint(1, 12),
+        day=random.randint(1, 28),
+        hour=random.randint(0, 23),
+        minute=random.randint(0, 59),
+      ),
+      gender=random.choice(list(BaziGender)),
+      precision=precision,
     ))
-    
-    #           Year    Month     Day     Hour
-    # Tiangan    甲       丁       丙       庚
-    #   Dizhi    子       卯       寅       寅
+
+  for _ in range(32):
+    chart: BaziChart = __random_chart()
+    dt: datetime = chart.bazi.solar_datetime
 
     j: BaziJson.BaziChartJsonDict = chart.json
     j_str: str = json.dumps(j)
     __j: dict = json.loads(j_str)
 
-    self.assertEqual(j, __j)
+    assert j == __j
 
-    self.assertEqual(j['pillars'], {
-      'year': '甲子',
-      'month': '丁卯',
-      'day': '丙寅',
-      'hour': '庚寅',
-    })
+    # Do something bad on the JSON object `__j`.
+    # This shouldn't have any effect on `chart`.
+    __j['datetime'] = datetime.now().isoformat() # type: ignore # `assert j == __j` narrows `__j` to the TypedDict; it is a plain dict.
+    __j['gender'] = 'male'
+    __j['tiangan_traits'], __j['dizhi_traits'] = __j['dizhi_traits'], __j['tiangan_traits']
+    __j['tiangan_shishen'], __j['dizhi_shishen'] = __j['dizhi_shishen'], __j['tiangan_shishen'] # type: ignore # Same narrowing; the mismatched swap is the point.
+    assert chart.json == j
+    assert chart.json != __j
 
-    self.assertEqual(j['tiangan_traits'], {
-      'year': '阳木',
-      'month': '阴火',
-      'day': '阳火',
-      'hour': '阳金',
-    })
+    assert datetime.fromisoformat(j['birth_time']) == dt
+    assert j['precision'] == str(chart.bazi.precision)
 
-    self.assertEqual(j['dizhi_traits'], {
-      'year': '阳水',
-      'month': '阴木',
-      'day': '阳木',
-      'hour': '阳木',
-    })
+    j_gender: BaziGender = BaziGender.MALE
+    if j['gender'] == 'female':
+      j_gender = BaziGender.FEMALE
+    assert j_gender == chart.bazi.gender
 
-    self.assertEqual(j['hidden_tiangan'], {
-      'year': '癸:100',
-      'month': '乙:100',
-      'day': '甲:60,丙:30,戊:10',
-      'hour': '甲:60,丙:30,戊:10',
-    })
+    # The rebuild parses everything -- precision included -- from the json itself.
+    __chart: BaziChart = BaziChart(
+      Bazi.create(datetime.fromisoformat(j['birth_time']), j_gender, j['precision'],
+                  backend=j['backend'])
+    )
 
-    self.assertEqual(j['tiangan_shishen'], {
-      'year': '偏印',
-      'month': '劫财',
-      'day': None, # The day master itself has no Shishen -- a real JSON null, not 'None'.
-      'hour': '偏财',
-    })
+    assert j == __chart.json
 
-    self.assertEqual(j['dizhi_shishen'], {
-      'year': '正官',
-      'month': '正印',
-      'day': '偏印',
-      'hour': '偏印',
-    })
+def test_json_correctness() -> None:
+  chart: BaziChart = BaziChart(Bazi.create(
+    birth_time=datetime(1984, 4, 2, 4, 2),
+    gender=BaziGender.男,
+    precision=BaziPrecision.DAY,
+  ))
 
-    self.assertEqual(j['nayin'], {
-      'year': '海中金',
-      'month': '炉中火',
-      'day': '炉中火',
-      'hour': '松柏木',
-    })
+  #           Year    Month     Day     Hour
+  # Tiangan    甲       丁       丙       庚
+  #   Dizhi    子       卯       寅       寅
 
-    self.assertEqual(j['shier_zhangsheng'], {
-      'year': '胎',
-      'month': '沐浴',
-      'day': '长生',
-      'hour': '长生',
-    })
+  j: BaziJson.BaziChartJsonDict = chart.json
+  j_str: str = json.dumps(j)
+  __j: dict = json.loads(j_str)
 
-  def test_deepcopy(self) -> None:
-    chart: BaziChart = BaziChart(Bazi.random())
+  assert j == __j
 
-    chart2: BaziChart = copy.deepcopy(chart)
+  assert j['pillars'] == {
+    'year': '甲子',
+    'month': '丁卯',
+    'day': '丙寅',
+    'hour': '庚寅',
+  }
 
-    self.assertIsNot(chart.bazi, chart2.bazi)
-    self.assertIsNot(chart._bazi, chart2._bazi)
+  assert j['tiangan_traits'] == {
+    'year': '阳木',
+    'month': '阴火',
+    'day': '阳火',
+    'hour': '阳金',
+  }
 
-    old_bazi: Bazi = chart._bazi
-    chart._bazi = BaziChart(Bazi.random())._bazi # type: ignore
+  assert j['dizhi_traits'] == {
+    'year': '阳水',
+    'month': '阴木',
+    'day': '阳木',
+    'hour': '阳木',
+  }
 
-    self.assertIsNot(chart.bazi, old_bazi)
-    self.assertIsNot(chart._bazi, old_bazi)
+  assert j['hidden_tiangan'] == {
+    'year': '癸:100',
+    'month': '乙:100',
+    'day': '甲:60,丙:30,戊:10',
+    'hour': '甲:60,丙:30,戊:10',
+  }
+
+  assert j['tiangan_shishen'] == {
+    'year': '偏印',
+    'month': '劫财',
+    'day': None, # The day master itself has no Shishen -- a real JSON null, not 'None'.
+    'hour': '偏财',
+  }
+
+  assert j['dizhi_shishen'] == {
+    'year': '正官',
+    'month': '正印',
+    'day': '偏印',
+    'hour': '偏印',
+  }
+
+  assert j['nayin'] == {
+    'year': '海中金',
+    'month': '炉中火',
+    'day': '炉中火',
+    'hour': '松柏木',
+  }
+
+  assert j['shier_zhangsheng'] == {
+    'year': '胎',
+    'month': '沐浴',
+    'day': '长生',
+    'hour': '长生',
+  }
+
+def test_deepcopy() -> None:
+  chart: BaziChart = BaziChart(Bazi.random())
+
+  chart2: BaziChart = copy.deepcopy(chart)
+
+  assert chart.bazi is not chart2.bazi
+  assert chart._bazi is not chart2._bazi
+
+  old_bazi: Bazi = chart._bazi
+  chart._bazi = BaziChart(Bazi.random())._bazi # type: ignore
+
+  assert chart.bazi is not old_bazi
+  assert chart._bazi is not old_bazi
 
 
-class TestBaziChartHourMinutePrecisions(unittest.TestCase):
+# HOUR / MINUTE charts (issue #6): the dayun counting and the birth-side year consume the
+# same attribution source as the pillars (`Bazi.bracketing_jies` / `Bazi.ganzhi_year`), so
+# a chart cannot contradict itself about which jie owns the birth month.
+
+def test_backward_dayun_counts_from_the_month_owning_jie() -> None:
   '''
-  HOUR / MINUTE charts (issue #6): the dayun counting and the birth-side year consume the
-  same attribution source as the pillars (`Bazi.bracketing_jies` / `Bazi.ganzhi_year`), so
-  a chart cannot contradict itself about which jie owns the birth month.
+  立春 2009 = 02-04 00:49:48. A HOUR birth at 02-04 00:30 ties into the new year (己丑, 阴),
+  so a male chart runs backward -- and the month-owning jie is 立春, whose true moment lies
+  19m48s AFTER the birth. Counting back to the owning jie gives a negative gap, clamped to
+  zero: the dayun starts at the birth itself. (Moment-level counting would instead walk ~29
+  days back to 小寒, starting the dayun ~9.7 years late and contradicting the 寅 month.)
   '''
+  chart: BaziChart = BaziChart(Bazi.create('2009-02-04 00:30', 'male', 'hour'))
+  assert chart.bazi.month_commander == Dizhi.寅
+  assert not chart.dayun_order
+  assert chart.dayun_start_moment == chart.bazi.solar_datetime
 
-  def test_backward_dayun_counts_from_the_month_owning_jie(self) -> None:
-    '''
-    立春 2009 = 02-04 00:49:48. A HOUR birth at 02-04 00:30 ties into the new year (己丑, 阴),
-    so a male chart runs backward -- and the month-owning jie is 立春, whose true moment lies
-    19m48s AFTER the birth. Counting back to the owning jie gives a negative gap, clamped to
-    zero: the dayun starts at the birth itself. (Moment-level counting would instead walk ~29
-    days back to 小寒, starting the dayun ~9.7 years late and contradicting the 寅 month.)
-    '''
-    chart: BaziChart = BaziChart(Bazi.create('2009-02-04 00:30', 'male', 'hour'))
-    self.assertEqual(chart.bazi.month_commander, Dizhi.寅)
-    self.assertFalse(chart.dayun_order)
-    self.assertEqual(chart.dayun_start_moment, chart.bazi.solar_datetime)
+def test_forward_dayun_skips_the_tie_jie() -> None:
+  '''
+  Same tie birth, female -> forward. The "next" jie must be the one AFTER the owning 立春,
+  i.e. 惊蛰 (2009-03-05 18:47:32) -- the owning jie already opened the birth month and does
+  not count as next, even though its true moment lies after the birth.
+  '''
+  chart: BaziChart = BaziChart(Bazi.create('2009-02-04 00:30', 'female', 'hour'))
+  assert chart.dayun_order
+  birth: datetime = chart.bazi.solar_datetime
+  gap: timedelta = datetime(2009, 3, 5, 18, 47, 32) - birth
+  assert chart.dayun_start_moment == birth + (gap / timedelta(days=3)) * timedelta(days=365)
 
-  def test_forward_dayun_skips_the_tie_jie(self) -> None:
-    '''
-    Same tie birth, female -> forward. The "next" jie must be the one AFTER the owning 立春,
-    i.e. 惊蛰 (2009-03-05 18:47:32) -- the owning jie already opened the birth month and does
-    not count as next, even though its true moment lies after the birth.
-    '''
-    chart: BaziChart = BaziChart(Bazi.create('2009-02-04 00:30', 'female', 'hour'))
-    self.assertTrue(chart.dayun_order)
-    birth: datetime = chart.bazi.solar_datetime
-    gap: timedelta = datetime(2009, 3, 5, 18, 47, 32) - birth
-    self.assertEqual(chart.dayun_start_moment, birth + (gap / timedelta(days=3)) * timedelta(days=365))
+def test_minute_precision_counts_to_the_true_moment() -> None:
+  '''
+  The same birth at MINUTE precision is NOT a tie (00:30 < 00:49): the year stays 戊子 (阳,
+  male -> forward), and the next jie is 立春 itself, 19m48s away.
+  '''
+  chart: BaziChart = BaziChart(Bazi.create('2009-02-04 00:30', 'male', 'minute'))
+  assert chart.bazi.month_commander == Dizhi.丑
+  assert chart.dayun_order
+  birth: datetime = chart.bazi.solar_datetime
+  gap: timedelta = datetime(2009, 2, 4, 0, 49, 48) - birth
+  assert chart.dayun_start_moment == birth + (gap / timedelta(days=3)) * timedelta(days=365)
 
-  def test_minute_precision_counts_to_the_true_moment(self) -> None:
-    '''
-    The same birth at MINUTE precision is NOT a tie (00:30 < 00:49): the year stays 戊子 (阳,
-    male -> forward), and the next jie is 立春 itself, 19m48s away.
-    '''
-    chart: BaziChart = BaziChart(Bazi.create('2009-02-04 00:30', 'male', 'minute'))
-    self.assertEqual(chart.bazi.month_commander, Dizhi.丑)
-    self.assertTrue(chart.dayun_order)
-    birth: datetime = chart.bazi.solar_datetime
-    gap: timedelta = datetime(2009, 2, 4, 0, 49, 48) - birth
-    self.assertEqual(chart.dayun_start_moment, birth + (gap / timedelta(days=3)) * timedelta(days=365))
+def test_backward_clamp_across_midnight_matches_the_same_shichen() -> None:
+  '''
+  R1 convergence find (grok / fable / kimi independently): the cross-midnight tie birth
+  (2009-02-03 23:30, male -> backward, clamp) must produce the SAME xiaoyun and dayun-year
+  face as its same-子时 sibling on the jieqi's own day (02-04 00:30) -- the four pillars
+  are identical, so the charts must be too. Before the fix, the day-level relabel of the
+  clamped start (= the birth itself, whose civil day still carries the OLD year) emptied
+  the xiaoyun and put the first dayun in 2008, contradicting the 己丑 2009 year pillar.
+  '''
+  across: BaziChart = BaziChart(Bazi.create('2009-02-03 23:30', 'male', 'hour'))
+  same_day: BaziChart = BaziChart(Bazi.create('2009-02-04 00:30', 'male', 'hour'))
 
-  def test_backward_clamp_across_midnight_matches_the_same_shichen(self) -> None:
-    '''
-    R1 convergence find (grok / fable / kimi independently): the cross-midnight tie birth
-    (2009-02-03 23:30, male -> backward, clamp) must produce the SAME xiaoyun and dayun-year
-    face as its same-子时 sibling on the jieqi's own day (02-04 00:30) -- the four pillars
-    are identical, so the charts must be too. Before the fix, the day-level relabel of the
-    clamped start (= the birth itself, whose civil day still carries the OLD year) emptied
-    the xiaoyun and put the first dayun in 2008, contradicting the 己丑 2009 year pillar.
-    '''
-    across: BaziChart = BaziChart(Bazi.create('2009-02-03 23:30', 'male', 'hour'))
-    same_day: BaziChart = BaziChart(Bazi.create('2009-02-04 00:30', 'male', 'hour'))
+  assert list(across.bazi.pillars) == list(same_day.bazi.pillars)
+  assert not across.dayun_order
+  assert across.dayun_start_moment == across.bazi.solar_datetime # Clamped.
 
-    self.assertEqual(list(across.bazi.pillars), list(same_day.bazi.pillars))
-    self.assertFalse(across.dayun_order)
-    self.assertEqual(across.dayun_start_moment, across.bazi.solar_datetime) # Clamped.
+  assert across.xiaoyun == same_day.xiaoyun
+  assert len(across.xiaoyun) == 1
+  assert next(across.dayun).ganzhi_year == 2009   # == the year pillar's year,
+  assert next(same_day.dayun).ganzhi_year == 2009 # on both sides of midnight.
 
-    self.assertEqual(across.xiaoyun, same_day.xiaoyun)
-    self.assertEqual(len(across.xiaoyun), 1)
-    self.assertEqual(next(across.dayun).ganzhi_year, 2009)   # == the year pillar's year,
-    self.assertEqual(next(same_day.dayun).ganzhi_year, 2009) # on both sides of midnight.
+@pytest.mark.parametrize('precision, first_year, year_pillar, xiaoyun_len', [
+  ('hour', 2009, '己丑', 10),
+  ('day',  2008, '戊子', 11),
+])
+def test_liunian_and_xiaoyun_start_from_the_attributed_year(precision: str, first_year: int, year_pillar: str, xiaoyun_len: int) -> None:
+  '''
+  The cross-midnight tie birth (2009-02-03 23:30, HOUR) belongs to 己丑 2009; the same
+  moment at DAY belongs to 戊子 2008. In both charts the first liunian must equal the year
+  pillar -- the invariant that keeps a chart self-consistent -- and the xiaoyun age count
+  follows the same attributed year (pinned lengths: forward 己丑 chart 10, backward 戊子
+  chart 11).
+  '''
+  chart: BaziChart = BaziChart(Bazi.create('2009-02-03 23:30', 'female', precision))
+  assert str(chart.bazi.year_pillar) == year_pillar
 
-  def test_liunian_and_xiaoyun_start_from_the_attributed_year(self) -> None:
-    '''
-    The cross-midnight tie birth (2009-02-03 23:30, HOUR) belongs to 己丑 2009; the same
-    moment at DAY belongs to 戊子 2008. In both charts the first liunian must equal the year
-    pillar -- the invariant that keeps a chart self-consistent -- and the xiaoyun age count
-    follows the same attributed year (pinned lengths: forward 己丑 chart 10, backward 戊子
-    chart 11).
-    '''
-    expected: list[tuple[str, int, str, int]] = [
-      ('hour', 2009, '己丑', 10),
-      ('day',  2008, '戊子', 11),
-    ]
-    for precision, first_year, year_pillar, xiaoyun_len in expected:
-      with self.subTest(precision=precision):
-        chart: BaziChart = BaziChart(Bazi.create('2009-02-03 23:30', 'female', precision))
-        self.assertEqual(str(chart.bazi.year_pillar), year_pillar)
+  first_liunian = next(chart.liunian)
+  assert first_liunian.ganzhi_year == first_year
+  assert first_liunian.ganzhi == chart.bazi.year_pillar
 
-        first_liunian = next(chart.liunian)
-        self.assertEqual(first_liunian.ganzhi_year, first_year)
-        self.assertEqual(first_liunian.ganzhi, chart.bazi.year_pillar)
-
-        self.assertEqual(len(chart.xiaoyun), xiaoyun_len)
+  assert len(chart.xiaoyun) == xiaoyun_len

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -3,12 +3,9 @@
 
 import pytest
 
-
-
 from src.defines import Shishen, Tiangan
 from src.common import frozendict
 from src.data_types import GanzhiData, BaziData, HiddenTianganDict
-
 
 
 def test_frozendict() -> None:
@@ -32,6 +29,7 @@ def test_frozendict() -> None:
   assert fd2[1] is fd2[1]
   assert fd2[1] is src_dict[1]
 
+
 def test_frozendict_hash() -> None:
   # Tuple semantics: equal contents hash equal, regardless of insertion order.
   fd1: frozendict[int, int] = frozendict({1: 2, 3: 4})
@@ -51,6 +49,7 @@ def test_frozendict_hash() -> None:
   bd: BaziData[HiddenTianganDict] = BaziData(htd, htd, htd, htd)
   assert hash(bd) == hash(BaziData(htd, htd, htd, htd))
   assert bd in {bd}
+
 
 def test_pillardata() -> None:
   combo1: GanzhiData[str, int] = GanzhiData('a', 1)
@@ -72,6 +71,7 @@ def test_pillardata() -> None:
 
   assert combo5 != Shishen.正官
   assert combo5 != (None, Shishen.七杀)
+
 
 def test_bazidata() -> None:
   bd1: BaziData[int] = BaziData(1, 2, 3, 4)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2024 Ningqi Wang (0xf3cd) <https://github.com/0xf3cd>
 # test_common.py
 
-import unittest
+import pytest
 
 
 
@@ -11,131 +11,129 @@ from src.data_types import GanzhiData, BaziData, HiddenTianganDict
 
 
 
-class TestCommon(unittest.TestCase):
+def test_frozendict() -> None:
+  fd: frozendict[int, int] = frozendict({1: 2, 3: 4})
+  assert fd[1] == 2
+  assert fd[3] == 4
+  with pytest.raises(TypeError):
+    fd[1] = 100 # type: ignore
 
-  def test_frozendict(self) -> None:
-    fd: frozendict[int, int] = frozendict({1: 2, 3: 4})
-    self.assertEqual(fd[1], 2)
-    self.assertEqual(fd[3], 4)
-    with self.assertRaises(TypeError):
-      fd[1] = 100 # type: ignore
+  # The mapping itself is detached from the source dict...
+  src_dict: dict[int, list[int]] = {1: [2, 3]}
+  fd2: frozendict[int, list[int]] = frozendict(src_dict)
+  src_dict[9] = [9]
+  assert 9 not in fd2
+  with pytest.raises(TypeError):
+    fd2[1] = [4, 5] # type: ignore
+  with pytest.raises(KeyError):
+    fd2[2]
 
-    # The mapping itself is detached from the source dict...
-    src_dict: dict[int, list[int]] = {1: [2, 3]}
-    fd2: frozendict[int, list[int]] = frozendict(src_dict)
-    src_dict[9] = [9]
-    self.assertNotIn(9, fd2)
-    with self.assertRaises(TypeError):
-      fd2[1] = [4, 5] # type: ignore
-    with self.assertRaises(KeyError):
-      fd2[2]
+  # ...but the frozendict is shallow-frozen: values are returned as-is, not copied.
+  assert fd2[1] is fd2[1]
+  assert fd2[1] is src_dict[1]
 
-    # ...but the frozendict is shallow-frozen: values are returned as-is, not copied.
-    self.assertIs(fd2[1], fd2[1])
-    self.assertIs(fd2[1], src_dict[1])
+def test_frozendict_hash() -> None:
+  # Tuple semantics: equal contents hash equal, regardless of insertion order.
+  fd1: frozendict[int, int] = frozendict({1: 2, 3: 4})
+  fd2: frozendict[int, int] = frozendict({3: 4, 1: 2})
+  assert fd1 == fd2
+  assert hash(fd1) == hash(fd2)
+  assert len({fd1, fd2}) == 1
+  assert len({fd1, frozendict({1: 2})}) == 2
 
-  def test_frozendict_hash(self) -> None:
-    # Tuple semantics: equal contents hash equal, regardless of insertion order.
-    fd1: frozendict[int, int] = frozendict({1: 2, 3: 4})
-    fd2: frozendict[int, int] = frozendict({3: 4, 1: 2})
-    self.assertEqual(fd1, fd2)
-    self.assertEqual(hash(fd1), hash(fd2))
-    self.assertEqual(len({fd1, fd2}), 1)
-    self.assertEqual(len({fd1, frozendict({1: 2})}), 2)
+  # Unhashable contents surface as TypeError on the first hash attempt.
+  with pytest.raises(TypeError):
+    hash(frozendict({1: [2, 3]}))
 
-    # Unhashable contents surface as TypeError on the first hash attempt.
-    with self.assertRaises(TypeError):
-      hash(frozendict({1: [2, 3]}))
+  # `BaziData[HiddenTianganDict]` must stay hashable -- the hidden-tiangan chain
+  # is frozendict all the way down.
+  htd: HiddenTianganDict = HiddenTianganDict({Tiangan.甲: 60, Tiangan.丙: 30, Tiangan.戊: 10})
+  bd: BaziData[HiddenTianganDict] = BaziData(htd, htd, htd, htd)
+  assert hash(bd) == hash(BaziData(htd, htd, htd, htd))
+  assert bd in {bd}
 
-    # `BaziData[HiddenTianganDict]` must stay hashable -- the hidden-tiangan chain
-    # is frozendict all the way down.
-    htd: HiddenTianganDict = HiddenTianganDict({Tiangan.甲: 60, Tiangan.丙: 30, Tiangan.戊: 10})
-    bd: BaziData[HiddenTianganDict] = BaziData(htd, htd, htd, htd)
-    self.assertEqual(hash(bd), hash(BaziData(htd, htd, htd, htd)))
-    self.assertIn(bd, {bd})
+def test_pillardata() -> None:
+  combo1: GanzhiData[str, int] = GanzhiData('a', 1)
+  combo2: GanzhiData[str, int] = GanzhiData('a', 1)
+  combo3: GanzhiData[str, int] = GanzhiData('a ', 1)
+  combo4: GanzhiData[str, float] = GanzhiData('a', 1.1)
+  assert combo1 == combo2
+  assert combo1 != combo3
+  assert combo1 != combo4
 
-  def test_pillardata(self) -> None:
-    combo1: GanzhiData[str, int] = GanzhiData('a', 1)
-    combo2: GanzhiData[str, int] = GanzhiData('a', 1)
-    combo3: GanzhiData[str, int] = GanzhiData('a ', 1)
-    combo4: GanzhiData[str, float] = GanzhiData('a', 1.1)
-    self.assertEqual(combo1, combo2)
-    self.assertNotEqual(combo1, combo3)
-    self.assertNotEqual(combo1, combo4)
+  assert combo1.tiangan == 'a'
+  assert combo1.dizhi == 1
+  assert combo4.dizhi == 1.1
 
-    self.assertEqual(combo1.tiangan, 'a')
-    self.assertEqual(combo1.dizhi, 1)
-    self.assertEqual(combo4.dizhi, 1.1)
+  combo5: GanzhiData[None, Shishen] = GanzhiData(None, Shishen.七杀)
+  assert combo5 == GanzhiData(None, Shishen.七杀)
+  assert combo5 != GanzhiData(Shishen.七杀, Shishen.七杀)
+  assert combo5 != GanzhiData(None, Shishen.正官)
 
-    combo5: GanzhiData[None, Shishen] = GanzhiData(None, Shishen.七杀)
-    self.assertEqual(combo5, GanzhiData(None, Shishen.七杀))
-    self.assertNotEqual(combo5, GanzhiData(Shishen.七杀, Shishen.七杀))
-    self.assertNotEqual(combo5, GanzhiData(None, Shishen.正官))
+  assert combo5 != Shishen.正官
+  assert combo5 != (None, Shishen.七杀)
 
-    self.assertNotEqual(combo5, Shishen.正官)
-    self.assertNotEqual(combo5, (None, Shishen.七杀))
+def test_bazidata() -> None:
+  bd1: BaziData[int] = BaziData(1, 2, 3, 4)
+  bd2: BaziData[int] = BaziData(1, 2, 3, 4)
+  bd3: BaziData[int] = BaziData(1, 2, 3, 5)
+  assert bd1 == bd2
+  assert bd1 != bd3
+  assert bd1 != [1, 2, 3, 4]
 
-  def test_bazidata(self) -> None:
-    bd1: BaziData[int] = BaziData(1, 2, 3, 4)
-    bd2: BaziData[int] = BaziData(1, 2, 3, 4)
-    bd3: BaziData[int] = BaziData(1, 2, 3, 5)
-    self.assertEqual(bd1, bd2)
-    self.assertNotEqual(bd1, bd3)
-    self.assertNotEqual(bd1, [1, 2, 3, 4])
+  assert bd1.year == 1
+  assert bd1.month == 2
+  assert bd1.day == 3
+  assert bd1.hour == 4
+  assert bd3.hour == 5
 
-    self.assertEqual(bd1.year, 1)
-    self.assertEqual(bd1.month, 2)
-    self.assertEqual(bd1.day, 3)
-    self.assertEqual(bd1.hour, 4)
-    self.assertEqual(bd3.hour, 5)
+  with pytest.raises(TypeError):
+    BaziData(1, 2, 3) # type: ignore # arity is enforced by the dataclass signature now
 
-    with self.assertRaises(TypeError):
-      BaziData(1, 2, 3) # type: ignore # arity is enforced by the dataclass signature now
+  bd5: BaziData[GanzhiData[Shishen | None, Shishen]] = BaziData(
+    GanzhiData(None, Shishen.七杀),
+    GanzhiData(Shishen.伤官, Shishen.偏印),
+    GanzhiData(Shishen.正官, Shishen.食神),
+    GanzhiData(Shishen.七杀, Shishen.正官),
+  )
 
-    bd5: BaziData[GanzhiData[Shishen | None, Shishen]] = BaziData(
-      GanzhiData(None, Shishen.七杀),
-      GanzhiData(Shishen.伤官, Shishen.偏印),
-      GanzhiData(Shishen.正官, Shishen.食神),
-      GanzhiData(Shishen.七杀, Shishen.正官),
-    )
+  bd6: BaziData[GanzhiData[Shishen | None, Shishen]] = BaziData(
+    GanzhiData(None, Shishen.七杀),
+    GanzhiData(Shishen.伤官, Shishen.偏印),
+    GanzhiData(Shishen.正官, Shishen.食神),
+    GanzhiData(Shishen.七杀, Shishen.正官),
+  )
 
-    bd6: BaziData[GanzhiData[Shishen | None, Shishen]] = BaziData(
-      GanzhiData(None, Shishen.七杀),
-      GanzhiData(Shishen.伤官, Shishen.偏印),
-      GanzhiData(Shishen.正官, Shishen.食神),
-      GanzhiData(Shishen.七杀, Shishen.正官),
-    )
+  bd7: BaziData[GanzhiData[Shishen | None, Shishen]] = BaziData(
+    GanzhiData(Shishen.比肩, Shishen.七杀),
+    GanzhiData(Shishen.伤官, Shishen.偏印),
+    GanzhiData(Shishen.正官, Shishen.食神),
+    GanzhiData(Shishen.七杀, Shishen.正官),
+  )
 
-    bd7: BaziData[GanzhiData[Shishen | None, Shishen]] = BaziData(
-      GanzhiData(Shishen.比肩, Shishen.七杀),
-      GanzhiData(Shishen.伤官, Shishen.偏印),
-      GanzhiData(Shishen.正官, Shishen.食神),
-      GanzhiData(Shishen.七杀, Shishen.正官),
-    )
+  bd8: BaziData[GanzhiData[Shishen | None, Shishen]] = BaziData(
+    GanzhiData(None, Shishen.七杀),
+    GanzhiData(Shishen.伤官, Shishen.伤官),
+    GanzhiData(Shishen.正官, Shishen.食神),
+    GanzhiData(Shishen.七杀, Shishen.正官),
+  )
 
-    bd8: BaziData[GanzhiData[Shishen | None, Shishen]] = BaziData(
-      GanzhiData(None, Shishen.七杀),
-      GanzhiData(Shishen.伤官, Shishen.伤官),
-      GanzhiData(Shishen.正官, Shishen.食神),
-      GanzhiData(Shishen.七杀, Shishen.正官),
-    )
+  bd9: BaziData[GanzhiData[Shishen | None, Shishen]] = BaziData(
+    GanzhiData(None, Shishen.七杀),
+    GanzhiData(Shishen.伤官, Shishen.偏印),
+    GanzhiData(None, Shishen.食神),
+    GanzhiData(Shishen.七杀, Shishen.正官),
+  )
 
-    bd9: BaziData[GanzhiData[Shishen | None, Shishen]] = BaziData(
-      GanzhiData(None, Shishen.七杀),
-      GanzhiData(Shishen.伤官, Shishen.偏印),
-      GanzhiData(None, Shishen.食神),
-      GanzhiData(Shishen.七杀, Shishen.正官),
-    )
+  bd10: BaziData[GanzhiData[Shishen | None, Shishen]] = BaziData(
+    GanzhiData(None, Shishen.七杀),
+    GanzhiData(Shishen.伤官, Shishen.偏印),
+    GanzhiData(Shishen.正官, Shishen.食神),
+    GanzhiData(Shishen.七杀, Shishen.伤官),
+  )
 
-    bd10: BaziData[GanzhiData[Shishen | None, Shishen]] = BaziData(
-      GanzhiData(None, Shishen.七杀),
-      GanzhiData(Shishen.伤官, Shishen.偏印),
-      GanzhiData(Shishen.正官, Shishen.食神),
-      GanzhiData(Shishen.七杀, Shishen.伤官),
-    )
-
-    self.assertEqual(bd5, bd6)
-    self.assertNotEqual(bd5, bd7)
-    self.assertNotEqual(bd5, bd8)
-    self.assertNotEqual(bd5, bd9)
-    self.assertNotEqual(bd5, bd10)
+  assert bd5 == bd6
+  assert bd5 != bd7
+  assert bd5 != bd8
+  assert bd5 != bd9
+  assert bd5 != bd10

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -8,6 +8,7 @@ from src.defines import Tiangan, Shishen
 from src.descriptions import SHISHEN_DESCRIPTIONS, TIANGAN_DESCRIPTIONS
 from src.interpreter import Interpreter
 
+
 def test_interpret_shishen() -> None:
   for shishen in Shishen:
     result: ShishenDescription = Interpreter.interpret_shishen(shishen)
@@ -26,6 +27,7 @@ def test_interpret_shishen() -> None:
 
     assert result == Interpreter.interpret_shishen(shishen)
 
+
 def test_interpret_tiangan() -> None:
   for tg in Tiangan:
     result: TianganDescription = Interpreter.interpret_tiangan(tg)
@@ -43,6 +45,7 @@ def test_interpret_tiangan() -> None:
         assert d[-1] == '。', f'"{d}" not ending with "。"' # End with '。'.
 
     assert result == Interpreter.interpret_tiangan(tg)
+
 
 def test_corpus_is_frozen() -> None:
   # The corpus tables are frozen: reassigning an entry must fail, and mutating a

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -1,63 +1,62 @@
 # Copyright (C) 2024 Ningqi Wang (0xf3cd) <https://github.com/0xf3cd>
 # test_interpreter.py
 
-import unittest
+import pytest
 
 from src.descriptions import ShishenDescription, TianganDescription
 from src.defines import Tiangan, Shishen
 from src.descriptions import SHISHEN_DESCRIPTIONS, TIANGAN_DESCRIPTIONS
 from src.interpreter import Interpreter
 
-class TestInterpreter(unittest.TestCase):
-  def test_interpret_shishen(self) -> None:
-    for shishen in Shishen:
-      result: ShishenDescription = Interpreter.interpret_shishen(shishen)
+def test_interpret_shishen() -> None:
+  for shishen in Shishen:
+    result: ShishenDescription = Interpreter.interpret_shishen(shishen)
 
-      keys: list[str] = ['general', 'in_good_status', 'in_bad_status', 'relationship']
-      for k in keys:
-        self.assertIn(k, result)
-        self.assertIsInstance(result[k], list) # type: ignore # mypy complains.
-        self.assertGreaterEqual(len(result[k]), 1) # type: ignore # mypy complains.
-        for d in result[k]: # type: ignore # mypy complains.
-          self.assertIsInstance(d, str)
-          self.assertGreaterEqual(len(d), 1)
+    keys: list[str] = ['general', 'in_good_status', 'in_bad_status', 'relationship']
+    for k in keys:
+      assert k in result
+      assert isinstance(result[k], list) # type: ignore # mypy complains.
+      assert len(result[k]) >= 1 # type: ignore # mypy complains.
+      for d in result[k]: # type: ignore # mypy complains.
+        assert isinstance(d, str)
+        assert len(d) >= 1
 
-          self.assertEqual(d, d.strip(), f'"{d}" not stripped') # No space at the beginning or end.
-          self.assertTrue(d[-1] == '。', f'"{d}" not ending with "。"') # End with '。'.
+        assert d == d.strip(), f'"{d}" not stripped' # No space at the beginning or end.
+        assert d[-1] == '。', f'"{d}" not ending with "。"' # End with '。'.
 
-      self.assertEqual(result, Interpreter.interpret_shishen(shishen))
+    assert result == Interpreter.interpret_shishen(shishen)
 
-  def test_interpret_tiangan(self) -> None:
-    for tg in Tiangan:
-      result: TianganDescription = Interpreter.interpret_tiangan(tg)
+def test_interpret_tiangan() -> None:
+  for tg in Tiangan:
+    result: TianganDescription = Interpreter.interpret_tiangan(tg)
 
-      keys: list[str] = ['general', 'personality']
-      for k in keys:
-        self.assertIn(k, result)
-        self.assertIsInstance(result[k], list) # type: ignore # mypy complains.
-        self.assertGreaterEqual(len(result[k]), 1) # type: ignore # mypy complains.
-        for d in result[k]: # type: ignore # mypy complains.
-          self.assertIsInstance(d, str)
-          self.assertGreaterEqual(len(d), 1)
+    keys: list[str] = ['general', 'personality']
+    for k in keys:
+      assert k in result
+      assert isinstance(result[k], list) # type: ignore # mypy complains.
+      assert len(result[k]) >= 1 # type: ignore # mypy complains.
+      for d in result[k]: # type: ignore # mypy complains.
+        assert isinstance(d, str)
+        assert len(d) >= 1
 
-          self.assertEqual(d, d.strip(), f'"{d}" not stripped') # No space at the beginning or end.
-          self.assertTrue(d[-1] == '。', f'"{d}" not ending with "。"') # End with '。'.
+        assert d == d.strip(), f'"{d}" not stripped' # No space at the beginning or end.
+        assert d[-1] == '。', f'"{d}" not ending with "。"' # End with '。'.
 
-      self.assertEqual(result, Interpreter.interpret_tiangan(tg))
+    assert result == Interpreter.interpret_tiangan(tg)
 
-  def test_corpus_is_frozen(self) -> None:
-    # The corpus tables are frozen: reassigning an entry must fail, and mutating a
-    # returned description must not corrupt the corpus.
-    # 语料表是冻结的：覆盖条目必须报错；修改返回的描述不能污染语料库。
-    with self.assertRaises(TypeError):
-      SHISHEN_DESCRIPTIONS[Shishen.比肩] = SHISHEN_DESCRIPTIONS[Shishen.比肩] # type: ignore # mypy complains.
-    with self.assertRaises(TypeError):
-      TIANGAN_DESCRIPTIONS[Tiangan.甲] = TIANGAN_DESCRIPTIONS[Tiangan.甲] # type: ignore # mypy complains.
+def test_corpus_is_frozen() -> None:
+  # The corpus tables are frozen: reassigning an entry must fail, and mutating a
+  # returned description must not corrupt the corpus.
+  # 语料表是冻结的：覆盖条目必须报错；修改返回的描述不能污染语料库。
+  with pytest.raises(TypeError):
+    SHISHEN_DESCRIPTIONS[Shishen.比肩] = SHISHEN_DESCRIPTIONS[Shishen.比肩] # type: ignore # mypy complains.
+  with pytest.raises(TypeError):
+    TIANGAN_DESCRIPTIONS[Tiangan.甲] = TIANGAN_DESCRIPTIONS[Tiangan.甲] # type: ignore # mypy complains.
 
-    mutated_shishen: ShishenDescription = Interpreter.interpret_shishen(Shishen.比肩)
-    mutated_shishen['general'].append('污染内容')
-    self.assertNotIn('污染内容', Interpreter.interpret_shishen(Shishen.比肩)['general'])
+  mutated_shishen: ShishenDescription = Interpreter.interpret_shishen(Shishen.比肩)
+  mutated_shishen['general'].append('污染内容')
+  assert '污染内容' not in Interpreter.interpret_shishen(Shishen.比肩)['general']
 
-    mutated_tg: TianganDescription = Interpreter.interpret_tiangan(Tiangan.甲)
-    mutated_tg['general'].append('污染内容')
-    self.assertNotIn('污染内容', Interpreter.interpret_tiangan(Tiangan.甲)['general'])
+  mutated_tg: TianganDescription = Interpreter.interpret_tiangan(Tiangan.甲)
+  mutated_tg['general'].append('污染内容')
+  assert '污染内容' not in Interpreter.interpret_tiangan(Tiangan.甲)['general']

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -8,6 +8,7 @@ import pytest
 
 from src.rules import BaziRules, TianganRules, DizhiRules, ShenshaRules
 
+
 def test_basic() -> None:
   assert BaziRules.HIDDEN_TIANGANS == BaziRules.HIDDEN_TIANGANS
   assert BaziRules.TIANGAN_ZHANGSHENG == BaziRules.TIANGAN_ZHANGSHENG
@@ -16,6 +17,7 @@ def test_basic() -> None:
   assert DizhiRules.DIZHI_PO == DizhiRules.DIZHI_PO
   assert ShenshaRules.TAOHUA == ShenshaRules.TAOHUA
 
+
 def test_cache() -> None:
   assert BaziRules.HIDDEN_TIANGANS is BaziRules.HIDDEN_TIANGANS
   assert BaziRules.TIANGAN_ZHANGSHENG is BaziRules.TIANGAN_ZHANGSHENG
@@ -23,6 +25,7 @@ def test_cache() -> None:
   assert TianganRules.TIANGAN_HE is TianganRules.TIANGAN_HE
   assert DizhiRules.DIZHI_PO is DizhiRules.DIZHI_PO
   assert ShenshaRules.TAOHUA is ShenshaRules.TAOHUA
+
 
 def test_dizhi_anhe() -> None:
   # `DIZHI_ANHE` is a frozendict keyed by `AnheDef` - one sub-table per definition.
@@ -36,6 +39,7 @@ def test_dizhi_anhe() -> None:
   with pytest.raises(KeyError):
     _ = DizhiRules.DIZHI_ANHE['not an AnheDef'] # type: ignore
 
+
 def test_dizhi_xing() -> None:
   # `DIZHI_XING` is a frozendict keyed by `XingDef` - one sub-table per definition.
   assert set(DizhiRules.DIZHI_XING) == set(DizhiRules.XingDef)
@@ -47,6 +51,7 @@ def test_dizhi_xing() -> None:
     DizhiRules.DIZHI_XING[DizhiRules.XingDef.STRICT] = '' # type: ignore
   with pytest.raises(KeyError):
     _ = DizhiRules.DIZHI_XING['not a XingDef'] # type: ignore
+
 
 def test_all_rules() -> None:
   # Every table on every Rule class reads stably: equal and identical across accesses.

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -3,67 +3,67 @@
 
 import re
 import inspect
-import unittest
+
+import pytest
 
 from src.rules import BaziRules, TianganRules, DizhiRules, ShenshaRules
 
-class TestRules(unittest.TestCase):
-  def test_basic(self) -> None:
-    self.assertEqual(BaziRules.HIDDEN_TIANGANS, BaziRules.HIDDEN_TIANGANS)
-    self.assertEqual(BaziRules.TIANGAN_ZHANGSHENG, BaziRules.TIANGAN_ZHANGSHENG)
-    self.assertEqual(BaziRules.TIANGAN_TRAITS, BaziRules.TIANGAN_TRAITS)
-    self.assertEqual(TianganRules.TIANGAN_HE, TianganRules.TIANGAN_HE)
-    self.assertEqual(DizhiRules.DIZHI_PO, DizhiRules.DIZHI_PO)
-    self.assertEqual(ShenshaRules.TAOHUA, ShenshaRules.TAOHUA)
+def test_basic() -> None:
+  assert BaziRules.HIDDEN_TIANGANS == BaziRules.HIDDEN_TIANGANS
+  assert BaziRules.TIANGAN_ZHANGSHENG == BaziRules.TIANGAN_ZHANGSHENG
+  assert BaziRules.TIANGAN_TRAITS == BaziRules.TIANGAN_TRAITS
+  assert TianganRules.TIANGAN_HE == TianganRules.TIANGAN_HE
+  assert DizhiRules.DIZHI_PO == DizhiRules.DIZHI_PO
+  assert ShenshaRules.TAOHUA == ShenshaRules.TAOHUA
 
-  def test_cache(self) -> None:
-    self.assertIs(BaziRules.HIDDEN_TIANGANS, BaziRules.HIDDEN_TIANGANS) 
-    self.assertIs(BaziRules.TIANGAN_ZHANGSHENG, BaziRules.TIANGAN_ZHANGSHENG)
-    self.assertIs(BaziRules.TIANGAN_TRAITS, BaziRules.TIANGAN_TRAITS)
-    self.assertIs(TianganRules.TIANGAN_HE, TianganRules.TIANGAN_HE)
-    self.assertIs(DizhiRules.DIZHI_PO, DizhiRules.DIZHI_PO)
-    self.assertIs(ShenshaRules.TAOHUA, ShenshaRules.TAOHUA)
+def test_cache() -> None:
+  assert BaziRules.HIDDEN_TIANGANS is BaziRules.HIDDEN_TIANGANS
+  assert BaziRules.TIANGAN_ZHANGSHENG is BaziRules.TIANGAN_ZHANGSHENG
+  assert BaziRules.TIANGAN_TRAITS is BaziRules.TIANGAN_TRAITS
+  assert TianganRules.TIANGAN_HE is TianganRules.TIANGAN_HE
+  assert DizhiRules.DIZHI_PO is DizhiRules.DIZHI_PO
+  assert ShenshaRules.TAOHUA is ShenshaRules.TAOHUA
 
-  def test_dizhi_anhe(self) -> None:
-    # `DIZHI_ANHE` is a frozendict keyed by `AnheDef` - one sub-table per definition.
-    self.assertSetEqual(set(DizhiRules.DIZHI_ANHE), set(DizhiRules.AnheDef))
+def test_dizhi_anhe() -> None:
+  # `DIZHI_ANHE` is a frozendict keyed by `AnheDef` - one sub-table per definition.
+  assert set(DizhiRules.DIZHI_ANHE) == set(DizhiRules.AnheDef)
 
-    for anhe_def in DizhiRules.AnheDef:
-      self.assertEqual(DizhiRules.DIZHI_ANHE[anhe_def], DizhiRules.DIZHI_ANHE[anhe_def])
+  for anhe_def in DizhiRules.AnheDef:
+    assert DizhiRules.DIZHI_ANHE[anhe_def] == DizhiRules.DIZHI_ANHE[anhe_def]
 
-    with self.assertRaises(TypeError):
-      DizhiRules.DIZHI_ANHE[DizhiRules.AnheDef.NORMAL] = '' # type: ignore
-    with self.assertRaises(KeyError):
-      _ = DizhiRules.DIZHI_ANHE['not an AnheDef'] # type: ignore
+  with pytest.raises(TypeError):
+    DizhiRules.DIZHI_ANHE[DizhiRules.AnheDef.NORMAL] = '' # type: ignore
+  with pytest.raises(KeyError):
+    _ = DizhiRules.DIZHI_ANHE['not an AnheDef'] # type: ignore
 
-  def test_dizhi_xing(self) -> None:
-    # `DIZHI_XING` is a frozendict keyed by `XingDef` - one sub-table per definition.
-    self.assertSetEqual(set(DizhiRules.DIZHI_XING), set(DizhiRules.XingDef))
+def test_dizhi_xing() -> None:
+  # `DIZHI_XING` is a frozendict keyed by `XingDef` - one sub-table per definition.
+  assert set(DizhiRules.DIZHI_XING) == set(DizhiRules.XingDef)
 
-    for xing_def in DizhiRules.XingDef:
-      self.assertEqual(DizhiRules.DIZHI_XING[xing_def], DizhiRules.DIZHI_XING[xing_def])
+  for xing_def in DizhiRules.XingDef:
+    assert DizhiRules.DIZHI_XING[xing_def] == DizhiRules.DIZHI_XING[xing_def]
 
-    with self.assertRaises(TypeError):
-      DizhiRules.DIZHI_XING[DizhiRules.XingDef.STRICT] = '' # type: ignore
-    with self.assertRaises(KeyError):
-      _ = DizhiRules.DIZHI_XING['not a XingDef'] # type: ignore
+  with pytest.raises(TypeError):
+    DizhiRules.DIZHI_XING[DizhiRules.XingDef.STRICT] = '' # type: ignore
+  with pytest.raises(KeyError):
+    _ = DizhiRules.DIZHI_XING['not a XingDef'] # type: ignore
 
-  def test_all_rules(self) -> None:
-    # Every table on every Rule class reads stably: equal and identical across accesses.
-    # (Runtime reassignment protection was deliberately retired; `Final` + mypy is the guard now.)
+def test_all_rules() -> None:
+  # Every table on every Rule class reads stably: equal and identical across accesses.
+  # (Runtime reassignment protection was deliberately retired; `Final` + mypy is the guard now.)
 
-    def list_all_rules(rule_class: type) -> list[str]:
-      # Assume that all rules' names are consist of '_' and upper letters.
-      # Use `inspect` and `re` to find out the names of the rules.
-      return [
-        member[0] for member in inspect.getmembers(rule_class)
-        if re.match(r'^[A-Z_]+$', member[0])
-      ]
-    
-    for klass in [BaziRules, TianganRules, DizhiRules, ShenshaRules]:
-      table_names: list[str] = list_all_rules(klass)
-      self.assertGreater(len(table_names), 0)
+  def list_all_rules(rule_class: type) -> list[str]:
+    # Assume that all rules' names are consist of '_' and upper letters.
+    # Use `inspect` and `re` to find out the names of the rules.
+    return [
+      member[0] for member in inspect.getmembers(rule_class)
+      if re.match(r'^[A-Z_]+$', member[0])
+    ]
 
-      for attr in table_names:
-        self.assertEqual(getattr(klass, attr), getattr(klass, attr))
-        self.assertIs(getattr(klass, attr), getattr(klass, attr)) # Same object on every access.
+  for klass in [BaziRules, TianganRules, DizhiRules, ShenshaRules]:
+    table_names: list[str] = list_all_rules(klass)
+    assert len(table_names) > 0
+
+    for attr in table_names:
+      assert getattr(klass, attr) == getattr(klass, attr)
+      assert getattr(klass, attr) is getattr(klass, attr) # Same object on every access.

--- a/tests/test_transit_chart.py
+++ b/tests/test_transit_chart.py
@@ -20,6 +20,7 @@ def test_basic() -> None:
     transits: TransitChart = TransitChart(bazi_chart)
     assert bazi_chart.json == transits.bazi_chart.json
 
+
 def test_basic_negative() -> None:
   with pytest.raises(AssertionError):
     TransitChart(BaziChart.random().bazi) # type: ignore
@@ -28,6 +29,7 @@ def test_basic_negative() -> None:
 
   with pytest.raises(AttributeError):
     TransitChart(BaziChart.random()).bazi_chart = BaziChart.random() # type: ignore
+
 
 def test_delegation() -> None:
   bazi: Bazi = Bazi.create(datetime(2000, 2, 4, 22, 1), BaziGender.MALE, BaziPrecision.DAY)
@@ -41,6 +43,7 @@ def test_delegation() -> None:
       assert transits.support(TransitMoment(gz_year), option) == db.support(TransitMoment(gz_year), option)
       if transits.support(TransitMoment(gz_year), option):
         assert transits.ganzhis(TransitMoment(gz_year), option) == db.ganzhis(TransitMoment(gz_year), option)
+
 
 def test_delegation_negative() -> None:
   bazi: Bazi = Bazi.create(datetime(2000, 2, 4, 22, 1), BaziGender.MALE, BaziPrecision.DAY)

--- a/tests/test_transit_chart.py
+++ b/tests/test_transit_chart.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2026 Ningqi Wang (0xf3cd) <https://github.com/0xf3cd>
 # test_transit_chart.py
 
-import unittest
+import pytest
 
 from datetime import datetime
 
@@ -12,45 +12,51 @@ from src.transits import TransitMoment, TransitOptions, TransitDatabase
 from src.transit_chart import TransitChart, 流年大运
 
 
-class TestTransitChart(unittest.TestCase):
-  def test_basic(self) -> None:
-    self.assertIs(TransitChart, 流年大运)
+def test_basic() -> None:
+  assert TransitChart is 流年大运
 
-    for _ in range(4):
-      bazi_chart: BaziChart = BaziChart.random()
-      transits: TransitChart = TransitChart(bazi_chart)
-      self.assertEqual(bazi_chart.json, transits.bazi_chart.json)
+  for _ in range(4):
+    bazi_chart: BaziChart = BaziChart.random()
+    transits: TransitChart = TransitChart(bazi_chart)
+    assert bazi_chart.json == transits.bazi_chart.json
 
-  def test_basic_negative(self) -> None:
-    self.assertRaises(AssertionError, lambda: TransitChart(BaziChart.random().bazi)) # type: ignore
-    self.assertRaises(AssertionError, lambda: TransitChart(datetime(2024, 1, 1))) # type: ignore
+def test_basic_negative() -> None:
+  with pytest.raises(AssertionError):
+    TransitChart(BaziChart.random().bazi) # type: ignore
+  with pytest.raises(AssertionError):
+    TransitChart(datetime(2024, 1, 1)) # type: ignore
 
-    with self.assertRaises(AttributeError):
-      TransitChart(BaziChart.random()).bazi_chart = BaziChart.random() # type: ignore
+  with pytest.raises(AttributeError):
+    TransitChart(BaziChart.random()).bazi_chart = BaziChart.random() # type: ignore
 
-  def test_delegation(self) -> None:
-    bazi: Bazi = Bazi.create(datetime(2000, 2, 4, 22, 1), BaziGender.MALE, BaziPrecision.DAY)
-    transits: TransitChart = TransitChart(BaziChart(bazi))
-    db: TransitDatabase = TransitDatabase(transits.bazi_chart)
+def test_delegation() -> None:
+  bazi: Bazi = Bazi.create(datetime(2000, 2, 4, 22, 1), BaziGender.MALE, BaziPrecision.DAY)
+  transits: TransitChart = TransitChart(BaziChart(bazi))
+  db: TransitDatabase = TransitDatabase(transits.bazi_chart)
 
-    first_dayun_gz_year: int = next(transits.bazi_chart.dayun).ganzhi_year
+  first_dayun_gz_year: int = next(transits.bazi_chart.dayun).ganzhi_year
 
-    for gz_year in (first_dayun_gz_year, first_dayun_gz_year + 7, first_dayun_gz_year + 25):
-      for option in TransitOptions:
-        self.assertEqual(transits.support(TransitMoment(gz_year), option), db.support(TransitMoment(gz_year), option))
-        if transits.support(TransitMoment(gz_year), option):
-          self.assertEqual(transits.ganzhis(TransitMoment(gz_year), option), db.ganzhis(TransitMoment(gz_year), option))
+  for gz_year in (first_dayun_gz_year, first_dayun_gz_year + 7, first_dayun_gz_year + 25):
+    for option in TransitOptions:
+      assert transits.support(TransitMoment(gz_year), option) == db.support(TransitMoment(gz_year), option)
+      if transits.support(TransitMoment(gz_year), option):
+        assert transits.ganzhis(TransitMoment(gz_year), option) == db.ganzhis(TransitMoment(gz_year), option)
 
-  def test_delegation_negative(self) -> None:
-    bazi: Bazi = Bazi.create(datetime(2000, 2, 4, 22, 1), BaziGender.MALE, BaziPrecision.DAY)
-    transits: TransitChart = TransitChart(BaziChart(bazi))
+def test_delegation_negative() -> None:
+  bazi: Bazi = Bazi.create(datetime(2000, 2, 4, 22, 1), BaziGender.MALE, BaziPrecision.DAY)
+  transits: TransitChart = TransitChart(BaziChart(bazi))
 
-    self.assertRaises(AssertionError, lambda: transits.support('1999', TransitOptions.XIAOYUN)) # type: ignore
-    self.assertRaises(AssertionError, lambda: transits.support(1999, TransitOptions.XIAOYUN)) # type: ignore # int no longer accepted; `TransitMoment` required.
-    self.assertRaises(AssertionError, lambda: transits.ganzhis(TransitMoment(1999), 'XIAOYUN')) # type: ignore
-    # Month/day-granularity moments are rejected until #48 / #48 落地前，月/日粒度的 moment 显式拒绝。
-    self.assertRaises(NotImplementedError, lambda: transits.support(TransitMoment(2000, gz_month=Dizhi.寅), TransitOptions.LIUNIAN))
+  with pytest.raises(AssertionError):
+    transits.support('1999', TransitOptions.XIAOYUN) # type: ignore
+  with pytest.raises(AssertionError):
+    transits.support(1999, TransitOptions.XIAOYUN) # type: ignore # int no longer accepted; `TransitMoment` required.
+  with pytest.raises(AssertionError):
+    transits.ganzhis(TransitMoment(1999), 'XIAOYUN') # type: ignore
+  # Month/day-granularity moments are rejected until #48 / #48 落地前，月/日粒度的 moment 显式拒绝。
+  with pytest.raises(NotImplementedError):
+    transits.support(TransitMoment(2000, gz_month=Dizhi.寅), TransitOptions.LIUNIAN)
 
-    first_dayun_gz_year: int = next(transits.bazi_chart.dayun).ganzhi_year
-    self.assertFalse(transits.support(TransitMoment(first_dayun_gz_year - 1), TransitOptions.DAYUN))
-    self.assertRaises(ValueError, lambda: transits.ganzhis(TransitMoment(first_dayun_gz_year - 1), TransitOptions.DAYUN))
+  first_dayun_gz_year: int = next(transits.bazi_chart.dayun).ganzhi_year
+  assert not transits.support(TransitMoment(first_dayun_gz_year - 1), TransitOptions.DAYUN)
+  with pytest.raises(ValueError):
+    transits.ganzhis(TransitMoment(first_dayun_gz_year - 1), TransitOptions.DAYUN)

--- a/tests/test_transits.py
+++ b/tests/test_transits.py
@@ -30,6 +30,7 @@ def test_simple() -> None:
   for year in range(first_dayun.ganzhi_year + 20, first_dayun.ganzhi_year + 30):
     assert db[year] == DayunTuple(first_dayun.ganzhi_year + 20, Ganzhi.from_str('辛巳'))
 
+
 def test_dayun_database() -> None:
   chart: BaziChart = BaziChart.random()
 
@@ -74,12 +75,12 @@ def test_support() -> None:
     with pytest.raises(AssertionError):
       db.support(TransitMoment(1999), TransitOptions(0x8))
 
-    # Test ganzhi years before the birth year. Expect not to support.
+    # Ganzhi years before the birth year are not supported.
     for gz_year in range(chart.bazi.ganzhi_date.year - 10, chart.bazi.ganzhi_date.year):
       for option in TransitOptions:
         assert not db.support(TransitMoment(gz_year), option)
 
-    # Test Xiaoyun / 小运.
+    # Xiaoyun / 小运.
     first_dayun_gz_year: int = next(chart.dayun).ganzhi_year
     for gz_year in range(chart.bazi.ganzhi_date.year, chart.bazi.ganzhi_date.year + len(chart.xiaoyun)):
       assert db.support(TransitMoment(gz_year), TransitOptions.XIAOYUN)
@@ -92,12 +93,13 @@ def test_support() -> None:
       else:
         assert gz_year < first_dayun_gz_year
 
-    # Test Dayun / 大运.
+    # Dayun / 大运.
     for start_gz_year, _ in itertools.islice(chart.dayun, 10): # Expect the first 10 dayuns to be supported anyways...
       for gz_year in range(start_gz_year, start_gz_year + 10):
         assert db.support(TransitMoment(gz_year), TransitOptions.DAYUN)
         assert db.support(TransitMoment(gz_year), TransitOptions.LIUNIAN)
         assert db.support(TransitMoment(gz_year), TransitOptions.DAYUN_LIUNIAN)
+
 
 def test_ganzhis() -> None:
   for _ in range(4):
@@ -158,12 +160,14 @@ def test_valid_shapes() -> None:
   assert day_moment.gz_month is None
   assert day_moment.solar_date == date(1990, 5, 20)
 
+
 def test_value_semantics() -> None:
   '''Equality and hash -- the contract that the exact-type check defends / 相等性与 hash——精确类型检查所捍卫的契约。'''
   assert TransitMoment(1990) == TransitMoment(1990)
   assert hash(TransitMoment(1990)) == hash(TransitMoment(1990))
   assert TransitMoment(1990) != TransitMoment(1990, gz_month=Dizhi.寅)
   assert 1 == len({TransitMoment(1990), TransitMoment(1990)})
+
 
 def test_invalid() -> None:
   with pytest.raises(AssertionError):
@@ -178,6 +182,7 @@ def test_invalid() -> None:
   # The month and day granularities are mutually exclusive / 月粒度与日粒度互斥。
   with pytest.raises(AssertionError):
     TransitMoment(1990, gz_month=Dizhi.寅, solar_date=date(1990, 5, 20))
+
 
 def test_granularity_rejection() -> None:
   '''Month/day granularities are explicitly rejected before #48 lands / #48 落地前，月/日粒度显式拒绝。'''
@@ -215,13 +220,14 @@ def test_enumeration() -> None:
 # HOUR / MINUTE charts (issue #6): the database's birth-side year must be the chart's own
 # precision-attributed `Bazi.ganzhi_year`, not the day-level `ganzhi_date.year`.
 
+
 def test_birth_year_is_precision_attributed() -> None:
   '''
   Cross-midnight tie chart (2009-02-03 23:30 female, HOUR): the chart's year pillar is
   己丑 2009, its liunian generator starts at 2009, and its dayun starts in 2018 (虚岁 10).
-  Before the fix the day-level 2008 leaked in: `ganzhis(2008, LIUNIAN)` returned 戊子 --
-  a ganzhi this chart's liunian never produces -- and 虚岁 10 mapped to 2017, so the true
-  dayun-start year 2018 answered `support == False` for xiaoyun.
+  The day-level 2008 must stay out of the database: 戊子 is a ganzhi this chart's liunian
+  never produces, and 虚岁 must count from 2009 so that the dayun-start year 2018 supports
+  xiaoyun.
   '''
   chart: BaziChart = BaziChart(Bazi.create('2009-02-03 23:30', 'female', 'hour'))
   assert chart.bazi.ganzhi_year == 2009
@@ -237,8 +243,9 @@ def test_birth_year_is_precision_attributed() -> None:
     chart.bazi.year_pillar, # The first liunian IS the year pillar.
   )
 
+
 def test_day_precision_unchanged() -> None:
-  '''At DAY the two year channels agree, so the database is unaffected by the migration.'''
+  '''At DAY the two year channels agree.'''
   chart: BaziChart = BaziChart(Bazi.create('2009-02-03 23:30', 'female', 'day'))
   assert chart.bazi.ganzhi_year == chart.bazi.ganzhi_date.year
   db: TransitDatabase = TransitDatabase(chart)

--- a/tests/test_transits.py
+++ b/tests/test_transits.py
@@ -1,11 +1,11 @@
 # Copyright (C) 2024 Ningqi Wang (0xf3cd) <https://github.com/0xf3cd>
 # test_transits.py
 
-import unittest
-
 import random
 import itertools
 from datetime import date, datetime
+
+import pytest
 
 from src.data_types import DayunTuple
 from src.defines import Ganzhi, Dizhi
@@ -17,223 +17,230 @@ from src.bazi_chart import BaziChart
 from src.transits import DayunDatabase, TransitMoment, TransitOptions, TransitDatabase, _ALL_OPTIONS
 
 
-class TestDayunDatabase(unittest.TestCase):
-  def test_simple(self) -> None:
-    bazi: Bazi = Bazi.create(datetime(2000, 2, 4, 22, 1), BaziGender.MALE, BaziPrecision.DAY)
-    chart: BaziChart = BaziChart(bazi)
-    db = DayunDatabase(chart)
+def test_simple() -> None:
+  bazi: Bazi = Bazi.create(datetime(2000, 2, 4, 22, 1), BaziGender.MALE, BaziPrecision.DAY)
+  chart: BaziChart = BaziChart(bazi)
+  db = DayunDatabase(chart)
 
-    first_dayun: DayunTuple = next(chart.dayun)
-    for year in range(first_dayun.ganzhi_year, first_dayun.ganzhi_year + 10):
-      self.assertEqual(db[year], DayunTuple(first_dayun.ganzhi_year, Ganzhi.from_str('己卯')))
-    for year in range(first_dayun.ganzhi_year + 10, first_dayun.ganzhi_year + 20):
-      self.assertEqual(db[year], DayunTuple(first_dayun.ganzhi_year + 10, Ganzhi.from_str('庚辰')))
-    for year in range(first_dayun.ganzhi_year + 20, first_dayun.ganzhi_year + 30):
-      self.assertEqual(db[year], DayunTuple(first_dayun.ganzhi_year + 20, Ganzhi.from_str('辛巳')))
+  first_dayun: DayunTuple = next(chart.dayun)
+  for year in range(first_dayun.ganzhi_year, first_dayun.ganzhi_year + 10):
+    assert db[year] == DayunTuple(first_dayun.ganzhi_year, Ganzhi.from_str('己卯'))
+  for year in range(first_dayun.ganzhi_year + 10, first_dayun.ganzhi_year + 20):
+    assert db[year] == DayunTuple(first_dayun.ganzhi_year + 10, Ganzhi.from_str('庚辰'))
+  for year in range(first_dayun.ganzhi_year + 20, first_dayun.ganzhi_year + 30):
+    assert db[year] == DayunTuple(first_dayun.ganzhi_year + 20, Ganzhi.from_str('辛巳'))
 
-  def test_dayun_database(self) -> None:
-    chart: BaziChart = BaziChart.random()
+def test_dayun_database() -> None:
+  chart: BaziChart = BaziChart.random()
 
-    expected: dict[int, DayunTuple] = {}
-    for start_year, dayun_ganzhi in itertools.islice(chart.dayun, 100):
-      for year in range(start_year, start_year + 10): # A dayun lasts for 10 years.
-        expected[year] = DayunTuple(start_year, dayun_ganzhi)
+  expected: dict[int, DayunTuple] = {}
+  for start_year, dayun_ganzhi in itertools.islice(chart.dayun, 100):
+    for year in range(start_year, start_year + 10): # A dayun lasts for 10 years.
+      expected[year] = DayunTuple(start_year, dayun_ganzhi)
 
-    db: DayunDatabase = DayunDatabase(chart)
-    self.assertRaises(AssertionError, lambda : db[next(chart.dayun).ganzhi_year - 1]) # Test the year before the start of the dayun.
+  db: DayunDatabase = DayunDatabase(chart)
+  with pytest.raises(AssertionError): # Test the year before the start of the dayun.
+    db[next(chart.dayun).ganzhi_year - 1]
 
-    years: list[int] = list(expected.keys())
+  years: list[int] = list(expected.keys())
 
-    for year in random.sample(years, 100):
-      self.assertEqual(db[year], expected[year])
-    
-    for year in random.sample(years, 100):
-      self.assertEqual(db[year], expected[year])
-    
-    random.shuffle(years)
-    for year in years:
-      self.assertEqual(db[year], expected[year])
+  for year in random.sample(years, 100):
+    assert db[year] == expected[year]
 
+  for year in random.sample(years, 100):
+    assert db[year] == expected[year]
 
-class TestTransitDatabase(unittest.TestCase):
-  def test_support(self) -> None:
-    for _ in range(4):
-      chart: BaziChart = BaziChart.random()
-      db: TransitDatabase = TransitDatabase(chart)
-
-      self.assertRaises(AssertionError, lambda: db.support('1999', TransitOptions.XIAOYUN)) # type: ignore
-      self.assertRaises(AssertionError, lambda: db.support(1999, TransitOptions.XIAOYUN)) # type: ignore # int no longer accepted; `TransitMoment` required.
-      self.assertRaises(AssertionError, lambda: db.support(TransitMoment(1999), 'XIAOYUN')) # type: ignore
-      self.assertRaises(AssertionError, lambda: db.support(TransitMoment(1999), 0x1 | 0x4)) # type: ignore
-      # Zero-value and unknown-bit flags are rejected on all Python versions (3.12+'s `in` used to let them through).
-      self.assertRaises(AssertionError, lambda: db.support(TransitMoment(1999), TransitOptions(0)))
-      self.assertRaises(AssertionError, lambda: db.support(TransitMoment(1999), TransitOptions(0x8)))
-
-      with self.subTest('Test ganzhi years before the birth year. Expect not to support.'):
-        for gz_year in range(chart.bazi.ganzhi_date.year - 10, chart.bazi.ganzhi_date.year):
-          for option in TransitOptions:
-            self.assertFalse(db.support(TransitMoment(gz_year), option))
-
-      with self.subTest('Test Xiaoyun / 小运.'):
-        first_dayun_gz_year: int = next(chart.dayun).ganzhi_year
-        for gz_year in range(chart.bazi.ganzhi_date.year, chart.bazi.ganzhi_date.year + len(chart.xiaoyun)):
-          self.assertTrue(db.support(TransitMoment(gz_year), TransitOptions.XIAOYUN))
-          self.assertTrue(db.support(TransitMoment(gz_year), TransitOptions.LIUNIAN))
-          self.assertTrue(db.support(TransitMoment(gz_year), TransitOptions.XIAOYUN_LIUNIAN))
-
-          # The last Xiaoyun year may also be the first Dayun year - this is the only expected overlap.
-          if db.support(TransitMoment(gz_year), TransitOptions.DAYUN):
-            self.assertEqual(gz_year, first_dayun_gz_year)
-          else:
-            self.assertLess(gz_year, first_dayun_gz_year)
-
-      with self.subTest('Test Dayun / 大运.'):
-        for start_gz_year, _ in itertools.islice(chart.dayun, 10): # Expect the first 10 dayuns to be supported anyways...
-          for gz_year in range(start_gz_year, start_gz_year + 10):
-            self.assertTrue(db.support(TransitMoment(gz_year), TransitOptions.DAYUN))
-            self.assertTrue(db.support(TransitMoment(gz_year), TransitOptions.LIUNIAN))
-            self.assertTrue(db.support(TransitMoment(gz_year), TransitOptions.DAYUN_LIUNIAN))
-
-  def test_ganzhis(self) -> None:
-    for _ in range(4):
-      chart = BaziChart.random()
-      db: TransitDatabase = TransitDatabase(chart)
-
-      xiaoyun_ganzhis: dict[int, Ganzhi] = {
-        chart.bazi.ganzhi_date.year + age - 1 : xy
-        for age, xy in chart.xiaoyun
-      }
-
-      dayun_start_gz_year: int = to_ganzhi(chart.dayun_start_moment).year
-      dayun_ganzhis: list[Ganzhi] = [dy.ganzhi for dy in itertools.islice(chart.dayun, 50)]
-
-      # Randomly select 20 ganzhi years to test...
-      random_liunians = random.sample(list(itertools.islice(chart.liunian, 200)), 20)
-      random.shuffle(random_liunians)
-
-      self.assertRaises(ValueError, lambda: db.ganzhis(TransitMoment(dayun_start_gz_year - 1), TransitOptions.DAYUN))
-
-      for gz_year, _ in random_liunians:
-        for option in TransitOptions:
-          if not db.support(TransitMoment(gz_year), option):
-            self.assertRaises(ValueError, lambda: db.ganzhis(TransitMoment(gz_year), option))
-            continue
-
-          transit_ganzhis: list[Ganzhi] = []
-          if option.value & TransitOptions.XIAOYUN.value:
-            transit_ganzhis.append(xiaoyun_ganzhis[gz_year])
-          if option.value & TransitOptions.DAYUN.value:
-            dayun_index: int = (gz_year - dayun_start_gz_year) // 10
-            transit_ganzhis.append(dayun_ganzhis[dayun_index])
-          if option.value & TransitOptions.LIUNIAN.value:
-            transit_ganzhis.append(bazi_utils.ganzhi_of_year(gz_year))
-
-          actual = db.ganzhis(TransitMoment(gz_year), option)
-          self.assertEqual(len(actual), len(transit_ganzhis))
-          for gz in actual:
-            self.assertIn(gz, transit_ganzhis)
+  random.shuffle(years)
+  for year in years:
+    assert db[year] == expected[year]
 
 
-class TestTransitMoment(unittest.TestCase):
-  def test_valid_shapes(self) -> None:
-    '''The three granularities / 三种粒度：年、月、日。'''
-    year_moment = TransitMoment(1990)
-    self.assertEqual(year_moment.gz_year, 1990)
-    self.assertIsNone(year_moment.gz_month)
-    self.assertIsNone(year_moment.solar_date)
-
-    month_moment = TransitMoment(1990, gz_month=Dizhi.寅)
-    self.assertEqual(month_moment.gz_year, 1990)
-    self.assertEqual(month_moment.gz_month, Dizhi.寅)
-    self.assertIsNone(month_moment.solar_date)
-
-    day_moment = TransitMoment(1990, solar_date=date(1990, 5, 20))
-    self.assertEqual(day_moment.gz_year, 1990)
-    self.assertIsNone(day_moment.gz_month)
-    self.assertEqual(day_moment.solar_date, date(1990, 5, 20))
-
-  def test_value_semantics(self) -> None:
-    '''Equality and hash -- the contract that the exact-type check defends / 相等性与 hash——精确类型检查所捍卫的契约。'''
-    self.assertEqual(TransitMoment(1990), TransitMoment(1990))
-    self.assertEqual(hash(TransitMoment(1990)), hash(TransitMoment(1990)))
-    self.assertNotEqual(TransitMoment(1990), TransitMoment(1990, gz_month=Dizhi.寅))
-    self.assertEqual(1, len({TransitMoment(1990), TransitMoment(1990)}))
-
-  def test_invalid(self) -> None:
-    self.assertRaises(AssertionError, lambda: TransitMoment('1990')) # type: ignore
-    self.assertRaises(AssertionError, lambda: TransitMoment(1990, gz_month=3)) # type: ignore
-    self.assertRaises(AssertionError, lambda: TransitMoment(1990, solar_date='1990-05-20')) # type: ignore
-    # `datetime` is a `date` subclass but breaks the value semantics / datetime 是 date 子类，但破坏值语义（与 date 不相等、hash 不同）。
-    self.assertRaises(AssertionError, lambda: TransitMoment(1990, solar_date=datetime(1990, 5, 20, 12, 0)))
-    # The month and day granularities are mutually exclusive / 月粒度与日粒度互斥。
-    self.assertRaises(AssertionError, lambda: TransitMoment(1990, gz_month=Dizhi.寅, solar_date=date(1990, 5, 20)))
-
-  def test_granularity_rejection(self) -> None:
-    '''Month/day granularities are explicitly rejected before #48 lands / #48 落地前，月/日粒度显式拒绝。'''
+def test_support() -> None:
+  for _ in range(4):
     chart: BaziChart = BaziChart.random()
     db: TransitDatabase = TransitDatabase(chart)
-    gz_year: int = chart.bazi.ganzhi_date.year
 
-    moments = [
-      TransitMoment(gz_year, gz_month=Dizhi.寅),
-      TransitMoment(gz_year, solar_date=date(gz_year, 5, 20)),
-    ]
-    for moment in moments:
-      self.assertRaises(NotImplementedError, lambda: db.support(moment, TransitOptions.LIUNIAN))
-      self.assertRaises(NotImplementedError, lambda: db.ganzhis(moment, TransitOptions.LIUNIAN))
+    with pytest.raises(AssertionError):
+      db.support('1999', TransitOptions.XIAOYUN) # type: ignore
+    with pytest.raises(AssertionError):
+      db.support(1999, TransitOptions.XIAOYUN) # type: ignore # int no longer accepted; `TransitMoment` required.
+    with pytest.raises(AssertionError):
+      db.support(TransitMoment(1999), 'XIAOYUN') # type: ignore
+    with pytest.raises(AssertionError):
+      db.support(TransitMoment(1999), 0x1 | 0x4) # type: ignore
+    # Zero-value and unknown-bit flags are rejected on all Python versions (3.12+'s `in` used to let them through).
+    with pytest.raises(AssertionError):
+      db.support(TransitMoment(1999), TransitOptions(0))
+    with pytest.raises(AssertionError):
+      db.support(TransitMoment(1999), TransitOptions(0x8))
 
+    # Test ganzhi years before the birth year. Expect not to support.
+    for gz_year in range(chart.bazi.ganzhi_date.year - 10, chart.bazi.ganzhi_date.year):
+      for option in TransitOptions:
+        assert not db.support(TransitMoment(gz_year), option)
 
-class TestAllOptions(unittest.TestCase):
-  def test_enumeration(self) -> None:
-    '''`_ALL_OPTIONS` enumerates all non-empty combos of the single-bit members / 枚举单 bit 成员的全部非空组合（扩位自动跟随）。'''
-    singles = [opt for opt in TransitOptions if opt.value > 0 and opt.value & (opt.value - 1) == 0]
+    # Test Xiaoyun / 小运.
+    first_dayun_gz_year: int = next(chart.dayun).ganzhi_year
+    for gz_year in range(chart.bazi.ganzhi_date.year, chart.bazi.ganzhi_date.year + len(chart.xiaoyun)):
+      assert db.support(TransitMoment(gz_year), TransitOptions.XIAOYUN)
+      assert db.support(TransitMoment(gz_year), TransitOptions.LIUNIAN)
+      assert db.support(TransitMoment(gz_year), TransitOptions.XIAOYUN_LIUNIAN)
 
-    self.assertEqual(len(_ALL_OPTIONS), 2 ** len(singles) - 1)
-    # The unnamed combo that the old hand-listed `random()` never returned.
-    self.assertIn(TransitOptions.XIAOYUN | TransitOptions.DAYUN, _ALL_OPTIONS)
-    # Every enumerated option is non-zero and composed of known bits only.
-    # (Do NOT assert `opt in TransitOptions` here -- on Python 3.11 the enum `in`
-    # rejects unnamed composites, which is exactly what this test enumerates.)
-    full_mask = sum(opt.value for opt in singles)
-    for opt in _ALL_OPTIONS:
-      self.assertGreater(opt.value, 0)
-      self.assertEqual(full_mask, opt.value | full_mask)
+      # The last Xiaoyun year may also be the first Dayun year - this is the only expected overlap.
+      if db.support(TransitMoment(gz_year), TransitOptions.DAYUN):
+        assert gz_year == first_dayun_gz_year
+      else:
+        assert gz_year < first_dayun_gz_year
 
+    # Test Dayun / 大运.
+    for start_gz_year, _ in itertools.islice(chart.dayun, 10): # Expect the first 10 dayuns to be supported anyways...
+      for gz_year in range(start_gz_year, start_gz_year + 10):
+        assert db.support(TransitMoment(gz_year), TransitOptions.DAYUN)
+        assert db.support(TransitMoment(gz_year), TransitOptions.LIUNIAN)
+        assert db.support(TransitMoment(gz_year), TransitOptions.DAYUN_LIUNIAN)
 
-class TestTransitDatabaseHourMinutePrecisions(unittest.TestCase):
-  '''
-  HOUR / MINUTE charts (issue #6): the database's birth-side year must be the chart's own
-  precision-attributed `Bazi.ganzhi_year`, not the day-level `ganzhi_date.year`.
-  '''
-
-  def test_birth_year_is_precision_attributed(self) -> None:
-    '''
-    Cross-midnight tie chart (2009-02-03 23:30 female, HOUR): the chart's year pillar is
-    己丑 2009, its liunian generator starts at 2009, and its dayun starts in 2018 (虚岁 10).
-    Before the fix the day-level 2008 leaked in: `ganzhis(2008, LIUNIAN)` returned 戊子 --
-    a ganzhi this chart's liunian never produces -- and 虚岁 10 mapped to 2017, so the true
-    dayun-start year 2018 answered `support == False` for xiaoyun.
-    '''
-    chart: BaziChart = BaziChart(Bazi.create('2009-02-03 23:30', 'female', 'hour'))
-    self.assertEqual(chart.bazi.ganzhi_year, 2009)
+def test_ganzhis() -> None:
+  for _ in range(4):
+    chart = BaziChart.random()
     db: TransitDatabase = TransitDatabase(chart)
 
-    for options in (TransitOptions.LIUNIAN, TransitOptions.XIAOYUN):
-      with self.subTest(options=options):
-        self.assertFalse(db.support(TransitMoment(2008), options))
-        self.assertTrue(db.support(TransitMoment(2009), options))
+    xiaoyun_ganzhis: dict[int, Ganzhi] = {
+      chart.bazi.ganzhi_date.year + age - 1 : xy
+      for age, xy in chart.xiaoyun
+    }
 
-    self.assertTrue(db.support(TransitMoment(2018), TransitOptions.XIAOYUN)) # 虚岁 10, the dayun-start year.
-    self.assertFalse(db.support(TransitMoment(2019), TransitOptions.XIAOYUN)) # Past the xiaoyun range.
-    self.assertEqual(
-      db.ganzhis(TransitMoment(2009), TransitOptions.LIUNIAN),
-      (chart.bazi.year_pillar,), # The first liunian IS the year pillar.
-    )
+    dayun_start_gz_year: int = to_ganzhi(chart.dayun_start_moment).year
+    dayun_ganzhis: list[Ganzhi] = [dy.ganzhi for dy in itertools.islice(chart.dayun, 50)]
 
-  def test_day_precision_unchanged(self) -> None:
-    '''At DAY the two year channels agree, so the database is unaffected by the migration.'''
-    chart: BaziChart = BaziChart(Bazi.create('2009-02-03 23:30', 'female', 'day'))
-    self.assertEqual(chart.bazi.ganzhi_year, chart.bazi.ganzhi_date.year)
-    db: TransitDatabase = TransitDatabase(chart)
-    self.assertTrue(db.support(TransitMoment(2008), TransitOptions.LIUNIAN))  # 戊子 2008 IS this chart's first liunian.
-    self.assertFalse(db.support(TransitMoment(2007), TransitOptions.LIUNIAN))
+    # Randomly select 20 ganzhi years to test...
+    random_liunians = random.sample(list(itertools.islice(chart.liunian, 200)), 20)
+    random.shuffle(random_liunians)
+
+    with pytest.raises(ValueError):
+      db.ganzhis(TransitMoment(dayun_start_gz_year - 1), TransitOptions.DAYUN)
+
+    for gz_year, _ in random_liunians:
+      for option in TransitOptions:
+        if not db.support(TransitMoment(gz_year), option):
+          with pytest.raises(ValueError):
+            db.ganzhis(TransitMoment(gz_year), option)
+          continue
+
+        transit_ganzhis: list[Ganzhi] = []
+        if option.value & TransitOptions.XIAOYUN.value:
+          transit_ganzhis.append(xiaoyun_ganzhis[gz_year])
+        if option.value & TransitOptions.DAYUN.value:
+          dayun_index: int = (gz_year - dayun_start_gz_year) // 10
+          transit_ganzhis.append(dayun_ganzhis[dayun_index])
+        if option.value & TransitOptions.LIUNIAN.value:
+          transit_ganzhis.append(bazi_utils.ganzhi_of_year(gz_year))
+
+        actual = db.ganzhis(TransitMoment(gz_year), option)
+        assert len(actual) == len(transit_ganzhis)
+        for gz in actual:
+          assert gz in transit_ganzhis
+
+
+def test_valid_shapes() -> None:
+  '''The three granularities / 三种粒度：年、月、日。'''
+  year_moment = TransitMoment(1990)
+  assert year_moment.gz_year == 1990
+  assert year_moment.gz_month is None
+  assert year_moment.solar_date is None
+
+  month_moment = TransitMoment(1990, gz_month=Dizhi.寅)
+  assert month_moment.gz_year == 1990
+  assert month_moment.gz_month == Dizhi.寅
+  assert month_moment.solar_date is None
+
+  day_moment = TransitMoment(1990, solar_date=date(1990, 5, 20))
+  assert day_moment.gz_year == 1990
+  assert day_moment.gz_month is None
+  assert day_moment.solar_date == date(1990, 5, 20)
+
+def test_value_semantics() -> None:
+  '''Equality and hash -- the contract that the exact-type check defends / 相等性与 hash——精确类型检查所捍卫的契约。'''
+  assert TransitMoment(1990) == TransitMoment(1990)
+  assert hash(TransitMoment(1990)) == hash(TransitMoment(1990))
+  assert TransitMoment(1990) != TransitMoment(1990, gz_month=Dizhi.寅)
+  assert 1 == len({TransitMoment(1990), TransitMoment(1990)})
+
+def test_invalid() -> None:
+  with pytest.raises(AssertionError):
+    TransitMoment('1990') # type: ignore
+  with pytest.raises(AssertionError):
+    TransitMoment(1990, gz_month=3) # type: ignore
+  with pytest.raises(AssertionError):
+    TransitMoment(1990, solar_date='1990-05-20') # type: ignore
+  # `datetime` is a `date` subclass but breaks the value semantics / datetime 是 date 子类，但破坏值语义（与 date 不相等、hash 不同）。
+  with pytest.raises(AssertionError):
+    TransitMoment(1990, solar_date=datetime(1990, 5, 20, 12, 0))
+  # The month and day granularities are mutually exclusive / 月粒度与日粒度互斥。
+  with pytest.raises(AssertionError):
+    TransitMoment(1990, gz_month=Dizhi.寅, solar_date=date(1990, 5, 20))
+
+def test_granularity_rejection() -> None:
+  '''Month/day granularities are explicitly rejected before #48 lands / #48 落地前，月/日粒度显式拒绝。'''
+  chart: BaziChart = BaziChart.random()
+  db: TransitDatabase = TransitDatabase(chart)
+  gz_year: int = chart.bazi.ganzhi_date.year
+
+  moments = [
+    TransitMoment(gz_year, gz_month=Dizhi.寅),
+    TransitMoment(gz_year, solar_date=date(gz_year, 5, 20)),
+  ]
+  for moment in moments:
+    with pytest.raises(NotImplementedError):
+      db.support(moment, TransitOptions.LIUNIAN)
+    with pytest.raises(NotImplementedError):
+      db.ganzhis(moment, TransitOptions.LIUNIAN)
+
+
+def test_enumeration() -> None:
+  '''`_ALL_OPTIONS` enumerates all non-empty combos of the single-bit members / 枚举单 bit 成员的全部非空组合（扩位自动跟随）。'''
+  singles = [opt for opt in TransitOptions if opt.value > 0 and opt.value & (opt.value - 1) == 0]
+
+  assert len(_ALL_OPTIONS) == 2 ** len(singles) - 1
+  # The unnamed combo that the old hand-listed `random()` never returned.
+  assert TransitOptions.XIAOYUN | TransitOptions.DAYUN in _ALL_OPTIONS
+  # Every enumerated option is non-zero and composed of known bits only.
+  # (Do NOT assert `opt in TransitOptions` here -- on Python 3.11 the enum `in`
+  # rejects unnamed composites, which is exactly what this test enumerates.)
+  full_mask = sum(opt.value for opt in singles)
+  for opt in _ALL_OPTIONS:
+    assert opt.value > 0
+    assert full_mask == opt.value | full_mask
+
+
+# HOUR / MINUTE charts (issue #6): the database's birth-side year must be the chart's own
+# precision-attributed `Bazi.ganzhi_year`, not the day-level `ganzhi_date.year`.
+
+def test_birth_year_is_precision_attributed() -> None:
+  '''
+  Cross-midnight tie chart (2009-02-03 23:30 female, HOUR): the chart's year pillar is
+  己丑 2009, its liunian generator starts at 2009, and its dayun starts in 2018 (虚岁 10).
+  Before the fix the day-level 2008 leaked in: `ganzhis(2008, LIUNIAN)` returned 戊子 --
+  a ganzhi this chart's liunian never produces -- and 虚岁 10 mapped to 2017, so the true
+  dayun-start year 2018 answered `support == False` for xiaoyun.
+  '''
+  chart: BaziChart = BaziChart(Bazi.create('2009-02-03 23:30', 'female', 'hour'))
+  assert chart.bazi.ganzhi_year == 2009
+  db: TransitDatabase = TransitDatabase(chart)
+
+  for options in (TransitOptions.LIUNIAN, TransitOptions.XIAOYUN):
+    assert not db.support(TransitMoment(2008), options)
+    assert db.support(TransitMoment(2009), options)
+
+  assert db.support(TransitMoment(2018), TransitOptions.XIAOYUN) # 虚岁 10, the dayun-start year.
+  assert not db.support(TransitMoment(2019), TransitOptions.XIAOYUN) # Past the xiaoyun range.
+  assert db.ganzhis(TransitMoment(2009), TransitOptions.LIUNIAN) == (
+    chart.bazi.year_pillar, # The first liunian IS the year pillar.
+  )
+
+def test_day_precision_unchanged() -> None:
+  '''At DAY the two year channels agree, so the database is unaffected by the migration.'''
+  chart: BaziChart = BaziChart(Bazi.create('2009-02-03 23:30', 'female', 'day'))
+  assert chart.bazi.ganzhi_year == chart.bazi.ganzhi_date.year
+  db: TransitDatabase = TransitDatabase(chart)
+  assert db.support(TransitMoment(2008), TransitOptions.LIUNIAN)  # 戊子 2008 IS this chart's first liunian.
+  assert not db.support(TransitMoment(2007), TransitOptions.LIUNIAN)

--- a/tests/utils/test_bazi_utils.py
+++ b/tests/utils/test_bazi_utils.py
@@ -38,6 +38,7 @@ def test_ganzhi_of_day_basic() -> None:
     d = date(2024, 3, 1) + timedelta(days=offset)
     assert bazi_utils.ganzhi_of_day(d) == Ganzhi.list_sexagenary_cycle()[offset % 60]
 
+
 def test_ganzhi_of_year() -> None:
   with pytest.raises(AssertionError):
     bazi_utils.ganzhi_of_year('2024') # type: ignore
@@ -58,11 +59,13 @@ def test_ganzhi_of_year() -> None:
     assert (bazi_utils.ganzhi_of_year(another_random_ganzhi_year) ==
             bazi_utils.ganzhi_of_year(random_ganzhi_year))
 
+
 def test_month_tiangan() -> None:
   assert bazi_utils.month_tiangan(Tiangan.甲, Dizhi.寅) == Tiangan.丙
   assert bazi_utils.month_tiangan(Tiangan.壬, Dizhi.子) == Tiangan.壬
   assert bazi_utils.month_tiangan(Tiangan.丁, Dizhi.丑) == Tiangan.癸
   assert bazi_utils.month_tiangan(Tiangan.戊, Dizhi.巳) == Tiangan.丁
+
 
 def test_hour_tiangan() -> None:
   assert bazi_utils.hour_tiangan(Tiangan.甲, Dizhi.寅) == Tiangan.丙
@@ -71,12 +74,14 @@ def test_hour_tiangan() -> None:
   assert bazi_utils.hour_tiangan(Tiangan.戊, Dizhi.巳) == Tiangan.丁
   assert bazi_utils.hour_tiangan(Tiangan.丙, Dizhi.卯) == Tiangan.辛
 
+
 def test_tiangan_traits() -> None:
   for idx, tg in enumerate(Tiangan):
     expected_wuxing: Wuxing = Wuxing.as_list()[idx // 2]
     expected_yinyang: Yinyang = Yinyang.as_list()[idx % 2]
     assert bazi_utils.tiangan_traits(tg) == TraitTuple(expected_wuxing, expected_yinyang)
     assert str(bazi_utils.tiangan_traits(tg)) == str(expected_yinyang) + str(expected_wuxing)
+
 
 def test_dizhi_traits() -> None:
   assert bazi_utils.dizhi_traits(Dizhi('子')) == TraitTuple(Wuxing('水'), Yinyang('阳'))
@@ -101,6 +106,7 @@ def test_dizhi_traits() -> None:
     expected_yinyang: Yinyang = Yinyang.as_list()[idx % 2]
     assert bazi_utils.dizhi_traits(dz) == TraitTuple(expected_wuxing, expected_yinyang)
 
+
 def test_hidden_tiangans() -> None:
   for dz in Dizhi:
     percentages: HiddenTianganDict = bazi_utils.hidden_tiangans(dz)
@@ -109,6 +115,7 @@ def test_hidden_tiangans() -> None:
     assert sum(percentages.values()) == 100
     for tg in percentages:
       assert tg in Tiangan
+
 
 def test_shishen() -> None:
   assert bazi_utils.shishen(Tiangan.甲, Tiangan.甲) == Shishen.比肩
@@ -127,6 +134,7 @@ def test_shishen() -> None:
 
   assert bazi_utils.shishen(Tiangan.甲, Tiangan.壬) == Shishen.偏印
   assert bazi_utils.shishen(Tiangan.甲, Dizhi.子) == Shishen.正印
+
 
 def test_nayin_str() -> None:
   assert bazi_utils.nayin_str(Ganzhi.from_str('甲子')) == '海中金'
@@ -151,6 +159,7 @@ def test_nayin_str() -> None:
       else:
         with pytest.raises(AssertionError):
           bazi_utils.nayin_str(gz) # Ganzhis not in the sexagenary cycle don't have nayin.
+
 
 def test_shier_zhangsheng() -> None:
   assert bazi_utils.shier_zhangsheng(*Ganzhi.from_str('甲子')) == ShierZhangsheng.沐浴
@@ -181,6 +190,7 @@ def test_shier_zhangsheng() -> None:
     assert (bazi_utils.shier_zhangsheng(*Ganzhi.from_strs('丁', str(dz))) ==
             bazi_utils.shier_zhangsheng(*Ganzhi.from_strs('己', str(dz))))
 
+
 def test_from_shier_zhangsheng() -> None:
   assert bazi_utils.from_shier_zhangsheng(Tiangan('甲'), ShierZhangsheng.沐浴) == Dizhi('子')
   assert bazi_utils.from_shier_zhangsheng(Tiangan('甲'), ShierZhangsheng.长生) == Dizhi('亥')
@@ -210,6 +220,7 @@ def test_from_shier_zhangsheng() -> None:
     assert (bazi_utils.from_shier_zhangsheng(Tiangan('丁'), place) ==
             bazi_utils.from_shier_zhangsheng(Tiangan('己'), place))
 
+
 def test_shier_zhangsheng_consistency() -> None:
   for tg, dz in itertools.product(Tiangan, Dizhi):
     zs: ShierZhangsheng = bazi_utils.shier_zhangsheng(tg, dz)
@@ -217,6 +228,7 @@ def test_shier_zhangsheng_consistency() -> None:
   for tg, zs in itertools.product(Tiangan, ShierZhangsheng):
     dz: Dizhi = bazi_utils.from_shier_zhangsheng(tg, zs) # type: ignore
     assert bazi_utils.shier_zhangsheng(tg, dz) == zs
+
 
 def test_lu() -> None:
   for tg in Tiangan:

--- a/tests/utils/test_bazi_utils.py
+++ b/tests/utils/test_bazi_utils.py
@@ -2,220 +2,222 @@
 # test_bazi_utils.py
 
 import random
-import unittest
 import itertools
 from datetime import date, datetime, timedelta
+
+import pytest
 
 from src.defines import Ganzhi, Tiangan, Dizhi, Wuxing, Yinyang, Shishen, ShierZhangsheng
 from src.data_types import TraitTuple, HiddenTianganDict
 from src.utils import bazi_utils
 
 
-class TestBaziUtils(unittest.TestCase):
-  def test_ganzhi_of_day_basic(self) -> None:
-    with self.subTest('Basic'):
-      d: date = date(2024, 3, 1)
-      self.assertEqual(bazi_utils.ganzhi_of_day(d), bazi_utils.ganzhi_of_day(d))
+def test_ganzhi_of_day_basic() -> None:
+  # Basic
+  d: date = date(2024, 3, 1)
+  assert bazi_utils.ganzhi_of_day(d) == bazi_utils.ganzhi_of_day(d)
 
-      dt: datetime = datetime(2024, 3, 1, 15, 34, 6)
-      self.assertEqual(bazi_utils.ganzhi_of_day(d), bazi_utils.ganzhi_of_day(dt)) # `bazi_utils.ganzhi_of_day` also takes `datetime` objects.
+  dt: datetime = datetime(2024, 3, 1, 15, 34, 6)
+  assert bazi_utils.ganzhi_of_day(d) == bazi_utils.ganzhi_of_day(dt) # `bazi_utils.ganzhi_of_day` also takes `datetime` objects.
 
-    with self.subTest('Correctness'):
-      d = date(2024, 3, 1)
-      self.assertEqual(bazi_utils.ganzhi_of_day(d), Ganzhi.from_str('甲子'))
-      self.assertEqual(bazi_utils.ganzhi_of_day(d + timedelta(days=1)), Ganzhi.from_str('乙丑'))
-      self.assertEqual(bazi_utils.ganzhi_of_day(d - timedelta(days=1)), Ganzhi.from_str('癸亥'))
+  # Correctness
+  d = date(2024, 3, 1)
+  assert bazi_utils.ganzhi_of_day(d) == Ganzhi.from_str('甲子')
+  assert bazi_utils.ganzhi_of_day(d + timedelta(days=1)) == Ganzhi.from_str('乙丑')
+  assert bazi_utils.ganzhi_of_day(d - timedelta(days=1)) == Ganzhi.from_str('癸亥')
 
-      self.assertEqual(bazi_utils.ganzhi_of_day(date(1914, 2, 14)), Ganzhi.from_str('辛未'))
-      self.assertEqual(bazi_utils.ganzhi_of_day(date(1933, 11, 1)), Ganzhi.from_str('辛未'))
-      self.assertEqual(bazi_utils.ganzhi_of_day(date(1958, 6, 29)), Ganzhi.from_str('丁丑'))
-      self.assertEqual(bazi_utils.ganzhi_of_day(date(1964, 1, 19)), Ganzhi.from_str('丁卯'))
-      self.assertEqual(bazi_utils.ganzhi_of_day(date(1984, 5, 31)), Ganzhi.from_str('乙丑'))
-      self.assertEqual(bazi_utils.ganzhi_of_day(date(1997, 1, 30)), Ganzhi.from_str('壬申'))
-      self.assertEqual(bazi_utils.ganzhi_of_day(date(2003, 7, 12)), Ganzhi.from_str('丙戌'))
+  assert bazi_utils.ganzhi_of_day(date(1914, 2, 14)) == Ganzhi.from_str('辛未')
+  assert bazi_utils.ganzhi_of_day(date(1933, 11, 1)) == Ganzhi.from_str('辛未')
+  assert bazi_utils.ganzhi_of_day(date(1958, 6, 29)) == Ganzhi.from_str('丁丑')
+  assert bazi_utils.ganzhi_of_day(date(1964, 1, 19)) == Ganzhi.from_str('丁卯')
+  assert bazi_utils.ganzhi_of_day(date(1984, 5, 31)) == Ganzhi.from_str('乙丑')
+  assert bazi_utils.ganzhi_of_day(date(1997, 1, 30)) == Ganzhi.from_str('壬申')
+  assert bazi_utils.ganzhi_of_day(date(2003, 7, 12)) == Ganzhi.from_str('丙戌')
 
-      for offset in range(-2000, 2000):
-        d = date(2024, 3, 1) + timedelta(days=offset)
-        self.assertEqual(bazi_utils.ganzhi_of_day(d), Ganzhi.list_sexagenary_cycle()[offset % 60])
+  for offset in range(-2000, 2000):
+    d = date(2024, 3, 1) + timedelta(days=offset)
+    assert bazi_utils.ganzhi_of_day(d) == Ganzhi.list_sexagenary_cycle()[offset % 60]
 
-  def test_ganzhi_of_year(self) -> None:
-    self.assertRaises(AssertionError, lambda: bazi_utils.ganzhi_of_year('2024')) # type: ignore
-    self.assertRaises(AssertionError, lambda: bazi_utils.ganzhi_of_year((2024,))) # type: ignore
+def test_ganzhi_of_year() -> None:
+  with pytest.raises(AssertionError):
+    bazi_utils.ganzhi_of_year('2024') # type: ignore
+  with pytest.raises(AssertionError):
+    bazi_utils.ganzhi_of_year((2024,)) # type: ignore
 
-    self.assertEqual(bazi_utils.ganzhi_of_year(1836), Ganzhi.from_str('丙申'))
-    self.assertEqual(bazi_utils.ganzhi_of_year(1930), Ganzhi.from_str('庚午'))
-    self.assertEqual(bazi_utils.ganzhi_of_year(1902), Ganzhi.from_str('壬寅'))
-    self.assertEqual(bazi_utils.ganzhi_of_year(1984), Ganzhi.from_str('甲子'))
-    self.assertEqual(bazi_utils.ganzhi_of_year(2024), Ganzhi.from_str('甲辰'))
-    self.assertEqual(bazi_utils.ganzhi_of_year(2075), Ganzhi.from_str('乙未'))
-    self.assertEqual(bazi_utils.ganzhi_of_year(2123), Ganzhi.from_str('癸未'))
+  assert bazi_utils.ganzhi_of_year(1836) == Ganzhi.from_str('丙申')
+  assert bazi_utils.ganzhi_of_year(1930) == Ganzhi.from_str('庚午')
+  assert bazi_utils.ganzhi_of_year(1902) == Ganzhi.from_str('壬寅')
+  assert bazi_utils.ganzhi_of_year(1984) == Ganzhi.from_str('甲子')
+  assert bazi_utils.ganzhi_of_year(2024) == Ganzhi.from_str('甲辰')
+  assert bazi_utils.ganzhi_of_year(2075) == Ganzhi.from_str('乙未')
+  assert bazi_utils.ganzhi_of_year(2123) == Ganzhi.from_str('癸未')
 
-    for _ in range(20):
-      random_ganzhi_year: int = random.randint(1000, 9999)
-      another_random_ganzhi_year: int = random.randint(-20, 20) * 60 + random_ganzhi_year
-      self.assertEqual(bazi_utils.ganzhi_of_year(another_random_ganzhi_year),
-                       bazi_utils.ganzhi_of_year(random_ganzhi_year))
+  for _ in range(20):
+    random_ganzhi_year: int = random.randint(1000, 9999)
+    another_random_ganzhi_year: int = random.randint(-20, 20) * 60 + random_ganzhi_year
+    assert (bazi_utils.ganzhi_of_year(another_random_ganzhi_year) ==
+            bazi_utils.ganzhi_of_year(random_ganzhi_year))
 
-  def test_month_tiangan(self) -> None:
-    self.assertEqual(bazi_utils.month_tiangan(Tiangan.甲, Dizhi.寅), Tiangan.丙)
-    self.assertEqual(bazi_utils.month_tiangan(Tiangan.壬, Dizhi.子), Tiangan.壬)
-    self.assertEqual(bazi_utils.month_tiangan(Tiangan.丁, Dizhi.丑), Tiangan.癸)
-    self.assertEqual(bazi_utils.month_tiangan(Tiangan.戊, Dizhi.巳), Tiangan.丁)
+def test_month_tiangan() -> None:
+  assert bazi_utils.month_tiangan(Tiangan.甲, Dizhi.寅) == Tiangan.丙
+  assert bazi_utils.month_tiangan(Tiangan.壬, Dizhi.子) == Tiangan.壬
+  assert bazi_utils.month_tiangan(Tiangan.丁, Dizhi.丑) == Tiangan.癸
+  assert bazi_utils.month_tiangan(Tiangan.戊, Dizhi.巳) == Tiangan.丁
 
-  def test_hour_tiangan(self) -> None:
-    self.assertEqual(bazi_utils.hour_tiangan(Tiangan.甲, Dizhi.寅), Tiangan.丙)
-    self.assertEqual(bazi_utils.hour_tiangan(Tiangan.壬, Dizhi.子), Tiangan.庚)
-    self.assertEqual(bazi_utils.hour_tiangan(Tiangan.丁, Dizhi.丑), Tiangan.辛)
-    self.assertEqual(bazi_utils.hour_tiangan(Tiangan.戊, Dizhi.巳), Tiangan.丁)
-    self.assertEqual(bazi_utils.hour_tiangan(Tiangan.丙, Dizhi.卯), Tiangan.辛)
+def test_hour_tiangan() -> None:
+  assert bazi_utils.hour_tiangan(Tiangan.甲, Dizhi.寅) == Tiangan.丙
+  assert bazi_utils.hour_tiangan(Tiangan.壬, Dizhi.子) == Tiangan.庚
+  assert bazi_utils.hour_tiangan(Tiangan.丁, Dizhi.丑) == Tiangan.辛
+  assert bazi_utils.hour_tiangan(Tiangan.戊, Dizhi.巳) == Tiangan.丁
+  assert bazi_utils.hour_tiangan(Tiangan.丙, Dizhi.卯) == Tiangan.辛
 
-  def test_tiangan_traits(self) -> None:
-    for idx, tg in enumerate(Tiangan):
-      expected_wuxing: Wuxing = Wuxing.as_list()[idx // 2]
-      expected_yinyang: Yinyang = Yinyang.as_list()[idx % 2]
-      self.assertEqual(bazi_utils.tiangan_traits(tg), TraitTuple(expected_wuxing, expected_yinyang))
-      self.assertEqual(str(bazi_utils.tiangan_traits(tg)), str(expected_yinyang) + str(expected_wuxing))
+def test_tiangan_traits() -> None:
+  for idx, tg in enumerate(Tiangan):
+    expected_wuxing: Wuxing = Wuxing.as_list()[idx // 2]
+    expected_yinyang: Yinyang = Yinyang.as_list()[idx % 2]
+    assert bazi_utils.tiangan_traits(tg) == TraitTuple(expected_wuxing, expected_yinyang)
+    assert str(bazi_utils.tiangan_traits(tg)) == str(expected_yinyang) + str(expected_wuxing)
 
-  def test_dizhi_traits(self) -> None:
-    self.assertEqual(bazi_utils.dizhi_traits(Dizhi('子')), TraitTuple(Wuxing('水'), Yinyang('阳')))
-    self.assertEqual(bazi_utils.dizhi_traits(Dizhi('辰')), TraitTuple(Wuxing('土'), Yinyang('阳')))
-    self.assertEqual(bazi_utils.dizhi_traits(Dizhi('巳')), TraitTuple(Wuxing('火'), Yinyang('阴')))
-    self.assertEqual(bazi_utils.dizhi_traits(Dizhi('丑')), TraitTuple(Wuxing('土'), Yinyang('阴')))
+def test_dizhi_traits() -> None:
+  assert bazi_utils.dizhi_traits(Dizhi('子')) == TraitTuple(Wuxing('水'), Yinyang('阳'))
+  assert bazi_utils.dizhi_traits(Dizhi('辰')) == TraitTuple(Wuxing('土'), Yinyang('阳'))
+  assert bazi_utils.dizhi_traits(Dizhi('巳')) == TraitTuple(Wuxing('火'), Yinyang('阴'))
+  assert bazi_utils.dizhi_traits(Dizhi('丑')) == TraitTuple(Wuxing('土'), Yinyang('阴'))
 
-    for idx, dz in enumerate(Dizhi):
-      expected_wuxing: Wuxing
-      month_idx: int = (idx - 2) % 12
-      if month_idx % 3 == 2:
-        expected_wuxing = Wuxing.土
-      elif month_idx < 3:
-        expected_wuxing = Wuxing.木
-      elif month_idx < 6:
-        expected_wuxing = Wuxing.火
-      elif month_idx < 9:
-        expected_wuxing = Wuxing.金
+  for idx, dz in enumerate(Dizhi):
+    expected_wuxing: Wuxing
+    month_idx: int = (idx - 2) % 12
+    if month_idx % 3 == 2:
+      expected_wuxing = Wuxing.土
+    elif month_idx < 3:
+      expected_wuxing = Wuxing.木
+    elif month_idx < 6:
+      expected_wuxing = Wuxing.火
+    elif month_idx < 9:
+      expected_wuxing = Wuxing.金
+    else:
+      expected_wuxing = Wuxing.水
+
+    expected_yinyang: Yinyang = Yinyang.as_list()[idx % 2]
+    assert bazi_utils.dizhi_traits(dz) == TraitTuple(expected_wuxing, expected_yinyang)
+
+def test_hidden_tiangans() -> None:
+  for dz in Dizhi:
+    percentages: HiddenTianganDict = bazi_utils.hidden_tiangans(dz)
+    assert len(percentages) >= 1
+    assert len(percentages) <= 3
+    assert sum(percentages.values()) == 100
+    for tg in percentages:
+      assert tg in Tiangan
+
+def test_shishen() -> None:
+  assert bazi_utils.shishen(Tiangan.甲, Tiangan.甲) == Shishen.比肩
+  assert bazi_utils.shishen(Tiangan.甲, Tiangan.乙) == Shishen.劫财
+  assert bazi_utils.shishen(Tiangan.甲, Dizhi.寅) == Shishen.比肩
+  assert bazi_utils.shishen(Tiangan.甲, Dizhi.卯) == Shishen.劫财
+
+  assert bazi_utils.shishen(Tiangan.甲, Tiangan.丙) == Shishen.食神
+  assert bazi_utils.shishen(Tiangan.甲, Dizhi.午) == Shishen.伤官
+
+  assert bazi_utils.shishen(Tiangan.甲, Tiangan.戊) == Shishen.偏财
+  assert bazi_utils.shishen(Tiangan.甲, Dizhi.未) == Shishen.正财
+
+  assert bazi_utils.shishen(Tiangan.甲, Tiangan.辛) == Shishen.正官
+  assert bazi_utils.shishen(Tiangan.甲, Dizhi.申) == Shishen.七杀
+
+  assert bazi_utils.shishen(Tiangan.甲, Tiangan.壬) == Shishen.偏印
+  assert bazi_utils.shishen(Tiangan.甲, Dizhi.子) == Shishen.正印
+
+def test_nayin_str() -> None:
+  assert bazi_utils.nayin_str(Ganzhi.from_str('甲子')) == '海中金'
+  assert bazi_utils.nayin_str(Ganzhi.from_str('乙丑')) == '海中金'
+  assert bazi_utils.nayin_str(Ganzhi.from_str('丙寅')) == '炉中火'
+
+  assert bazi_utils.nayin_str(Ganzhi.from_str('癸卯')) == '金箔金'
+  assert bazi_utils.nayin_str(Ganzhi.from_str('甲辰')) == '覆灯火'
+  assert bazi_utils.nayin_str(Ganzhi.from_str('乙巳')) == '覆灯火'
+  assert bazi_utils.nayin_str(Ganzhi.from_str('丙午')) == '天河水'
+
+  assert bazi_utils.nayin_str(Ganzhi.from_str('辛酉')) == '石榴木'
+  assert bazi_utils.nayin_str(Ganzhi.from_str('壬戌')) == '大海水'
+  assert bazi_utils.nayin_str(Ganzhi.from_str('癸亥')) == '大海水'
+
+  cycle: list[Ganzhi] = Ganzhi.list_sexagenary_cycle()
+  for tg in Tiangan:
+    for dz in Dizhi:
+      gz: Ganzhi = Ganzhi(tg, dz)
+      if gz in cycle:
+        assert len(bazi_utils.nayin_str(gz)) == 3
       else:
-        expected_wuxing = Wuxing.水
-      
-      expected_yinyang: Yinyang = Yinyang.as_list()[idx % 2]
-      self.assertEqual(bazi_utils.dizhi_traits(dz), TraitTuple(expected_wuxing, expected_yinyang))
+        with pytest.raises(AssertionError):
+          bazi_utils.nayin_str(gz) # Ganzhis not in the sexagenary cycle don't have nayin.
 
-  def test_hidden_tiangans(self) -> None:
-    for dz in Dizhi:
-      percentages: HiddenTianganDict = bazi_utils.hidden_tiangans(dz)
-      self.assertGreaterEqual(len(percentages), 1)
-      self.assertLessEqual(len(percentages), 3)
-      self.assertEqual(sum(percentages.values()), 100)
-      for tg in percentages:
-        self.assertIn(tg, Tiangan)
+def test_shier_zhangsheng() -> None:
+  assert bazi_utils.shier_zhangsheng(*Ganzhi.from_str('甲子')) == ShierZhangsheng.沐浴
+  assert bazi_utils.shier_zhangsheng(*Ganzhi.from_str('甲亥')) == ShierZhangsheng.长生
+  assert bazi_utils.shier_zhangsheng(*Ganzhi.from_str('甲午')) == ShierZhangsheng.死
 
-  def test_shishen(self) -> None:
-    self.assertEqual(bazi_utils.shishen(Tiangan.甲, Tiangan.甲), Shishen.比肩)
-    self.assertEqual(bazi_utils.shishen(Tiangan.甲, Tiangan.乙), Shishen.劫财)
-    self.assertEqual(bazi_utils.shishen(Tiangan.甲, Dizhi.寅), Shishen.比肩)
-    self.assertEqual(bazi_utils.shishen(Tiangan.甲, Dizhi.卯), Shishen.劫财)
+  assert bazi_utils.shier_zhangsheng(*Ganzhi.from_str('乙亥')) == ShierZhangsheng.死
+  assert bazi_utils.shier_zhangsheng(*Ganzhi.from_str('乙丑')) == ShierZhangsheng.衰
 
-    self.assertEqual(bazi_utils.shishen(Tiangan.甲, Tiangan.丙), Shishen.食神)
-    self.assertEqual(bazi_utils.shishen(Tiangan.甲, Dizhi.午), Shishen.伤官)
-    
-    self.assertEqual(bazi_utils.shishen(Tiangan.甲, Tiangan.戊), Shishen.偏财)
-    self.assertEqual(bazi_utils.shishen(Tiangan.甲, Dizhi.未), Shishen.正财)
+  assert bazi_utils.shier_zhangsheng(*Ganzhi.from_str('丙午')) == ShierZhangsheng.帝旺
+  assert bazi_utils.shier_zhangsheng(*Ganzhi.from_str('丙未')) == ShierZhangsheng.衰
 
-    self.assertEqual(bazi_utils.shishen(Tiangan.甲, Tiangan.辛), Shishen.正官)
-    self.assertEqual(bazi_utils.shishen(Tiangan.甲, Dizhi.申), Shishen.七杀)
+  assert bazi_utils.shier_zhangsheng(*Ganzhi.from_str('丁未')) == ShierZhangsheng.冠带
+  assert bazi_utils.shier_zhangsheng(*Ganzhi.from_str('丁戌')) == ShierZhangsheng.养
 
-    self.assertEqual(bazi_utils.shishen(Tiangan.甲, Tiangan.壬), Shishen.偏印)
-    self.assertEqual(bazi_utils.shishen(Tiangan.甲, Dizhi.子), Shishen.正印)
+  assert bazi_utils.shier_zhangsheng(*Ganzhi.from_str('戊戌')) == ShierZhangsheng.墓
+  assert bazi_utils.shier_zhangsheng(*Ganzhi.from_str('戊亥')) == ShierZhangsheng.绝
 
-  def test_nayin_str(self) -> None:
-    self.assertEqual(bazi_utils.nayin_str(Ganzhi.from_str('甲子')), '海中金')
-    self.assertEqual(bazi_utils.nayin_str(Ganzhi.from_str('乙丑')), '海中金')
-    self.assertEqual(bazi_utils.nayin_str(Ganzhi.from_str('丙寅')), '炉中火')
+  assert bazi_utils.shier_zhangsheng(*Ganzhi.from_str('己亥')) == ShierZhangsheng.胎
+  assert bazi_utils.shier_zhangsheng(*Ganzhi.from_str('庚辰')) == ShierZhangsheng.养
+  assert bazi_utils.shier_zhangsheng(*Ganzhi.from_str('辛酉')) == ShierZhangsheng.临官
+  assert bazi_utils.shier_zhangsheng(*Ganzhi.from_str('壬申')) == ShierZhangsheng.长生
+  assert bazi_utils.shier_zhangsheng(*Ganzhi.from_str('癸卯')) == ShierZhangsheng.长生
 
-    self.assertEqual(bazi_utils.nayin_str(Ganzhi.from_str('癸卯')), '金箔金')
-    self.assertEqual(bazi_utils.nayin_str(Ganzhi.from_str('甲辰')), '覆灯火')
-    self.assertEqual(bazi_utils.nayin_str(Ganzhi.from_str('乙巳')), '覆灯火')
-    self.assertEqual(bazi_utils.nayin_str(Ganzhi.from_str('丙午')), '天河水')
+  for dz in Dizhi:
+    assert (bazi_utils.shier_zhangsheng(*Ganzhi.from_strs('丙', str(dz))) ==
+            bazi_utils.shier_zhangsheng(*Ganzhi.from_strs('戊', str(dz))))
+    assert (bazi_utils.shier_zhangsheng(*Ganzhi.from_strs('丁', str(dz))) ==
+            bazi_utils.shier_zhangsheng(*Ganzhi.from_strs('己', str(dz))))
 
-    self.assertEqual(bazi_utils.nayin_str(Ganzhi.from_str('辛酉')), '石榴木')
-    self.assertEqual(bazi_utils.nayin_str(Ganzhi.from_str('壬戌')), '大海水')
-    self.assertEqual(bazi_utils.nayin_str(Ganzhi.from_str('癸亥')), '大海水')
+def test_from_shier_zhangsheng() -> None:
+  assert bazi_utils.from_shier_zhangsheng(Tiangan('甲'), ShierZhangsheng.沐浴) == Dizhi('子')
+  assert bazi_utils.from_shier_zhangsheng(Tiangan('甲'), ShierZhangsheng.长生) == Dizhi('亥')
+  assert bazi_utils.from_shier_zhangsheng(Tiangan('甲'), ShierZhangsheng.死) == Dizhi('午')
 
-    cycle: list[Ganzhi] = Ganzhi.list_sexagenary_cycle()
-    for tg in Tiangan:
-      for dz in Dizhi:
-        gz: Ganzhi = Ganzhi(tg, dz)
-        if gz in cycle:
-          self.assertEqual(len(bazi_utils.nayin_str(gz)), 3)
-        else:
-          with self.assertRaises(AssertionError):
-            bazi_utils.nayin_str(gz) # Ganzhis not in the sexagenary cycle don't have nayin.
+  assert bazi_utils.from_shier_zhangsheng(Tiangan('乙'), ShierZhangsheng.死) == Dizhi('亥')
+  assert bazi_utils.from_shier_zhangsheng(Tiangan('乙'), ShierZhangsheng.衰) == Dizhi('丑')
 
-  def test_shier_zhangsheng(self) -> None:
-    self.assertEqual(bazi_utils.shier_zhangsheng(*Ganzhi.from_str('甲子')), ShierZhangsheng.沐浴)
-    self.assertEqual(bazi_utils.shier_zhangsheng(*Ganzhi.from_str('甲亥')), ShierZhangsheng.长生)
-    self.assertEqual(bazi_utils.shier_zhangsheng(*Ganzhi.from_str('甲午')), ShierZhangsheng.死)
+  assert bazi_utils.from_shier_zhangsheng(Tiangan('丙'), ShierZhangsheng.帝旺) == Dizhi('午')
+  assert bazi_utils.from_shier_zhangsheng(Tiangan('丙'), ShierZhangsheng.衰) == Dizhi('未')
 
-    self.assertEqual(bazi_utils.shier_zhangsheng(*Ganzhi.from_str('乙亥')), ShierZhangsheng.死)
-    self.assertEqual(bazi_utils.shier_zhangsheng(*Ganzhi.from_str('乙丑')), ShierZhangsheng.衰)
+  assert bazi_utils.from_shier_zhangsheng(Tiangan('丁'), ShierZhangsheng.冠带) == Dizhi('未')
+  assert bazi_utils.from_shier_zhangsheng(Tiangan('丁'), ShierZhangsheng.养) == Dizhi('戌')
 
-    self.assertEqual(bazi_utils.shier_zhangsheng(*Ganzhi.from_str('丙午')), ShierZhangsheng.帝旺)
-    self.assertEqual(bazi_utils.shier_zhangsheng(*Ganzhi.from_str('丙未')), ShierZhangsheng.衰)
+  assert bazi_utils.from_shier_zhangsheng(Tiangan('戊'), ShierZhangsheng.墓) == Dizhi('戌')
+  assert bazi_utils.from_shier_zhangsheng(Tiangan('戊'), ShierZhangsheng.绝) == Dizhi('亥')
 
-    self.assertEqual(bazi_utils.shier_zhangsheng(*Ganzhi.from_str('丁未')), ShierZhangsheng.冠带)
-    self.assertEqual(bazi_utils.shier_zhangsheng(*Ganzhi.from_str('丁戌')), ShierZhangsheng.养)
+  assert bazi_utils.from_shier_zhangsheng(Tiangan('己'), ShierZhangsheng.胎) == Dizhi('亥')
+  assert bazi_utils.from_shier_zhangsheng(Tiangan('庚'), ShierZhangsheng.养) == Dizhi('辰')
+  assert bazi_utils.from_shier_zhangsheng(Tiangan('辛'), ShierZhangsheng.临官) == Dizhi('酉')
+  assert bazi_utils.from_shier_zhangsheng(Tiangan('壬'), ShierZhangsheng.长生) == Dizhi('申')
+  assert bazi_utils.from_shier_zhangsheng(Tiangan('癸'), ShierZhangsheng.长生) == Dizhi('卯')
 
-    self.assertEqual(bazi_utils.shier_zhangsheng(*Ganzhi.from_str('戊戌')), ShierZhangsheng.墓)
-    self.assertEqual(bazi_utils.shier_zhangsheng(*Ganzhi.from_str('戊亥')), ShierZhangsheng.绝)
+  for place in ShierZhangsheng:
+    assert (bazi_utils.from_shier_zhangsheng(Tiangan('丙'), place) ==
+            bazi_utils.from_shier_zhangsheng(Tiangan('戊'), place))
+    assert (bazi_utils.from_shier_zhangsheng(Tiangan('丁'), place) ==
+            bazi_utils.from_shier_zhangsheng(Tiangan('己'), place))
 
-    self.assertEqual(bazi_utils.shier_zhangsheng(*Ganzhi.from_str('己亥')), ShierZhangsheng.胎)
-    self.assertEqual(bazi_utils.shier_zhangsheng(*Ganzhi.from_str('庚辰')), ShierZhangsheng.养)
-    self.assertEqual(bazi_utils.shier_zhangsheng(*Ganzhi.from_str('辛酉')), ShierZhangsheng.临官)
-    self.assertEqual(bazi_utils.shier_zhangsheng(*Ganzhi.from_str('壬申')), ShierZhangsheng.长生)
-    self.assertEqual(bazi_utils.shier_zhangsheng(*Ganzhi.from_str('癸卯')), ShierZhangsheng.长生)
+def test_shier_zhangsheng_consistency() -> None:
+  for tg, dz in itertools.product(Tiangan, Dizhi):
+    zs: ShierZhangsheng = bazi_utils.shier_zhangsheng(tg, dz)
+    assert bazi_utils.from_shier_zhangsheng(tg, zs) == dz
+  for tg, zs in itertools.product(Tiangan, ShierZhangsheng):
+    dz: Dizhi = bazi_utils.from_shier_zhangsheng(tg, zs) # type: ignore
+    assert bazi_utils.shier_zhangsheng(tg, dz) == zs
 
-    for dz in Dizhi:
-      self.assertEqual(bazi_utils.shier_zhangsheng(*Ganzhi.from_strs('丙', str(dz))),
-                       bazi_utils.shier_zhangsheng(*Ganzhi.from_strs('戊', str(dz))))
-      self.assertEqual(bazi_utils.shier_zhangsheng(*Ganzhi.from_strs('丁', str(dz))),
-                       bazi_utils.shier_zhangsheng(*Ganzhi.from_strs('己', str(dz))))
-      
-  def test_from_shier_zhangsheng(self) -> None:
-    self.assertEqual(bazi_utils.from_shier_zhangsheng(Tiangan('甲'), ShierZhangsheng.沐浴), Dizhi('子'))
-    self.assertEqual(bazi_utils.from_shier_zhangsheng(Tiangan('甲'), ShierZhangsheng.长生), Dizhi('亥'))
-    self.assertEqual(bazi_utils.from_shier_zhangsheng(Tiangan('甲'), ShierZhangsheng.死), Dizhi('午'))
-
-    self.assertEqual(bazi_utils.from_shier_zhangsheng(Tiangan('乙'), ShierZhangsheng.死), Dizhi('亥'))
-    self.assertEqual(bazi_utils.from_shier_zhangsheng(Tiangan('乙'), ShierZhangsheng.衰), Dizhi('丑'))
-
-    self.assertEqual(bazi_utils.from_shier_zhangsheng(Tiangan('丙'), ShierZhangsheng.帝旺), Dizhi('午'))
-    self.assertEqual(bazi_utils.from_shier_zhangsheng(Tiangan('丙'), ShierZhangsheng.衰), Dizhi('未'))
-
-    self.assertEqual(bazi_utils.from_shier_zhangsheng(Tiangan('丁'), ShierZhangsheng.冠带), Dizhi('未'))
-    self.assertEqual(bazi_utils.from_shier_zhangsheng(Tiangan('丁'), ShierZhangsheng.养), Dizhi('戌'))
-
-    self.assertEqual(bazi_utils.from_shier_zhangsheng(Tiangan('戊'), ShierZhangsheng.墓), Dizhi('戌'))
-    self.assertEqual(bazi_utils.from_shier_zhangsheng(Tiangan('戊'), ShierZhangsheng.绝), Dizhi('亥'))
-
-    self.assertEqual(bazi_utils.from_shier_zhangsheng(Tiangan('己'), ShierZhangsheng.胎), Dizhi('亥'))
-    self.assertEqual(bazi_utils.from_shier_zhangsheng(Tiangan('庚'), ShierZhangsheng.养), Dizhi('辰'))
-    self.assertEqual(bazi_utils.from_shier_zhangsheng(Tiangan('辛'), ShierZhangsheng.临官), Dizhi('酉'))
-    self.assertEqual(bazi_utils.from_shier_zhangsheng(Tiangan('壬'), ShierZhangsheng.长生), Dizhi('申'))
-    self.assertEqual(bazi_utils.from_shier_zhangsheng(Tiangan('癸'), ShierZhangsheng.长生), Dizhi('卯'))
-
-    for place in ShierZhangsheng:
-      self.assertEqual(bazi_utils.from_shier_zhangsheng(Tiangan('丙'), place),
-                       bazi_utils.from_shier_zhangsheng(Tiangan('戊'), place))
-      self.assertEqual(bazi_utils.from_shier_zhangsheng(Tiangan('丁'), place),
-                       bazi_utils.from_shier_zhangsheng(Tiangan('己'), place))
-      
-  def test_shier_zhangsheng_consistency(self) -> None:
-    for tg, dz in itertools.product(Tiangan, Dizhi):
-      zs: ShierZhangsheng = bazi_utils.shier_zhangsheng(tg, dz)
-      self.assertEqual(bazi_utils.from_shier_zhangsheng(tg, zs), dz)
-    for tg, zs in itertools.product(Tiangan, ShierZhangsheng):
-      dz: Dizhi = bazi_utils.from_shier_zhangsheng(tg, zs) # type: ignore
-      self.assertEqual(bazi_utils.shier_zhangsheng(tg, dz), zs)
-
-  def test_lu(self) -> None:
-    for tg in Tiangan:
-      self.assertEqual(bazi_utils.lu(tg), bazi_utils.from_shier_zhangsheng(tg, ShierZhangsheng('临官')))
+def test_lu() -> None:
+  for tg in Tiangan:
+    assert bazi_utils.lu(tg) == bazi_utils.from_shier_zhangsheng(tg, ShierZhangsheng('临官'))

--- a/tests/utils/test_dizhi_utils.py
+++ b/tests/utils/test_dizhi_utils.py
@@ -6,7 +6,6 @@ import random
 import itertools
 
 import pytest
-import unittest
 
 from collections import Counter
 from typing import Any
@@ -18,1138 +17,1119 @@ from src.utils import bazi_utils, tiangan_utils, dizhi_utils
 from src.utils.dizhi_utils import DizhiCombo, DizhiRelationCombos, DizhiRelationDiscovery
 
 
-class TestDizhiUtils(unittest.TestCase):
-  DzCmpType = list[set[Dizhi]] | Iterable[DizhiCombo]
-  @staticmethod
-  def __dz_equal(l1: DzCmpType, l2: DzCmpType) -> bool:
-    _l1 = list(l1)
-    _l2 = list(l2)
-    if len(_l1) != len(_l2):
+DzCmpType = list[set[Dizhi]] | Iterable[DizhiCombo]
+
+def _dz_equal(l1: DzCmpType, l2: DzCmpType) -> bool:
+  _l1 = list(l1)
+  _l2 = list(l2)
+  if len(_l1) != len(_l2):
+    return False
+  for s in _l1:
+    if s not in _l2:
       return False
-    for s in _l1:
-      if s not in _l2:
-        return False
-    return True
-
-  def test_search_sanhui(self) -> None:
-    sanhui_combos: list[DizhiCombo] = [
-      DizhiCombo((Dizhi.from_index(2), Dizhi.from_index(3), Dizhi.from_index(4))),
-      DizhiCombo((Dizhi.from_index(5), Dizhi.from_index(6), Dizhi.from_index(7))),
-      DizhiCombo((Dizhi.from_index(8), Dizhi.from_index(9), Dizhi.from_index(10))),
-      DizhiCombo((Dizhi.from_index(11), Dizhi.from_index(0), Dizhi.from_index(1))),
-    ]
-
-    self.assertTrue(self.__dz_equal(
-      dizhi_utils.search([], DizhiRelation.三会),
-      [],
-    ))
-    self.assertTrue(self.__dz_equal(
-      dizhi_utils.search(list(Dizhi), DizhiRelation.三会),
-      [set(c) for c in sanhui_combos],
-    ))
-    
-    for _ in range(500):
-      dizhis: list[Dizhi] = random.sample(Dizhi.as_list(), random.randint(0, len(Dizhi)))
-      result: DizhiRelationCombos = dizhi_utils.search(dizhis, DizhiRelation.三会)
-      expected_result: list[set[Dizhi]] = [set(c) for c in sanhui_combos if c.issubset(dizhis)]
-      self.assertTrue(self.__dz_equal(result, expected_result))
-
-  def test_sanhui(self) -> None:
-    with self.assertRaises(TypeError):
-      dizhi_utils.sanhui(Dizhi.子) # type: ignore
-    with self.assertRaises(TypeError):
-      dizhi_utils.sanhui(Dizhi.子, Dizhi.辰) # type: ignore
-    with self.assertRaises(TypeError):
-      dizhi_utils.sanhui(Dizhi.子, Dizhi.辰, Dizhi.子, Dizhi.辰) # type: ignore
-    with self.assertRaises(TypeError):
-      dizhi_utils.sanhui((Dizhi.亥, Dizhi.子, Dizhi.丑)) # type: ignore
-    with self.assertRaises(TypeError):
-      dizhi_utils.sanhui({Dizhi.亥, Dizhi.子, Dizhi.丑}) # type: ignore
-    with self.assertRaises(TypeError):
-      dizhi_utils.sanhui([Dizhi.亥, Dizhi.子, Dizhi.丑]) # type: ignore
-    with self.assertRaises(AssertionError):
-      dizhi_utils.sanhui('亥', '子', '丑') # type: ignore
-
-    dizhi_tuples: list[tuple[Dizhi, Dizhi, Dizhi]] = [
-      (Dizhi.寅, Dizhi.卯, Dizhi.辰), # Spring / 春
-      (Dizhi.巳, Dizhi.午, Dizhi.未), # Summer / 夏
-      (Dizhi.申, Dizhi.酉, Dizhi.戌), # Fall   / 秋
-      (Dizhi.亥, Dizhi.子, Dizhi.丑), # Winter / 冬
-    ]
-    expected: dict[DizhiCombo, Wuxing] = { 
-      DizhiCombo(dizhis) : bazi_utils.traits(dizhis[0]).wuxing for dizhis in dizhi_tuples 
-    }
-    
-    for dizhis in itertools.product(Dizhi, repeat=3):
-      fs: DizhiCombo = DizhiCombo(dizhis)
-      if fs in expected:
-        for combo in itertools.permutations(dizhis):
-          self.assertEqual(dizhi_utils.sanhui(*combo), expected[fs])
-      else:
-        for combo in itertools.permutations(dizhis):
-          self.assertIsNone(dizhi_utils.sanhui(*dizhis))
-
-  def test_search_liuhe(self) -> None:
-    liuhe_combos: list[DizhiCombo] = [
-      DizhiCombo((dz1, dz2)) for dz1, dz2 in itertools.combinations(Dizhi, 2) if (dz1.index + dz2.index) % 12 == 1
-    ]
-
-    self.assertTrue(self.__dz_equal(
-      dizhi_utils.search([], DizhiRelation.六合),
-      [],
-    ))
-    self.assertTrue(self.__dz_equal(
-      dizhi_utils.search(list(Dizhi), DizhiRelation.六合),
-      liuhe_combos,
-    ))
-
-    for _ in range(500):
-      dizhis: list[Dizhi] = random.sample(Dizhi.as_list(), random.randint(0, len(Dizhi)))
-      result: DizhiRelationCombos = dizhi_utils.search(dizhis, DizhiRelation.六合)
-      expected_result: list[set[Dizhi]] = [set(c) for c in liuhe_combos if c.issubset(dizhis)]
-      self.assertTrue(self.__dz_equal(result, expected_result))
-
-  def test_liuhe(self) -> None:
-    with self.assertRaises(TypeError):
-      dizhi_utils.liuhe(Dizhi.子) # type: ignore
-    with self.assertRaises(TypeError):
-      dizhi_utils.liuhe(Dizhi.子, Dizhi.辰, Dizhi.子, Dizhi.辰) # type: ignore
-    with self.assertRaises(TypeError):
-      dizhi_utils.liuhe((Dizhi.子, Dizhi.丑)) # type: ignore
-    with self.assertRaises(TypeError):
-      dizhi_utils.liuhe({Dizhi.子, Dizhi.丑}) # type: ignore
-    with self.assertRaises(TypeError):
-      dizhi_utils.liuhe([Dizhi.子, Dizhi.丑]) # type: ignore
-    with self.assertRaises(AssertionError):
-      dizhi_utils.liuhe('亥', '子') # type: ignore
-
-    liuhe_combos: list[DizhiCombo] = [
-      DizhiCombo((dz1, dz2)) for dz1, dz2 in itertools.combinations(Dizhi, 2) if (dz1.index + dz2.index) % 12 == 1
-    ]
-
-    for dz1, dz2 in itertools.permutations(Dizhi, 2):
-      liuhe_result: Wuxing | None = dizhi_utils.liuhe(dz1, dz2)
-      liuhe_result2: Wuxing | None = dizhi_utils.liuhe(dz2, dz1)
-      self.assertEqual(liuhe_result, liuhe_result2)
-      
-      if DizhiCombo((dz1, dz2)) in liuhe_combos:
-        wx1, wx2 = bazi_utils.traits(dz1).wuxing, bazi_utils.traits(dz2).wuxing
-        if wx1.generates(wx2):
-          self.assertEqual(liuhe_result, wx2)
-        elif wx2.generates(wx1):
-          self.assertEqual(liuhe_result, wx1)
-        else:
-          self.assertTrue(wx1.destructs(wx2) or wx2.destructs(wx1))
-          if {dz1, dz2} == {Dizhi.子, Dizhi.丑}:
-            self.assertEqual(liuhe_result, Wuxing.土)
-          elif {dz1, dz2} == {Dizhi.卯, Dizhi.戌}:
-            self.assertEqual(liuhe_result, Wuxing.火)
-          else:
-            self.assertEqual({dz1, dz2}, {Dizhi.申, Dizhi.巳})
-            self.assertEqual(liuhe_result, Wuxing.水)
-      else:
-        self.assertIsNone(liuhe_result)
-
-  def test_search_anhe(self) -> None:
-    anhe_combos: list[DizhiCombo] = [ # 天干五合对应的地支暗合，5组。
-      DizhiCombo((bazi_utils.lu(tg1), bazi_utils.lu(tg2))) 
-      for tg1, tg2 in itertools.combinations(Tiangan, 2) if tiangan_utils.he(tg1, tg2) is not None
-    ] + [ # `NORMAL_EXTENDED` 中额外的1组。
-      DizhiCombo((Dizhi.寅, Dizhi.丑)), 
-    ]
-
-    self.assertTrue(self.__dz_equal(
-      dizhi_utils.search([], DizhiRelation.暗合),
-      [],
-    ))
-    self.assertTrue(self.__dz_equal(
-      dizhi_utils.search(list(Dizhi), DizhiRelation.暗合),
-      anhe_combos,
-    ))
-
-    for _ in range(500):
-      dizhis: list[Dizhi] = random.sample(Dizhi.as_list(), random.randint(0, len(Dizhi)))
-      result: DizhiRelationCombos = dizhi_utils.search(dizhis, DizhiRelation.暗合)
-      expected_result: list[set[Dizhi]] = [set(c) for c in anhe_combos if c.issubset(dizhis)]
-      self.assertTrue(self.__dz_equal(result, expected_result))
-
-  def test_anhe(self) -> None:
-    with self.assertRaises(TypeError):
-      dizhi_utils.anhe(Dizhi.子) # type: ignore
-    with self.assertRaises(TypeError):
-      dizhi_utils.anhe(Dizhi.子, Dizhi.辰, Dizhi.子, Dizhi.辰) # type: ignore
-    with self.assertRaises(TypeError):
-      dizhi_utils.anhe((Dizhi.子, Dizhi.丑)) # type: ignore
-    with self.assertRaises(TypeError):
-      dizhi_utils.anhe({Dizhi.子, Dizhi.丑}) # type: ignore
-    with self.assertRaises(TypeError):
-      dizhi_utils.anhe([Dizhi.子, Dizhi.丑]) # type: ignore
-    with self.assertRaises(AssertionError):
-      dizhi_utils.anhe('亥', '子') # type: ignore
-    with self.assertRaises(TypeError):
-      dizhi_utils.anhe(Dizhi.子, Dizhi.辰, DizhiRules.AnheDef.NORMAL + 100) # type: ignore
-    with self.assertRaises(AssertionError):
-      dizhi_utils.anhe(Dizhi.子, Dizhi.辰, definition='DizhiRules.AnheDef.NORMAL') # type: ignore
-
-    normal_combos: list[DizhiCombo] = [
-      DizhiCombo((bazi_utils.lu(tg1), bazi_utils.lu(tg2))) 
-      for tg1, tg2 in itertools.combinations(Tiangan, 2) if tiangan_utils.he(tg1, tg2) is not None
-    ] 
-    
-    normal_extended_combos: list[DizhiCombo] = normal_combos + [
-      DizhiCombo((Dizhi.寅, Dizhi.丑)), 
-    ]
-
-    mangpai_combos: list[DizhiCombo] = [
-      DizhiCombo((Dizhi.寅, Dizhi.丑)), 
-      DizhiCombo((Dizhi.午, Dizhi.亥)), 
-      DizhiCombo((Dizhi.卯, Dizhi.申)), 
-    ]
-
-    expected: dict[DizhiRules.AnheDef, list[DizhiCombo]] = {
-      DizhiRules.AnheDef.NORMAL: normal_combos,
-      DizhiRules.AnheDef.NORMAL_EXTENDED: normal_extended_combos,
-      DizhiRules.AnheDef.MANGPAI: mangpai_combos
-    }
-
-    for dz1, dz2 in itertools.product(Dizhi, Dizhi):
-      for anhe_def in DizhiRules.AnheDef:
-        self.assertEqual(dizhi_utils.anhe(dz1, dz2, definition=anhe_def), DizhiCombo((dz1, dz2)) in expected[anhe_def])
-        self.assertEqual(dizhi_utils.anhe(dz1, dz2, definition=anhe_def), dizhi_utils.anhe(dz2, dz1, definition=anhe_def))
-
-    # Ensure the default definition is `NORMAL`.
-    for dz1, dz2 in itertools.product(Dizhi, Dizhi):
-      self.assertEqual(dizhi_utils.anhe(dz1, dz2), DizhiCombo((dz1, dz2)) in normal_extended_combos)
-      self.assertEqual(dizhi_utils.anhe(dz1, dz2), dizhi_utils.anhe(dz2, dz1))
-
-  def test_search_tonghe(self) -> None:
-    tonghe_combos: set[DizhiCombo] = set()
-    for dz1, dz2 in itertools.product(Dizhi, Dizhi):
-      hidden1, hidden2 = bazi_utils.hidden_tiangans(dz1), bazi_utils.hidden_tiangans(dz2)
-      if len(hidden1) != len(hidden2):
-        continue
-      expected_hidden2: list[Tiangan] = [Tiangan.from_index((tg.index + 5) % 10) for tg in hidden1]
-      if all(tg in hidden2 for tg in expected_hidden2):
-        tonghe_combos.add(DizhiCombo((dz1, dz2)))
-
-    self.assertTrue(self.__dz_equal(
-      dizhi_utils.search([], DizhiRelation.通合),
-      [],
-    ))
-    self.assertTrue(self.__dz_equal(
-      dizhi_utils.search(list(Dizhi), DizhiRelation.通合),
-      tonghe_combos,
-    ))
-
-    for _ in range(500):
-      dizhis: list[Dizhi] = random.sample(Dizhi.as_list(), random.randint(0, len(Dizhi)))
-      result: DizhiRelationCombos = dizhi_utils.search(dizhis, DizhiRelation.通合)
-      expected_result: list[set[Dizhi]] = [set(c) for c in tonghe_combos if c.issubset(dizhis)]
-      self.assertTrue(self.__dz_equal(result, expected_result))
-
-  def test_tonghe(self) -> None:
-    with self.assertRaises(TypeError):
-      dizhi_utils.tonghe(Dizhi.子) # type: ignore
-    with self.assertRaises(TypeError):
-      dizhi_utils.tonghe(Dizhi.子, Dizhi.辰, Dizhi.子, Dizhi.辰) # type: ignore
-    with self.assertRaises(TypeError):
-      dizhi_utils.tonghe((Dizhi.子, Dizhi.丑)) # type: ignore
-    with self.assertRaises(TypeError):
-      dizhi_utils.tonghe({Dizhi.子, Dizhi.丑}) # type: ignore
-    with self.assertRaises(TypeError):
-      dizhi_utils.tonghe([Dizhi.子, Dizhi.丑]) # type: ignore
-    with self.assertRaises(AssertionError):
-      dizhi_utils.tonghe('亥', '子') # type: ignore
-
-    tonghe_combos: set[DizhiCombo] = set()
-    for dz1, dz2 in itertools.product(Dizhi, Dizhi):
-      hidden1, hidden2 = bazi_utils.hidden_tiangans(dz1), bazi_utils.hidden_tiangans(dz2)
-      if len(hidden1) != len(hidden2):
-        continue
-      expected_hidden2: list[Tiangan] = [Tiangan.from_index((tg.index + 5) % 10) for tg in hidden1]
-      if all(tg in hidden2 for tg in expected_hidden2):
-        tonghe_combos.add(DizhiCombo((dz1, dz2)))
-
-    for dz1, dz2 in itertools.product(Dizhi, Dizhi):
-      self.assertEqual(dizhi_utils.tonghe(dz1, dz2), DizhiCombo((dz1, dz2)) in tonghe_combos)
-      self.assertEqual(dizhi_utils.tonghe(dz1, dz2), dizhi_utils.tonghe(dz2, dz1))
-
-  def test_search_tongluhe(self) -> None:
-    tongluhe_combos: list[DizhiCombo] = [ # 天干五合对应的地支禄身。
-      DizhiCombo((bazi_utils.lu(tg1), bazi_utils.lu(tg2))) 
-      for tg1, tg2 in itertools.combinations(Tiangan, 2) if tiangan_utils.he(tg1, tg2) is not None
-    ]
-
-    self.assertTrue(self.__dz_equal(
-      dizhi_utils.search([], DizhiRelation.通禄合),
-      [],
-    ))
-    self.assertTrue(self.__dz_equal(
-      dizhi_utils.search(list(Dizhi), DizhiRelation.通禄合),
-      tongluhe_combos,
-    ))
-
-    for _ in range(500):
-      dizhis: list[Dizhi] = random.sample(Dizhi.as_list(), random.randint(0, len(Dizhi)))
-      result: DizhiRelationCombos = dizhi_utils.search(dizhis, DizhiRelation.通禄合)
-      expected_result: list[set[Dizhi]] = [set(c) for c in tongluhe_combos if c.issubset(dizhis)]
-      self.assertTrue(self.__dz_equal(result, expected_result))
-
-  def test_tongluhe(self) -> None:
-    with self.assertRaises(TypeError):
-      dizhi_utils.tongluhe(Dizhi.子) # type: ignore
-    with self.assertRaises(TypeError):
-      dizhi_utils.tongluhe(Dizhi.子, Dizhi.辰, Dizhi.子, Dizhi.辰) # type: ignore
-    with self.assertRaises(TypeError):
-      dizhi_utils.tongluhe((Dizhi.子, Dizhi.丑)) # type: ignore
-    with self.assertRaises(TypeError):
-      dizhi_utils.tongluhe({Dizhi.子, Dizhi.丑}) # type: ignore
-    with self.assertRaises(TypeError):
-      dizhi_utils.tongluhe([Dizhi.子, Dizhi.丑]) # type: ignore
-    with self.assertRaises(AssertionError):
-      dizhi_utils.tongluhe('亥', '子') # type: ignore
-
-    tongluhe_combos: list[DizhiCombo] = [ # 天干五合对应的地支禄身。
-      DizhiCombo((bazi_utils.lu(tg1), bazi_utils.lu(tg2))) 
-      for tg1, tg2 in itertools.combinations(Tiangan, 2) if tiangan_utils.he(tg1, tg2) is not None
-    ]
-
-    for dz1, dz2 in itertools.product(Dizhi, Dizhi):
-      self.assertEqual(dizhi_utils.tongluhe(dz1, dz2), DizhiCombo((dz1, dz2)) in tongluhe_combos)
-      self.assertEqual(dizhi_utils.tongluhe(dz1, dz2), dizhi_utils.tongluhe(dz2, dz1))
-
-  @staticmethod
-  def __gen_sanhe_table() -> dict[DizhiCombo, Wuxing]:
-    return {
-      DizhiCombo((
-        dz, 
-        Dizhi.from_index((dz.index + 4) % 12), 
-        Dizhi.from_index((dz.index - 4) % 12),
-      )) : bazi_utils.traits(dz).wuxing
-      for dz in [Dizhi('子'), Dizhi('午'), Dizhi('卯'), Dizhi('酉')]
-    }
-
-  def test_search_sanhe(self) -> None:
-    sanhe_table: dict[DizhiCombo, Wuxing] = self.__gen_sanhe_table()
-
-    self.assertTrue(self.__dz_equal(
-      dizhi_utils.search([], DizhiRelation.三合),
-      [],
-    ))
-    self.assertTrue(self.__dz_equal(
-      dizhi_utils.search(list(Dizhi), DizhiRelation.三合),
-      sanhe_table.keys(),
-    ))
-
-    for _ in range(500):
-      dizhis: list[Dizhi] = random.sample(Dizhi.as_list(), random.randint(0, len(Dizhi)))
-      result: DizhiRelationCombos = dizhi_utils.search(dizhis, DizhiRelation.三合)
-      expected_result: list[set[Dizhi]] = [set(c) for c in sanhe_table if c.issubset(dizhis)]
-      self.assertTrue(self.__dz_equal(result, expected_result))
-
-  def test_sanhe(self) -> None:
-    with self.assertRaises(TypeError):
-      dizhi_utils.sanhe(Dizhi.子) # type: ignore
-    with self.assertRaises(TypeError):
-      dizhi_utils.sanhe(Dizhi.子, Dizhi.辰) # type: ignore
-    with self.assertRaises(TypeError):
-      dizhi_utils.sanhe(Dizhi.子, Dizhi.辰, Dizhi.子, Dizhi.辰) # type: ignore
-    with self.assertRaises(TypeError):
-      dizhi_utils.sanhe((Dizhi.亥, Dizhi.子, Dizhi.丑)) # type: ignore
-    with self.assertRaises(TypeError):
-      dizhi_utils.sanhe({Dizhi.亥, Dizhi.子, Dizhi.丑}) # type: ignore
-    with self.assertRaises(TypeError):
-      dizhi_utils.sanhe([Dizhi.亥, Dizhi.子, Dizhi.丑]) # type: ignore
-    with self.assertRaises(AssertionError):
-      dizhi_utils.sanhe('亥', '子', '丑') # type: ignore
-
-    sanhe_table: dict[DizhiCombo, Wuxing] = self.__gen_sanhe_table()
-    
-    for dizhis in itertools.product(Dizhi, repeat=3):
-      fs: DizhiCombo = DizhiCombo(dizhis)
-      if fs in sanhe_table:
-        for combo in itertools.permutations(dizhis):
-          self.assertEqual(dizhi_utils.sanhe(*combo), sanhe_table[fs])
-      else:
-        for combo in itertools.permutations(dizhis):
-          self.assertIsNone(dizhi_utils.sanhe(*dizhis))
-
-  @staticmethod
-  def __gen_banhe_table() -> dict[DizhiCombo, Wuxing]:
-    pivots: set[Dizhi] = {Dizhi('子'), Dizhi('午'), Dizhi('卯'), Dizhi('酉')} # 四中神
-    sanhe_table: dict[DizhiCombo, Wuxing] = TestDizhiUtils.__gen_sanhe_table()
-
-    d: dict[DizhiCombo, Wuxing] = {}
-    for sanhe_dizhis, wx in sanhe_table.items():
-      for dz1, dz2 in itertools.combinations(sanhe_dizhis, 2):
-        if any(dz in pivots for dz in (dz1, dz2)): # 半合局需要出现中神
-          d[DizhiCombo((dz1, dz2))] = wx
-    return d
-
-  def test_search_banhe(self) -> None:
-    banhe_table: dict[DizhiCombo, Wuxing] = self.__gen_banhe_table()
-
-    self.assertTrue(self.__dz_equal(
-      dizhi_utils.search([], DizhiRelation.半合),
-      [],
-    ))
-    self.assertTrue(self.__dz_equal(
-      dizhi_utils.search(list(Dizhi), DizhiRelation.半合),
-      banhe_table.keys()
-    ))
-
-    for _ in range(500):
-      dizhis: list[Dizhi] = random.sample(Dizhi.as_list(), random.randint(0, len(Dizhi)))
-      result: DizhiRelationCombos = dizhi_utils.search(dizhis, DizhiRelation.半合)
-      expected_result: list[set[Dizhi]] = [set(c) for c in banhe_table if c.issubset(dizhis)]
-      self.assertTrue(self.__dz_equal(result, expected_result))
-
-  def test_banhe(self) -> None:
-    with self.assertRaises(TypeError):
-      dizhi_utils.banhe(Dizhi.子) # type: ignore
-    with self.assertRaises(TypeError):
-      dizhi_utils.banhe(Dizhi.子, Dizhi.辰, Dizhi.申) # type: ignore
-    with self.assertRaises(TypeError):
-      dizhi_utils.banhe((Dizhi.子, Dizhi.丑)) # type: ignore
-    with self.assertRaises(TypeError):
-      dizhi_utils.banhe({Dizhi.子, Dizhi.丑}) # type: ignore
-    with self.assertRaises(TypeError):
-      dizhi_utils.banhe([Dizhi.子, Dizhi.丑]) # type: ignore
-    with self.assertRaises(AssertionError):
-      dizhi_utils.banhe('亥', '子') # type: ignore
-
-    banhe_table: dict[DizhiCombo, Wuxing] = self.__gen_banhe_table()
-
-    for dz1, dz2 in itertools.product(Dizhi, Dizhi):
-      self.assertEqual(dizhi_utils.banhe(dz1, dz2), banhe_table.get(DizhiCombo((dz1, dz2)), None))
-      self.assertEqual(dizhi_utils.banhe(dz1, dz2), dizhi_utils.banhe(dz2, dz1))
-
-  def test_search_xing(self) -> None:
-    xing_expected: list[dict[Dizhi, int]] = [ # 辰午酉亥自刑
-      {
-        dz : 2,
-      } for dz in [Dizhi.辰, Dizhi.午, Dizhi.酉, Dizhi.亥]
-    ] + [ # 其他相刑
-      { Dizhi.子 : 1, Dizhi.卯 : 1, },
-      { Dizhi.寅 : 1, Dizhi.巳 : 1, Dizhi.申 : 1, },
-      { Dizhi.丑 : 1, Dizhi.未 : 1, Dizhi.戌 : 1, },
-    ] + [ # LOOSE def.
-      { Dizhi.寅 : 1, Dizhi.巳 : 1, },
-      { Dizhi.巳 : 1, Dizhi.申 : 1, },
-      { Dizhi.寅 : 1, Dizhi.申 : 1, },
-      { Dizhi.丑 : 1, Dizhi.未 : 1, },
-      { Dizhi.未 : 1, Dizhi.戌 : 1, },
-      { Dizhi.丑 : 1, Dizhi.戌 : 1, },
-    ]
-
-    def __find_qualified(dizhis: list[Dizhi]) -> list[set[Dizhi]]:
-      ret: list[set[Dizhi]] = []
-      for required in xing_expected:
-        if all(
-          sum(dz == d for d in dizhis) >= required[dz] 
-          for dz in required
-        ):
-          ret.append(set(required.keys())) 
-      return ret
-
-    self.assertTrue(self.__dz_equal(
-      dizhi_utils.search([], DizhiRelation.刑),
-      [],
-    ))
-    self.assertTrue(self.__dz_equal(
-      dizhi_utils.search([Dizhi.子, Dizhi.卯], DizhiRelation.刑),
-      [{Dizhi.子, Dizhi.卯}],
-    ))
-    self.assertTrue(self.__dz_equal(
-      dizhi_utils.search([Dizhi.卯, Dizhi.子], DizhiRelation.刑),
-      [{Dizhi.子, Dizhi.卯}],
-    ))
-    self.assertTrue(self.__dz_equal(
-      dizhi_utils.search(list(Dizhi), DizhiRelation.刑),
-      [{Dizhi.子, Dizhi.卯}, 
-       {Dizhi.寅, Dizhi.巳, Dizhi.申}, {Dizhi.寅, Dizhi.巳}, {Dizhi.巳, Dizhi.申}, {Dizhi.寅, Dizhi.申}, 
-       {Dizhi.丑, Dizhi.未, Dizhi.戌}, {Dizhi.丑, Dizhi.未}, {Dizhi.未, Dizhi.戌}, {Dizhi.丑, Dizhi.戌}],
-    ))
-    self.assertTrue(self.__dz_equal(
-      dizhi_utils.search(list(Dizhi) + [Dizhi.辰, Dizhi.午, Dizhi.酉, Dizhi.亥], DizhiRelation.刑),
-      [set(d.keys()) for d in xing_expected]
-    ))
-
-    for _ in range(500):
-      dizhis: list[Dizhi] = [] 
-      for _ in range(random.randint(1, 4)):
-        dizhis += random.sample(list(Dizhi), random.randint(0, len(Dizhi)))
-      result: DizhiRelationCombos = dizhi_utils.search(dizhis, DizhiRelation.刑)
-      expected_result: list[set[Dizhi]] = __find_qualified(dizhis)
-      self.assertTrue(self.__dz_equal(result, expected_result))
-
-  def test_xing_negative(self) -> None:
-    with self.assertRaises(AssertionError):
-      dizhi_utils.xing(Dizhi.子, Dizhi.辰, Dizhi.子, Dizhi.辰)
-    with self.assertRaises(AssertionError):
-      dizhi_utils.xing((Dizhi.子, Dizhi.丑)) # type: ignore
-    with self.assertRaises(AssertionError):
-      dizhi_utils.xing({Dizhi.子, Dizhi.丑}) # type: ignore
-    with self.assertRaises(AssertionError):
-      dizhi_utils.xing([Dizhi.子, Dizhi.丑]) # type: ignore
-    with self.assertRaises(AssertionError):
-      dizhi_utils.xing('亥', '子') # type: ignore
-    with self.assertRaises(AssertionError):
-      dizhi_utils.xing(Dizhi.子, Dizhi.辰, DizhiRules.XingDef.LOOSE) # type: ignore
-    with self.assertRaises(AssertionError):
-      dizhi_utils.xing(Dizhi.子, Dizhi.辰, definition='DizhiRules.X.NORMAL') # type: ignore
-
-    for dz in Dizhi:
-      self.assertIsNone(dizhi_utils.xing(dz))
-      self.assertIsNone(dizhi_utils.xing(dz, definition=DizhiRules.XingDef.STRICT))
-      self.assertIsNone(dizhi_utils.xing(dz, definition=DizhiRules.XingDef.LOOSE))
-
-    for _ in range(500):
-      random_dizhis: list[Dizhi] = random.sample(list(Dizhi), random.randint(4, len(Dizhi)))
-      with self.assertRaises(AssertionError):
-        self.assertIsNone(dizhi_utils.xing(*random_dizhis))
-      with self.assertRaises(AssertionError):
-        self.assertIsNone(dizhi_utils.xing(*random_dizhis, definition=DizhiRules.XingDef.STRICT))
-      with self.assertRaises(AssertionError):
-        self.assertIsNone(dizhi_utils.xing(*random_dizhis, definition=DizhiRules.XingDef.LOOSE))
-
-  @pytest.mark.slow
-  def test_xing_strict(self) -> None:
-    self.assertIsNone(dizhi_utils.xing())
-    self.assertIsNone(dizhi_utils.xing(definition=DizhiRules.XingDef.STRICT))
-    self.assertEqual(dizhi_utils.xing(Dizhi.亥, definition=DizhiRules.XingDef.STRICT), None)
-    self.assertEqual(dizhi_utils.xing(Dizhi.亥, Dizhi.亥, definition=DizhiRules.XingDef.STRICT), DizhiRules.XingSubType.自刑)
-    self.assertEqual(dizhi_utils.xing(Dizhi.亥, Dizhi.亥, Dizhi.亥, definition=DizhiRules.XingDef.STRICT), None)
-    self.assertEqual(dizhi_utils.xing(Dizhi.子, Dizhi.卯, definition=DizhiRules.XingDef.STRICT), DizhiRules.XingSubType.子卯刑)
-    self.assertEqual(dizhi_utils.xing(Dizhi.卯, Dizhi.子, definition=DizhiRules.XingDef.STRICT), DizhiRules.XingSubType.子卯刑)
-    self.assertEqual(dizhi_utils.xing(Dizhi.子, Dizhi.卯, Dizhi.亥, definition=DizhiRules.XingDef.STRICT), None)
-    self.assertEqual(dizhi_utils.xing(Dizhi.寅, Dizhi.巳, Dizhi.申, definition=DizhiRules.XingDef.STRICT), DizhiRules.XingSubType.三刑)
-    self.assertEqual(dizhi_utils.xing(Dizhi.巳, Dizhi.寅, Dizhi.申, definition=DizhiRules.XingDef.STRICT), DizhiRules.XingSubType.三刑)
-    self.assertEqual(dizhi_utils.xing(Dizhi.寅, Dizhi.巳, definition=DizhiRules.XingDef.STRICT), None)
-    self.assertEqual(dizhi_utils.xing(Dizhi.巳, Dizhi.寅, definition=DizhiRules.XingDef.STRICT), None)
-
-    def __expected_strict_xing(dizhis: tuple[Dizhi, ...]) -> DizhiRules.XingSubType | None:
-      # In `XingDef.STRICT` mode, we don't care about the direction.
-      __fs: DizhiCombo = DizhiCombo(dizhis)
-      if __fs in [DizhiCombo((Dizhi.丑, Dizhi.戌, Dizhi.未)), DizhiCombo((Dizhi.寅, Dizhi.巳, Dizhi.申))]:
-        return DizhiRules.XingSubType.三刑
-      elif __fs == DizhiCombo((Dizhi.子, Dizhi.卯)):
-        return DizhiRules.XingSubType.子卯刑
-      elif len(__fs) == 1 and len(dizhis) == 2 and dizhis[0] in (Dizhi.辰, Dizhi.午, Dizhi.酉, Dizhi.亥):
-        return DizhiRules.XingSubType.自刑
-      return None
-    
-    for dz in Dizhi:
-      self.assertIsNone(dizhi_utils.xing(dz, definition=DizhiRules.XingDef.STRICT))
-
-    for dz1, dz2 in itertools.product(Dizhi, Dizhi):
-      strict_result: DizhiRules.XingSubType | None = dizhi_utils.xing(dz1, dz2, definition=DizhiRules.XingDef.STRICT)
-      strict_result2: DizhiRules.XingSubType | None = dizhi_utils.xing(dz2, dz1, definition=DizhiRules.XingDef.STRICT)
-      strict_result3: DizhiRules.XingSubType | None = dizhi_utils.xing(dz1, dz2, definition=DizhiRules.XingDef.STRICT)
-      self.assertEqual(strict_result, strict_result2)
-      self.assertEqual(strict_result, strict_result3)
-      self.assertEqual(strict_result, __expected_strict_xing((dz1, dz2)))
-
-    for dz_tuple in itertools.product(Dizhi, Dizhi, Dizhi):
-      strict_result4: DizhiRules.XingSubType | None = dizhi_utils.xing(*dz_tuple, definition=DizhiRules.XingDef.STRICT)
-      for dz1, dz2, dz3 in itertools.permutations(dz_tuple, 3):
-        self.assertEqual(strict_result4, dizhi_utils.xing(dz1, dz2, dz3, definition=DizhiRules.XingDef.STRICT))
-        self.assertEqual(strict_result4, dizhi_utils.xing(dz1, dz2, dz3, definition=DizhiRules.XingDef.STRICT))
-
-  def test_xing_loose(self) -> None:
-    self.assertIsNone(dizhi_utils.xing(definition=DizhiRules.XingDef.LOOSE))
-    self.assertEqual(dizhi_utils.xing(Dizhi.亥, definition=DizhiRules.XingDef.LOOSE), 
-                     None)
-    self.assertEqual(dizhi_utils.xing(Dizhi.亥, Dizhi.亥, definition=DizhiRules.XingDef.LOOSE), 
-                     DizhiRules.XingSubType.自刑)
-    self.assertEqual(dizhi_utils.xing(Dizhi.亥, Dizhi.亥, Dizhi.亥, definition=DizhiRules.XingDef.LOOSE), 
-                     None)
-    self.assertEqual(dizhi_utils.xing(Dizhi.子, Dizhi.卯, definition=DizhiRules.XingDef.LOOSE), 
-                     DizhiRules.XingSubType.子卯刑)
-    self.assertEqual(dizhi_utils.xing(Dizhi.卯, Dizhi.子, definition=DizhiRules.XingDef.LOOSE), 
-                     DizhiRules.XingSubType.子卯刑)
-    self.assertEqual(dizhi_utils.xing(Dizhi.子, Dizhi.卯, Dizhi.亥, definition=DizhiRules.XingDef.LOOSE), 
-                     None)
-    self.assertEqual(dizhi_utils.xing(Dizhi.寅, Dizhi.巳, Dizhi.申, definition=DizhiRules.XingDef.LOOSE), 
-                     DizhiRules.XingSubType.三刑)
-    self.assertEqual(dizhi_utils.xing(Dizhi.巳, Dizhi.寅, Dizhi.申, definition=DizhiRules.XingDef.LOOSE), 
-                     DizhiRules.XingSubType.三刑)
-    self.assertEqual(dizhi_utils.xing(Dizhi.寅, Dizhi.巳, definition=DizhiRules.XingDef.LOOSE), 
-                     DizhiRules.XingSubType.三刑)
-    self.assertEqual(dizhi_utils.xing(Dizhi.巳, Dizhi.寅, definition=DizhiRules.XingDef.LOOSE), 
-                     None)
-
-    sanxing_list: list[tuple[Dizhi, ...]] = [
-      (Dizhi.丑, Dizhi.戌),
-      (Dizhi.戌, Dizhi.未),
-      (Dizhi.未, Dizhi.丑),
-      (Dizhi.寅, Dizhi.巳),
-      (Dizhi.巳, Dizhi.申),
-      (Dizhi.申, Dizhi.寅),
-      *(list(itertools.permutations((Dizhi.丑, Dizhi.戌, Dizhi.未)))),
-      *(list(itertools.permutations((Dizhi.寅, Dizhi.巳, Dizhi.申)))),
-    ]
-
-    zimaoxing_list: list[tuple[Dizhi, ...]] = [
-      (Dizhi.子, Dizhi.卯),
-      (Dizhi.卯, Dizhi.子),
-    ]
-
-    zixing_list: list[tuple[Dizhi, ...]] = [
-      (dz, dz) for dz in (Dizhi.辰, Dizhi.午, Dizhi.酉, Dizhi.亥)
-    ]
-
-    for dz in Dizhi:
-      self.assertIsNone(dizhi_utils.xing(dz, definition=DizhiRules.XingDef.LOOSE))
-
-    dz_tuple: tuple[Dizhi, ...]
-    for dz_tuple in itertools.product(Dizhi, Dizhi):
-      loose_result: DizhiRules.XingSubType | None = dizhi_utils.xing(*dz_tuple, definition=DizhiRules.XingDef.LOOSE)
-      if loose_result is DizhiRules.XingSubType.三刑:
-        self.assertIn(dz_tuple, sanxing_list)
-      elif loose_result is DizhiRules.XingSubType.子卯刑:
-        self.assertIn(dz_tuple, zimaoxing_list)
-      elif loose_result is DizhiRules.XingSubType.自刑:
-        self.assertIn(dz_tuple, zixing_list)
-      else:
-        self.assertIsNone(loose_result)
-        self.assertNotIn(dz_tuple, sanxing_list)
-        self.assertNotIn(dz_tuple, zimaoxing_list)
-        self.assertNotIn(dz_tuple, zixing_list)
-
-    for dz_tuple in itertools.product(Dizhi, Dizhi, Dizhi):
-      loose_result2: DizhiRules.XingSubType | None = dizhi_utils.xing(*dz_tuple, definition=DizhiRules.XingDef.LOOSE)
-      if loose_result2 is None:
-        self.assertNotIn(dz_tuple, sanxing_list)
-        self.assertNotIn(dz_tuple, zimaoxing_list)
-        self.assertNotIn(dz_tuple, zixing_list)
-      else:
-        self.assertEqual(loose_result2, DizhiRules.XingSubType.三刑)
-        self.assertIn(dz_tuple, sanxing_list)
-
-  def test_search_chong(self) -> None:
-    chong_table: list[set[Dizhi]] = [set(dz_tuple) for dz_tuple in zip(Dizhi.as_list()[:6], Dizhi.as_list()[6:])]
-
-    self.assertTrue(self.__dz_equal(
-      dizhi_utils.search([], DizhiRelation.冲),
-      [],
-    ))
-    self.assertTrue(self.__dz_equal(
-      dizhi_utils.search(list(Dizhi), DizhiRelation.冲),
-      chong_table,
-    ))
-
-    for _ in range(500):
-      dizhis: list[Dizhi] = random.sample(list(Dizhi), random.randint(0, len(Dizhi)))
-      result: DizhiRelationCombos = dizhi_utils.search(dizhis, DizhiRelation.冲)
-      expected_result: list[set[Dizhi]] = [c for c in chong_table if c.issubset(dizhis)]
-      self.assertTrue(self.__dz_equal(result, expected_result))
-
-  def test_chong(self) -> None:
-    with self.assertRaises(TypeError):
-      dizhi_utils.chong(Dizhi.子) # type: ignore
-    with self.assertRaises(TypeError):
-      dizhi_utils.chong(Dizhi.子, Dizhi.辰, Dizhi.辰) # type: ignore
-    with self.assertRaises(TypeError):
-      dizhi_utils.chong(Dizhi.子, Dizhi.辰, Dizhi.子, Dizhi.辰) # type: ignore
-    with self.assertRaises(TypeError):
-      dizhi_utils.chong((Dizhi.亥, Dizhi.子, Dizhi.丑)) # type: ignore
-    with self.assertRaises(TypeError):
-      dizhi_utils.chong({Dizhi.亥, Dizhi.子, Dizhi.丑}) # type: ignore
-    with self.assertRaises(TypeError):
-      dizhi_utils.chong([Dizhi.亥, Dizhi.子, Dizhi.丑]) # type: ignore
-    with self.assertRaises(AssertionError):
-      dizhi_utils.chong('亥', '子') # type: ignore
-    with self.assertRaises(AssertionError):
-      dizhi_utils.chong(Tiangan.甲, '子') # type: ignore
-
-    chong_table: list[set[Dizhi]] = [set(dz_tuple) for dz_tuple in zip(Dizhi.as_list()[:6], Dizhi.as_list()[6:])]
-
-    for dz1, dz2 in itertools.product(Dizhi, repeat=2):
-      self.assertEqual(dizhi_utils.chong(dz1, dz2), dizhi_utils.chong(dz2, dz1), 'CHONG (冲) is a bi-directional relation')
-      self.assertEqual(dizhi_utils.chong(dz1, dz2), {dz1, dz2} in chong_table)
-
-  @staticmethod
-  def __gen_po_table() -> list[set[Dizhi]]:
-    return [{
-      Dizhi.from_index(dz_idx), Dizhi.from_index((dz_idx - 3) % 12),
-    } for dz_idx in range(0, 12, 2)]
-
-  def test_search_po(self) -> None:
-    po_table: list[set[Dizhi]] = self.__gen_po_table()
-
-    self.assertTrue(self.__dz_equal(
-      dizhi_utils.search([], DizhiRelation.破),
-      [],
-    ))
-    self.assertTrue(self.__dz_equal(
-      dizhi_utils.search(list(Dizhi), DizhiRelation.破),
-      po_table,
-    ))
-
-    for _ in range(500):
-      dizhis: list[Dizhi] = random.sample(list(Dizhi), random.randint(0, len(Dizhi)))
-      result: DizhiRelationCombos = dizhi_utils.search(dizhis, DizhiRelation.破)
-      expected_result: list[set[Dizhi]] = [c for c in po_table if c.issubset(dizhis)]
-      self.assertTrue(self.__dz_equal(result, expected_result))
-
-  def test_po(self) -> None:
-    with self.assertRaises(TypeError):
-      dizhi_utils.po(Dizhi.子) # type: ignore
-    with self.assertRaises(TypeError):
-      dizhi_utils.po(Dizhi.子, Dizhi.辰, Dizhi.辰) # type: ignore
-    with self.assertRaises(TypeError):
-      dizhi_utils.po(Dizhi.子, Dizhi.辰, Dizhi.子, Dizhi.辰) # type: ignore
-    with self.assertRaises(TypeError):
-      dizhi_utils.po((Dizhi.亥, Dizhi.子, Dizhi.丑)) # type: ignore
-    with self.assertRaises(TypeError):
-      dizhi_utils.po({Dizhi.亥, Dizhi.子, Dizhi.丑}) # type: ignore
-    with self.assertRaises(TypeError):
-      dizhi_utils.po([Dizhi.亥, Dizhi.子, Dizhi.丑]) # type: ignore
-    with self.assertRaises(AssertionError):
-      dizhi_utils.po([Dizhi.亥, Dizhi.子], [Dizhi.丑]) # type: ignore
-    with self.assertRaises(AssertionError):
-      dizhi_utils.po('亥', '子') # type: ignore
-
-    po_table: list[set[Dizhi]] = self.__gen_po_table()
-
-    for dz1, dz2 in itertools.product(Dizhi, repeat=2):
-      self.assertEqual(dizhi_utils.po(dz1, dz2), dizhi_utils.po(dz2, dz1), 'PO (破) is a bi-directional relation')
-      self.assertEqual(dizhi_utils.po(dz1, dz2), {dz1, dz2} in po_table)
-
-  @staticmethod
-  def __gen_hai_table() -> set[DizhiCombo]:
-    ret: set[DizhiCombo] = set()
-    for dz1, dz2 in itertools.combinations(Dizhi, 2):
-      if dizhi_utils.liuhe(dz1, dz2):
-        dz1_chong: Dizhi = Dizhi.from_index((dz1.index + 6) % 12)
-        dz2_chong: Dizhi = Dizhi.from_index((dz2.index + 6) % 12)
-        ret.add(DizhiCombo((dz1, dz2_chong)))
-        ret.add(DizhiCombo((dz1_chong, dz2)))
-    return ret
-  
-  def test_search_hai(self) -> None:
-    hai_set: set[DizhiCombo] = self.__gen_hai_table()
-
-    self.assertTrue(self.__dz_equal(
-      dizhi_utils.search([], DizhiRelation.害),
-      [],
-    ))
-    self.assertTrue(self.__dz_equal(
-      dizhi_utils.search(list(Dizhi), DizhiRelation.害),
-      hai_set,
-    ))
-    self.assertTrue(self.__dz_equal(
-      dizhi_utils.search(list(Dizhi) * 2, DizhiRelation.害),
-      hai_set,
-    ))
-
-    for _ in range(500):
-      dizhis: list[Dizhi] = random.sample(list(Dizhi), random.randint(0, len(Dizhi)))
-      result: DizhiRelationCombos = dizhi_utils.search(dizhis, DizhiRelation.害)
-      expected_result: list[DizhiCombo] = [c for c in hai_set if c.issubset(dizhis)]
-      self.assertTrue(self.__dz_equal(result, expected_result))
-
-  def test_hai(self) -> None:
-    with self.assertRaises(TypeError):
-      dizhi_utils.hai(Dizhi.子) # type: ignore
-    with self.assertRaises(TypeError):
-      dizhi_utils.hai(Dizhi.子, Dizhi.辰, Dizhi.辰) # type: ignore
-    with self.assertRaises(TypeError):
-      dizhi_utils.hai((Dizhi.亥, Dizhi.子, Dizhi.丑)) # type: ignore
-    with self.assertRaises(TypeError):
-      dizhi_utils.hai({Dizhi.亥, Dizhi.子, Dizhi.丑}) # type: ignore
-    with self.assertRaises(AssertionError):
-      dizhi_utils.hai([Dizhi.亥], [Dizhi.丑]) # type: ignore
-    with self.assertRaises(AssertionError):
-      dizhi_utils.hai('亥', '丑') # type: ignore
-
-    hai_set: set[DizhiCombo] = self.__gen_hai_table()
-
-    for dz1, dz2 in itertools.product(Dizhi, repeat=2):
-      self.assertEqual(dizhi_utils.hai(dz1, dz2), dizhi_utils.hai(dz2, dz1), 'HAI (害) is a bi-directional relation')
-      self.assertEqual(dizhi_utils.hai(dz1, dz2), DizhiCombo((dz1, dz2)) in hai_set)
-
-  def test_search_sheng_ke(self) -> None:
-    for _ in range(200):
-      dizhis: list[Dizhi] = random.sample(list(Dizhi), random.randint(0, len(Dizhi)))
-      sheng_result: DizhiRelationCombos = dizhi_utils.search(dizhis, DizhiRelation.生)
-      ke_result: DizhiRelationCombos = dizhi_utils.search(dizhis, DizhiRelation.克)
-
-      for fs in sheng_result:
-        for dz in fs:
-          self.assertIn(dz, dizhis)
-      for fs in ke_result:
-        for dz in fs:
-          self.assertIn(dz, dizhis)
-
-      for dz1, dz2 in itertools.combinations(dizhis, 2):
-        wx1, wx2 = bazi_utils.traits(dz1).wuxing, bazi_utils.traits(dz2).wuxing
-        if wx1.generates(wx2) or wx2.generates(wx1):
-          self.assertTrue(DizhiCombo((dz1, dz2)) in sheng_result)
-        if wx1.destructs(wx2) or wx2.destructs(wx1):
-          self.assertTrue(DizhiCombo((dz1, dz2)) in ke_result)
-
-  def test_sheng(self) -> None:
-    with self.assertRaises(TypeError):
-      dizhi_utils.sheng(Dizhi.子) # type: ignore
-    with self.assertRaises(TypeError):
-      dizhi_utils.sheng(Dizhi.子, Dizhi.辰, Dizhi.辰) # type: ignore
-    with self.assertRaises(TypeError):
-      dizhi_utils.sheng((Dizhi.亥, Dizhi.子, Dizhi.丑)) # type: ignore
-    with self.assertRaises(TypeError):
-      dizhi_utils.sheng({Dizhi.亥, Dizhi.子, Dizhi.丑}) # type: ignore
-    with self.assertRaises(AssertionError):
-      dizhi_utils.sheng([Dizhi.亥], [Dizhi.丑]) # type: ignore
-    with self.assertRaises(AssertionError):
-      dizhi_utils.sheng('亥', '丑') # type: ignore
-
-    for dz1, dz2 in itertools.product(Dizhi, repeat=2):
+  return True
+
+
+def test_search_sanhui() -> None:
+  sanhui_combos: list[DizhiCombo] = [
+    DizhiCombo((Dizhi.from_index(2), Dizhi.from_index(3), Dizhi.from_index(4))),
+    DizhiCombo((Dizhi.from_index(5), Dizhi.from_index(6), Dizhi.from_index(7))),
+    DizhiCombo((Dizhi.from_index(8), Dizhi.from_index(9), Dizhi.from_index(10))),
+    DizhiCombo((Dizhi.from_index(11), Dizhi.from_index(0), Dizhi.from_index(1))),
+  ]
+
+  assert _dz_equal(
+    dizhi_utils.search([], DizhiRelation.三会),
+    [],
+  )
+  assert _dz_equal(
+    dizhi_utils.search(list(Dizhi), DizhiRelation.三会),
+    [set(c) for c in sanhui_combos],
+  )
+
+  for _ in range(500):
+    dizhis: list[Dizhi] = random.sample(Dizhi.as_list(), random.randint(0, len(Dizhi)))
+    result: DizhiRelationCombos = dizhi_utils.search(dizhis, DizhiRelation.三会)
+    expected_result: list[set[Dizhi]] = [set(c) for c in sanhui_combos if c.issubset(dizhis)]
+    assert _dz_equal(result, expected_result)
+
+def test_sanhui() -> None:
+  with pytest.raises(TypeError):
+    dizhi_utils.sanhui(Dizhi.子) # type: ignore
+  with pytest.raises(TypeError):
+    dizhi_utils.sanhui(Dizhi.子, Dizhi.辰) # type: ignore
+  with pytest.raises(TypeError):
+    dizhi_utils.sanhui(Dizhi.子, Dizhi.辰, Dizhi.子, Dizhi.辰) # type: ignore
+  with pytest.raises(TypeError):
+    dizhi_utils.sanhui((Dizhi.亥, Dizhi.子, Dizhi.丑)) # type: ignore
+  with pytest.raises(TypeError):
+    dizhi_utils.sanhui({Dizhi.亥, Dizhi.子, Dizhi.丑}) # type: ignore
+  with pytest.raises(TypeError):
+    dizhi_utils.sanhui([Dizhi.亥, Dizhi.子, Dizhi.丑]) # type: ignore
+  with pytest.raises(AssertionError):
+    dizhi_utils.sanhui('亥', '子', '丑') # type: ignore
+
+  dizhi_tuples: list[tuple[Dizhi, Dizhi, Dizhi]] = [
+    (Dizhi.寅, Dizhi.卯, Dizhi.辰), # Spring / 春
+    (Dizhi.巳, Dizhi.午, Dizhi.未), # Summer / 夏
+    (Dizhi.申, Dizhi.酉, Dizhi.戌), # Fall   / 秋
+    (Dizhi.亥, Dizhi.子, Dizhi.丑), # Winter / 冬
+  ]
+  expected: dict[DizhiCombo, Wuxing] = {
+    DizhiCombo(dizhis) : bazi_utils.traits(dizhis[0]).wuxing for dizhis in dizhi_tuples
+  }
+
+  for dizhis in itertools.product(Dizhi, repeat=3):
+    fs: DizhiCombo = DizhiCombo(dizhis)
+    if fs in expected:
+      for combo in itertools.permutations(dizhis):
+        assert dizhi_utils.sanhui(*combo) == expected[fs]
+    else:
+      for combo in itertools.permutations(dizhis):
+        assert dizhi_utils.sanhui(*dizhis) is None
+
+def test_search_liuhe() -> None:
+  liuhe_combos: list[DizhiCombo] = [
+    DizhiCombo((dz1, dz2)) for dz1, dz2 in itertools.combinations(Dizhi, 2) if (dz1.index + dz2.index) % 12 == 1
+  ]
+
+  assert _dz_equal(
+    dizhi_utils.search([], DizhiRelation.六合),
+    [],
+  )
+  assert _dz_equal(
+    dizhi_utils.search(list(Dizhi), DizhiRelation.六合),
+    liuhe_combos,
+  )
+
+  for _ in range(500):
+    dizhis: list[Dizhi] = random.sample(Dizhi.as_list(), random.randint(0, len(Dizhi)))
+    result: DizhiRelationCombos = dizhi_utils.search(dizhis, DizhiRelation.六合)
+    expected_result: list[set[Dizhi]] = [set(c) for c in liuhe_combos if c.issubset(dizhis)]
+    assert _dz_equal(result, expected_result)
+
+def test_liuhe() -> None:
+  with pytest.raises(TypeError):
+    dizhi_utils.liuhe(Dizhi.子) # type: ignore
+  with pytest.raises(TypeError):
+    dizhi_utils.liuhe(Dizhi.子, Dizhi.辰, Dizhi.子, Dizhi.辰) # type: ignore
+  with pytest.raises(TypeError):
+    dizhi_utils.liuhe((Dizhi.子, Dizhi.丑)) # type: ignore
+  with pytest.raises(TypeError):
+    dizhi_utils.liuhe({Dizhi.子, Dizhi.丑}) # type: ignore
+  with pytest.raises(TypeError):
+    dizhi_utils.liuhe([Dizhi.子, Dizhi.丑]) # type: ignore
+  with pytest.raises(AssertionError):
+    dizhi_utils.liuhe('亥', '子') # type: ignore
+
+  liuhe_combos: list[DizhiCombo] = [
+    DizhiCombo((dz1, dz2)) for dz1, dz2 in itertools.combinations(Dizhi, 2) if (dz1.index + dz2.index) % 12 == 1
+  ]
+
+  for dz1, dz2 in itertools.permutations(Dizhi, 2):
+    liuhe_result: Wuxing | None = dizhi_utils.liuhe(dz1, dz2)
+    liuhe_result2: Wuxing | None = dizhi_utils.liuhe(dz2, dz1)
+    assert liuhe_result == liuhe_result2
+
+    if DizhiCombo((dz1, dz2)) in liuhe_combos:
       wx1, wx2 = bazi_utils.traits(dz1).wuxing, bazi_utils.traits(dz2).wuxing
       if wx1.generates(wx2):
-        self.assertTrue(dizhi_utils.sheng(dz1, dz2))
-        self.assertFalse(dizhi_utils.sheng(dz2, dz1))
+        assert liuhe_result == wx2
+      elif wx2.generates(wx1):
+        assert liuhe_result == wx1
       else:
-        self.assertFalse(dizhi_utils.sheng(dz1, dz2))
-
-  def test_ke(self) -> None:
-    with self.assertRaises(TypeError):
-      dizhi_utils.ke(Dizhi.子) # type: ignore
-    with self.assertRaises(TypeError):
-      dizhi_utils.ke(Dizhi.子, Dizhi.辰, Dizhi.辰) # type: ignore
-    with self.assertRaises(TypeError):
-      dizhi_utils.ke((Dizhi.亥, Dizhi.子, Dizhi.丑)) # type: ignore
-    with self.assertRaises(TypeError):
-      dizhi_utils.ke({Dizhi.亥, Dizhi.子, Dizhi.丑}) # type: ignore
-    with self.assertRaises(AssertionError):
-      dizhi_utils.ke([Dizhi.亥], [Dizhi.丑]) # type: ignore
-    with self.assertRaises(AssertionError):
-      dizhi_utils.ke('亥', '丑') # type: ignore
-
-    for dz1, dz2 in itertools.product(Dizhi, repeat=2):
-      wx1, wx2 = bazi_utils.traits(dz1).wuxing, bazi_utils.traits(dz2).wuxing
-      if wx1.destructs(wx2):
-        self.assertTrue(dizhi_utils.ke(dz1, dz2))
-        self.assertFalse(dizhi_utils.ke(dz2, dz1))
-      else:
-        self.assertFalse(dizhi_utils.ke(dz1, dz2))
-
-  def test_search_negative(self) -> None:
-    with self.assertRaises(TypeError):
-      dizhi_utils.search([Dizhi.子, Dizhi.午]) # type: ignore
-
-    for tg_relation in TianganRelation:
-      with self.assertRaises(AssertionError):
-        dizhi_utils.search([Dizhi.子, Dizhi.午], tg_relation) # type: ignore
-
-    for relation in DizhiRelation:
-      with self.assertRaises(AssertionError):
-        dizhi_utils.search(Dizhi.子, relation) # type: ignore
-      with self.assertRaises(AssertionError):
-        dizhi_utils.search(['甲', '己'], relation) # type: ignore
-      with self.assertRaises(AssertionError):
-        dizhi_utils.search([Dizhi.子, Dizhi.午], str(relation)) # type: ignore
-      with self.assertRaises(AssertionError):
-        dizhi_utils.search({Dizhi.子, Dizhi.午}, relation) # type: ignore
-
-  @pytest.mark.slow
-  def test_search(self) -> None:
-    for relation in DizhiRelation:
-      for round in range(300):
-        dizhis: list[Dizhi] = random.sample(list(Dizhi), random.randint(0, len(Dizhi)))
-        for _ in range(random.randint(0, 2)):
-          dizhis += random.sample(list(Dizhi), random.randint(0, len(Dizhi)))
-
-        dizhi_counter: Counter[Dizhi] = Counter(dizhis)
-        result: DizhiRelationCombos = dizhi_utils.search(dizhis, relation)
-        for _ in range(2):
-          random.shuffle(dizhis)
-          copied: list[Dizhi] = copy.deepcopy(dizhis)
-          self.assertTrue(self.__dz_equal(result, dizhi_utils.search(dizhis, relation)))
-          self.assertListEqual(copied, dizhis) # Ensure `search` has no effect on the input `dizhis`.
-
-        result2: DizhiRelationCombos = dizhi_utils.search(dizhis + dizhis, relation)
-        result3: DizhiRelationCombos = dizhi_utils.search(dizhis + dizhis + dizhis, relation)
-
-        # Expectedly, `result2` and `result3` should be equal to `result1`.
-        # The only exception is 自刑。
-        result_patched: DizhiRelationCombos = copy.deepcopy(result)
-        if relation is DizhiRelation.刑:
-          for dz in (Dizhi.午, Dizhi.辰, Dizhi.酉, Dizhi.亥):
-            if dizhi_counter[dz] == 1:
-              fs = DizhiCombo((dz,))
-              self.assertNotIn(fs, result_patched)
-              self.assertIn(fs, result2)
-              self.assertIn(fs, result3)
-              result_patched = result_patched + (fs,) # Patch it up.
-
-        self.assertTrue(self.__dz_equal(result_patched, result2))
-        self.assertTrue(self.__dz_equal(result_patched, result3))
-
-  @staticmethod
-  def __run_all_relation_methods(dizhis: list[Dizhi]) -> list[Any]:
-    '''This test basically iterates all possible permutations of `dizhis` and invokes all relation checking methods.'''
-    dizhi_set: set[Dizhi] = set(dizhis)
-    sorted_dizhis: list[Dizhi] = sorted(dizhi_set, key=lambda dz : dz.index)
-    result: list[Any] = []
-
-    result.append(dizhi_utils.xing(definition=DizhiRules.XingDef.STRICT))
-    result.append(dizhi_utils.xing(definition=DizhiRules.XingDef.LOOSE))
-
-    for dz in sorted_dizhis:
-      result.append(dizhi_utils.xing(dz, definition=DizhiRules.XingDef.STRICT))
-      result.append(dizhi_utils.xing(dz, definition=DizhiRules.XingDef.LOOSE))
-
-    dz_tuple: tuple[Dizhi, ...]
-    for dz_tuple in itertools.permutations(sorted_dizhis, 2):
-      result.append(dizhi_utils.liuhe(*dz_tuple))
-      result.append(dizhi_utils.anhe(*dz_tuple, definition=DizhiRules.AnheDef.NORMAL))
-      result.append(dizhi_utils.anhe(*dz_tuple, definition=DizhiRules.AnheDef.NORMAL_EXTENDED))
-      result.append(dizhi_utils.anhe(*dz_tuple, definition=DizhiRules.AnheDef.MANGPAI))
-      result.append(dizhi_utils.tonghe(*dz_tuple))
-      result.append(dizhi_utils.tongluhe(*dz_tuple))
-      result.append(dizhi_utils.banhe(*dz_tuple))
-      result.append(dizhi_utils.xing(*dz_tuple, definition=DizhiRules.XingDef.STRICT))
-      result.append(dizhi_utils.xing(*dz_tuple, definition=DizhiRules.XingDef.LOOSE))
-      result.append(dizhi_utils.chong(*dz_tuple))
-      result.append(dizhi_utils.po(*dz_tuple))
-      result.append(dizhi_utils.hai(*dz_tuple))
-      result.append(dizhi_utils.sheng(*dz_tuple))
-      result.append(dizhi_utils.ke(*dz_tuple))
-
-    for dz_tuple in itertools.permutations(sorted_dizhis, 3):
-      result.append(dizhi_utils.sanhui(*dz_tuple)) # Mypy complains... # type: ignore
-      result.append(dizhi_utils.sanhe(*dz_tuple)) # Mypy complains... # type: ignore
-      result.append(dizhi_utils.xing(*dz_tuple, definition=DizhiRules.XingDef.STRICT)) # Mypy complains... # type: ignore
-      result.append(dizhi_utils.xing(*dz_tuple, definition=DizhiRules.XingDef.LOOSE)) # Mypy complains... # type: ignore
-    
-    return result
-
-  @pytest.mark.slow
-  def test_discover(self) -> None:
-    for _ in range(512):
-      dizhis: list[Dizhi] = random.sample(Dizhi.as_list(), random.randint(0, len(Dizhi))) + \
-                            random.sample(Dizhi.as_list(), random.randint(0, len(Dizhi)))
-      discovery: DizhiRelationDiscovery = dizhi_utils.discover(dizhis)
-
-      with self.subTest('correctness'):
-        for rel in DizhiRelation:
-          if rel in discovery:
-            self.assertSetEqual(set(discovery[rel]), set(dizhi_utils.search(dizhis, rel)))
-          else:
-            self.assertEqual(len(dizhi_utils.search(dizhis, rel)), 0)
-
-      with self.subTest('consistency'):
-        discovery2: DizhiRelationDiscovery = dizhi_utils.discover(dizhis)
-        self.assertEqual(discovery, discovery2)
-
-  @pytest.mark.slow
-  def test_discover_mutual(self) -> None:
-    def __random_dz_lists() -> tuple[list[Dizhi], list[Dizhi]]:
-      dizhis1: list[Dizhi] = random.sample(Dizhi.as_list(), random.randint(0, len(Dizhi)))
-      dizhis2: list[Dizhi] = random.sample(Dizhi.as_list(), random.randint(0, len(Dizhi)))
-
-      if random.randint(0, 2) == 0:
-        dizhis1.extend(random.sample(Dizhi.as_list(), random.randint(0, len(Dizhi))))
-      if random.randint(0, 2) == 0:
-        dizhis2.extend(random.sample(Dizhi.as_list(), random.randint(0, len(Dizhi))))
-
-      return dizhis1, dizhis2
-
-    for _ in range(16):
-      dizhis1, dizhis2 = __random_dz_lists()
-      discovery: DizhiRelationDiscovery = dizhi_utils.discover_mutual(dizhis1, dizhis2)
-
-      self.assertEqual(discovery, dizhi_utils.discover_mutual(dizhis1, dizhis2)) # Test consistency
-      self.assertEqual(discovery, dizhi_utils.discover_mutual(dizhis2, dizhis1)) # Test symmetry/equivalence
-
-      expected: dict[DizhiRelation, set[DizhiCombo]] = {
-        rel : set() for rel in DizhiRelation
-      }
-      
-      rules: list[tuple[DizhiRelation, Callable[..., Any], int]] = [
-        (DizhiRelation.三会, dizhi_utils.sanhui, 3),
-        (DizhiRelation.三合, dizhi_utils.sanhe, 3),
-        (DizhiRelation.刑, dizhi_utils.xing, 3),
-        (DizhiRelation.六合, dizhi_utils.liuhe, 2),
-        (DizhiRelation.暗合, dizhi_utils.anhe, 2),
-        (DizhiRelation.通合, dizhi_utils.tonghe, 2),
-        (DizhiRelation.通禄合, dizhi_utils.tongluhe, 2),
-        (DizhiRelation.半合, dizhi_utils.banhe, 2),
-        (DizhiRelation.刑, dizhi_utils.xing, 2),
-        (DizhiRelation.冲, dizhi_utils.chong, 2),
-        (DizhiRelation.破, dizhi_utils.po, 2),
-        (DizhiRelation.害, dizhi_utils.hai, 2),
-        (DizhiRelation.生, dizhi_utils.sheng, 2),
-        (DizhiRelation.克, dizhi_utils.ke, 2),
-      ]
-      
-      # Fill `expected`...
-      dizhis1_set, dizhis2_set = set(dizhis1), set(dizhis2)
-      for rel, f, n in rules:
-        for dz_tuple in itertools.permutations(dizhis1 + dizhis2, n):
-          combo = DizhiCombo(dz_tuple)
-          if not f(*dz_tuple):
-            continue
-          if any(combo.isdisjoint(s) for s in (dizhis1_set, dizhis2_set)):
-            continue
-
-          self.assertIn(combo, discovery[rel])
-          expected[rel].add(combo)
-
-      for rel, expected_combos in expected.items():
-        if rel in discovery:
-          for combo in discovery[rel]:
-            self.assertIn(combo, expected_combos)
+        assert wx1.destructs(wx2) or wx2.destructs(wx1)
+        if {dz1, dz2} == {Dizhi.子, Dizhi.丑}:
+          assert liuhe_result == Wuxing.土
+        elif {dz1, dz2} == {Dizhi.卯, Dizhi.戌}:
+          assert liuhe_result == Wuxing.火
         else:
-          self.assertEqual(len(expected_combos), 0)
+          assert {dz1, dz2} == {Dizhi.申, Dizhi.巳}
+          assert liuhe_result == Wuxing.水
+    else:
+      assert liuhe_result is None
 
-  def test_edge_cases(self) -> None:
-    '''Test `discover_mutual` on 三合、三会、三刑、自刑'''
-    for combo_fs in DizhiRules.DIZHI_SANHE:
-      part1 = [random.choice(list(combo_fs))]
-      part2 = list(combo_fs - set(part1))
+def test_search_anhe() -> None:
+  anhe_combos: list[DizhiCombo] = [ # 天干五合对应的地支暗合，5组。
+    DizhiCombo((bazi_utils.lu(tg1), bazi_utils.lu(tg2)))
+    for tg1, tg2 in itertools.combinations(Tiangan, 2) if tiangan_utils.he(tg1, tg2) is not None
+  ] + [ # `NORMAL_EXTENDED` 中额外的1组。
+    DizhiCombo((Dizhi.寅, Dizhi.丑)),
+  ]
 
-      self.assertNotIn(DizhiRelation.三合, dizhi_utils.discover_mutual([], [*combo_fs]))
+  assert _dz_equal(
+    dizhi_utils.search([], DizhiRelation.暗合),
+    [],
+  )
+  assert _dz_equal(
+    dizhi_utils.search(list(Dizhi), DizhiRelation.暗合),
+    anhe_combos,
+  )
 
-      self.assertTupleEqual((combo_fs,), 
-                            dizhi_utils.discover_mutual(part1, part2)[DizhiRelation.三合])
-      self.assertEqual(dizhi_utils.discover_mutual(part1, part2), 
-                       dizhi_utils.discover_mutual(part2, part1))
+  for _ in range(500):
+    dizhis: list[Dizhi] = random.sample(Dizhi.as_list(), random.randint(0, len(Dizhi)))
+    result: DizhiRelationCombos = dizhi_utils.search(dizhis, DizhiRelation.暗合)
+    expected_result: list[set[Dizhi]] = [set(c) for c in anhe_combos if c.issubset(dizhis)]
+    assert _dz_equal(result, expected_result)
 
-    for combo_fs in DizhiRules.DIZHI_SANHUI:
-      part1 = [random.choice(list(combo_fs))]
-      part2 = list(combo_fs - set(part1))
+def test_anhe() -> None:
+  with pytest.raises(TypeError):
+    dizhi_utils.anhe(Dizhi.子) # type: ignore
+  with pytest.raises(TypeError):
+    dizhi_utils.anhe(Dizhi.子, Dizhi.辰, Dizhi.子, Dizhi.辰) # type: ignore
+  with pytest.raises(TypeError):
+    dizhi_utils.anhe((Dizhi.子, Dizhi.丑)) # type: ignore
+  with pytest.raises(TypeError):
+    dizhi_utils.anhe({Dizhi.子, Dizhi.丑}) # type: ignore
+  with pytest.raises(TypeError):
+    dizhi_utils.anhe([Dizhi.子, Dizhi.丑]) # type: ignore
+  with pytest.raises(AssertionError):
+    dizhi_utils.anhe('亥', '子') # type: ignore
+  with pytest.raises(TypeError):
+    dizhi_utils.anhe(Dizhi.子, Dizhi.辰, DizhiRules.AnheDef.NORMAL + 100) # type: ignore
+  with pytest.raises(AssertionError):
+    dizhi_utils.anhe(Dizhi.子, Dizhi.辰, definition='DizhiRules.AnheDef.NORMAL') # type: ignore
 
-      self.assertNotIn(DizhiRelation.三会, dizhi_utils.discover_mutual([], [*combo_fs]))
+  normal_combos: list[DizhiCombo] = [
+    DizhiCombo((bazi_utils.lu(tg1), bazi_utils.lu(tg2)))
+    for tg1, tg2 in itertools.combinations(Tiangan, 2) if tiangan_utils.he(tg1, tg2) is not None
+  ]
 
-      self.assertTupleEqual((combo_fs,), 
-                            dizhi_utils.discover_mutual(part1, part2)[DizhiRelation.三会])
-      self.assertEqual(dizhi_utils.discover_mutual(part1, part2), 
-                       dizhi_utils.discover_mutual(part2, part1))
-    
-    for combo_tuple in DizhiRules.DIZHI_XING[DizhiRules.XingDef.LOOSE]:
-      part1 = [random.choice(combo_tuple)]
-      part2 = list(combo_tuple)
-      part2.remove(part1[0])
+  normal_extended_combos: list[DizhiCombo] = normal_combos + [
+    DizhiCombo((Dizhi.寅, Dizhi.丑)),
+  ]
 
-      self.assertNotIn(DizhiRelation.刑, dizhi_utils.discover_mutual([], [*combo_tuple]))
+  mangpai_combos: list[DizhiCombo] = [
+    DizhiCombo((Dizhi.寅, Dizhi.丑)),
+    DizhiCombo((Dizhi.午, Dizhi.亥)),
+    DizhiCombo((Dizhi.卯, Dizhi.申)),
+  ]
 
-      self.assertIn(frozenset(combo_tuple), 
-                    dizhi_utils.discover_mutual(part1, part2)[DizhiRelation.刑])
-      self.assertEqual(dizhi_utils.discover_mutual(part1, part2), 
-                       dizhi_utils.discover_mutual(part2, part1))
-      
-    self.assertTupleEqual((frozenset({Dizhi.午}),),
-                          dizhi_utils.discover_mutual([Dizhi.午], [Dizhi.午])[DizhiRelation.刑])
+  expected: dict[DizhiRules.AnheDef, list[DizhiCombo]] = {
+    DizhiRules.AnheDef.NORMAL: normal_combos,
+    DizhiRules.AnheDef.NORMAL_EXTENDED: normal_extended_combos,
+    DizhiRules.AnheDef.MANGPAI: mangpai_combos
+  }
 
-  @pytest.mark.slow
-  def test_consistency(self) -> None:
-    '''This test mainly tests that staticmethods in `dizhi_utils` give consistent results.'''
+  for dz1, dz2 in itertools.product(Dizhi, Dizhi):
+    for anhe_def in DizhiRules.AnheDef:
+      assert dizhi_utils.anhe(dz1, dz2, definition=anhe_def) == (DizhiCombo((dz1, dz2)) in expected[anhe_def])
+      assert dizhi_utils.anhe(dz1, dz2, definition=anhe_def) == dizhi_utils.anhe(dz2, dz1, definition=anhe_def)
 
-    def __split(dizhis: list[Dizhi]) -> tuple[list[Dizhi], list[Dizhi]]:
-      dz_idx_list: list[int] = [idx for idx, _ in enumerate(dizhis)]
-      part1_idx_list: list[int] = random.sample(dz_idx_list, random.randint(0, len(dz_idx_list)))
-      part2_idx_list: list[int] = [idx for idx in dz_idx_list if idx not in part1_idx_list]
-      assert len(part1_idx_list) + len(part2_idx_list) == len(dizhis)
-      assert len(set(part1_idx_list + part2_idx_list)) == len(dizhis)
+  # Ensure the default definition is `NORMAL`.
+  for dz1, dz2 in itertools.product(Dizhi, Dizhi):
+    assert dizhi_utils.anhe(dz1, dz2) == (DizhiCombo((dz1, dz2)) in normal_extended_combos)
+    assert dizhi_utils.anhe(dz1, dz2) == dizhi_utils.anhe(dz2, dz1)
 
-      part1_dizhis: list[Dizhi] = [dizhis[idx] for idx in part1_idx_list]
-      part2_dizhis: list[Dizhi] = [dizhis[idx] for idx in part2_idx_list]
-      assert len(part1_dizhis) + len(part2_dizhis) == len(dizhis)
+def test_search_tonghe() -> None:
+  tonghe_combos: set[DizhiCombo] = set()
+  for dz1, dz2 in itertools.product(Dizhi, Dizhi):
+    hidden1, hidden2 = bazi_utils.hidden_tiangans(dz1), bazi_utils.hidden_tiangans(dz2)
+    if len(hidden1) != len(hidden2):
+      continue
+    expected_hidden2: list[Tiangan] = [Tiangan.from_index((tg.index + 5) % 10) for tg in hidden1]
+    if all(tg in hidden2 for tg in expected_hidden2):
+      tonghe_combos.add(DizhiCombo((dz1, dz2)))
 
-      return part1_dizhis, part2_dizhis
+  assert _dz_equal(
+    dizhi_utils.search([], DizhiRelation.通合),
+    [],
+  )
+  assert _dz_equal(
+    dizhi_utils.search(list(Dizhi), DizhiRelation.通合),
+    tonghe_combos,
+  )
 
-    for attempt in range(8):
-      dizhis: list[Dizhi] = []
-      for _ in range(random.randint(0, 4)):
-        dizhis.extend(random.sample(list(Dizhi), random.randint(0, 5)))
-      copied_dizhis: list[Dizhi] = copy.deepcopy(dizhis)
+  for _ in range(500):
+    dizhis: list[Dizhi] = random.sample(Dizhi.as_list(), random.randint(0, len(Dizhi)))
+    result: DizhiRelationCombos = dizhi_utils.search(dizhis, DizhiRelation.通合)
+    expected_result: list[set[Dizhi]] = [set(c) for c in tonghe_combos if c.issubset(dizhis)]
+    assert _dz_equal(result, expected_result)
 
-      for relation in DizhiRelation:
-        relation_results: list[list[Any]] = []
-        combo_results: list[DizhiRelationCombos] = []
-        discover_results: list[DizhiRelationDiscovery] = []
-        discover_mutual_results: list[DizhiRelationDiscovery] = []
+def test_tonghe() -> None:
+  with pytest.raises(TypeError):
+    dizhi_utils.tonghe(Dizhi.子) # type: ignore
+  with pytest.raises(TypeError):
+    dizhi_utils.tonghe(Dizhi.子, Dizhi.辰, Dizhi.子, Dizhi.辰) # type: ignore
+  with pytest.raises(TypeError):
+    dizhi_utils.tonghe((Dizhi.子, Dizhi.丑)) # type: ignore
+  with pytest.raises(TypeError):
+    dizhi_utils.tonghe({Dizhi.子, Dizhi.丑}) # type: ignore
+  with pytest.raises(TypeError):
+    dizhi_utils.tonghe([Dizhi.子, Dizhi.丑]) # type: ignore
+  with pytest.raises(AssertionError):
+    dizhi_utils.tonghe('亥', '子') # type: ignore
 
-        dizhis_p1, dizhis_p2 = __split(dizhis)
-       
-        for _ in range(5):
-          if random.randint(0, 1) == 0:
-            relation_results.append(self.__run_all_relation_methods(dizhis))
-          if random.randint(0, 1) == 0:
-            combo_results.append(dizhi_utils.search(dizhis, relation))
-          if random.randint(0, 1) == 0:
-            discover_results.append(dizhi_utils.discover(dizhis))
-          if random.randint(0, 1) == 0:
-            discover_mutual_results.append(dizhi_utils.discover_mutual(dizhis_p1, dizhis_p2))
-            discover_mutual_results.append(dizhi_utils.discover_mutual(dizhis_p2, dizhis_p1))
+  tonghe_combos: set[DizhiCombo] = set()
+  for dz1, dz2 in itertools.product(Dizhi, Dizhi):
+    hidden1, hidden2 = bazi_utils.hidden_tiangans(dz1), bazi_utils.hidden_tiangans(dz2)
+    if len(hidden1) != len(hidden2):
+      continue
+    expected_hidden2: list[Tiangan] = [Tiangan.from_index((tg.index + 5) % 10) for tg in hidden1]
+    if all(tg in hidden2 for tg in expected_hidden2):
+      tonghe_combos.add(DizhiCombo((dz1, dz2)))
 
-        for rr1, rr2 in itertools.pairwise(relation_results):
-          self.assertEqual(rr1, rr2)
-        for cr1, cr2 in itertools.pairwise(combo_results):
-          self.assertEqual(cr1, cr2)
-        for dr1, dr2 in itertools.pairwise(discover_results):
-          self.assertEqual(dr1, dr2)
-        for dmr1, dmr2 in itertools.pairwise(discover_mutual_results):
-          self.assertEqual(dmr1, dmr2)
+  for dz1, dz2 in itertools.product(Dizhi, Dizhi):
+    assert dizhi_utils.tonghe(dz1, dz2) == (DizhiCombo((dz1, dz2)) in tonghe_combos)
+    assert dizhi_utils.tonghe(dz1, dz2) == dizhi_utils.tonghe(dz2, dz1)
 
-      self.assertEqual(dizhis, copied_dizhis) # Ensure the order of `dizhis` was not changed.
+def test_search_tongluhe() -> None:
+  tongluhe_combos: list[DizhiCombo] = [ # 天干五合对应的地支禄身。
+    DizhiCombo((bazi_utils.lu(tg1), bazi_utils.lu(tg2)))
+    for tg1, tg2 in itertools.combinations(Tiangan, 2) if tiangan_utils.he(tg1, tg2) is not None
+  ]
 
-  def test_discovery_filter(self) -> None:
-    for _ in range(5):
+  assert _dz_equal(
+    dizhi_utils.search([], DizhiRelation.通禄合),
+    [],
+  )
+  assert _dz_equal(
+    dizhi_utils.search(list(Dizhi), DizhiRelation.通禄合),
+    tongluhe_combos,
+  )
+
+  for _ in range(500):
+    dizhis: list[Dizhi] = random.sample(Dizhi.as_list(), random.randint(0, len(Dizhi)))
+    result: DizhiRelationCombos = dizhi_utils.search(dizhis, DizhiRelation.通禄合)
+    expected_result: list[set[Dizhi]] = [set(c) for c in tongluhe_combos if c.issubset(dizhis)]
+    assert _dz_equal(result, expected_result)
+
+def test_tongluhe() -> None:
+  with pytest.raises(TypeError):
+    dizhi_utils.tongluhe(Dizhi.子) # type: ignore
+  with pytest.raises(TypeError):
+    dizhi_utils.tongluhe(Dizhi.子, Dizhi.辰, Dizhi.子, Dizhi.辰) # type: ignore
+  with pytest.raises(TypeError):
+    dizhi_utils.tongluhe((Dizhi.子, Dizhi.丑)) # type: ignore
+  with pytest.raises(TypeError):
+    dizhi_utils.tongluhe({Dizhi.子, Dizhi.丑}) # type: ignore
+  with pytest.raises(TypeError):
+    dizhi_utils.tongluhe([Dizhi.子, Dizhi.丑]) # type: ignore
+  with pytest.raises(AssertionError):
+    dizhi_utils.tongluhe('亥', '子') # type: ignore
+
+  tongluhe_combos: list[DizhiCombo] = [ # 天干五合对应的地支禄身。
+    DizhiCombo((bazi_utils.lu(tg1), bazi_utils.lu(tg2)))
+    for tg1, tg2 in itertools.combinations(Tiangan, 2) if tiangan_utils.he(tg1, tg2) is not None
+  ]
+
+  for dz1, dz2 in itertools.product(Dizhi, Dizhi):
+    assert dizhi_utils.tongluhe(dz1, dz2) == (DizhiCombo((dz1, dz2)) in tongluhe_combos)
+    assert dizhi_utils.tongluhe(dz1, dz2) == dizhi_utils.tongluhe(dz2, dz1)
+
+def _gen_sanhe_table() -> dict[DizhiCombo, Wuxing]:
+  return {
+    DizhiCombo((
+      dz,
+      Dizhi.from_index((dz.index + 4) % 12),
+      Dizhi.from_index((dz.index - 4) % 12),
+    )) : bazi_utils.traits(dz).wuxing
+    for dz in [Dizhi('子'), Dizhi('午'), Dizhi('卯'), Dizhi('酉')]
+  }
+
+def test_search_sanhe() -> None:
+  sanhe_table: dict[DizhiCombo, Wuxing] = _gen_sanhe_table()
+
+  assert _dz_equal(
+    dizhi_utils.search([], DizhiRelation.三合),
+    [],
+  )
+  assert _dz_equal(
+    dizhi_utils.search(list(Dizhi), DizhiRelation.三合),
+    sanhe_table.keys(),
+  )
+
+  for _ in range(500):
+    dizhis: list[Dizhi] = random.sample(Dizhi.as_list(), random.randint(0, len(Dizhi)))
+    result: DizhiRelationCombos = dizhi_utils.search(dizhis, DizhiRelation.三合)
+    expected_result: list[set[Dizhi]] = [set(c) for c in sanhe_table if c.issubset(dizhis)]
+    assert _dz_equal(result, expected_result)
+
+def test_sanhe() -> None:
+  with pytest.raises(TypeError):
+    dizhi_utils.sanhe(Dizhi.子) # type: ignore
+  with pytest.raises(TypeError):
+    dizhi_utils.sanhe(Dizhi.子, Dizhi.辰) # type: ignore
+  with pytest.raises(TypeError):
+    dizhi_utils.sanhe(Dizhi.子, Dizhi.辰, Dizhi.子, Dizhi.辰) # type: ignore
+  with pytest.raises(TypeError):
+    dizhi_utils.sanhe((Dizhi.亥, Dizhi.子, Dizhi.丑)) # type: ignore
+  with pytest.raises(TypeError):
+    dizhi_utils.sanhe({Dizhi.亥, Dizhi.子, Dizhi.丑}) # type: ignore
+  with pytest.raises(TypeError):
+    dizhi_utils.sanhe([Dizhi.亥, Dizhi.子, Dizhi.丑]) # type: ignore
+  with pytest.raises(AssertionError):
+    dizhi_utils.sanhe('亥', '子', '丑') # type: ignore
+
+  sanhe_table: dict[DizhiCombo, Wuxing] = _gen_sanhe_table()
+
+  for dizhis in itertools.product(Dizhi, repeat=3):
+    fs: DizhiCombo = DizhiCombo(dizhis)
+    if fs in sanhe_table:
+      for combo in itertools.permutations(dizhis):
+        assert dizhi_utils.sanhe(*combo) == sanhe_table[fs]
+    else:
+      for combo in itertools.permutations(dizhis):
+        assert dizhi_utils.sanhe(*dizhis) is None
+
+def _gen_banhe_table() -> dict[DizhiCombo, Wuxing]:
+  pivots: set[Dizhi] = {Dizhi('子'), Dizhi('午'), Dizhi('卯'), Dizhi('酉')} # 四中神
+  sanhe_table: dict[DizhiCombo, Wuxing] = _gen_sanhe_table()
+
+  d: dict[DizhiCombo, Wuxing] = {}
+  for sanhe_dizhis, wx in sanhe_table.items():
+    for dz1, dz2 in itertools.combinations(sanhe_dizhis, 2):
+      if any(dz in pivots for dz in (dz1, dz2)): # 半合局需要出现中神
+        d[DizhiCombo((dz1, dz2))] = wx
+  return d
+
+def test_search_banhe() -> None:
+  banhe_table: dict[DizhiCombo, Wuxing] = _gen_banhe_table()
+
+  assert _dz_equal(
+    dizhi_utils.search([], DizhiRelation.半合),
+    [],
+  )
+  assert _dz_equal(
+    dizhi_utils.search(list(Dizhi), DizhiRelation.半合),
+    banhe_table.keys()
+  )
+
+  for _ in range(500):
+    dizhis: list[Dizhi] = random.sample(Dizhi.as_list(), random.randint(0, len(Dizhi)))
+    result: DizhiRelationCombos = dizhi_utils.search(dizhis, DizhiRelation.半合)
+    expected_result: list[set[Dizhi]] = [set(c) for c in banhe_table if c.issubset(dizhis)]
+    assert _dz_equal(result, expected_result)
+
+def test_banhe() -> None:
+  with pytest.raises(TypeError):
+    dizhi_utils.banhe(Dizhi.子) # type: ignore
+  with pytest.raises(TypeError):
+    dizhi_utils.banhe(Dizhi.子, Dizhi.辰, Dizhi.申) # type: ignore
+  with pytest.raises(TypeError):
+    dizhi_utils.banhe((Dizhi.子, Dizhi.丑)) # type: ignore
+  with pytest.raises(TypeError):
+    dizhi_utils.banhe({Dizhi.子, Dizhi.丑}) # type: ignore
+  with pytest.raises(TypeError):
+    dizhi_utils.banhe([Dizhi.子, Dizhi.丑]) # type: ignore
+  with pytest.raises(AssertionError):
+    dizhi_utils.banhe('亥', '子') # type: ignore
+
+  banhe_table: dict[DizhiCombo, Wuxing] = _gen_banhe_table()
+
+  for dz1, dz2 in itertools.product(Dizhi, Dizhi):
+    assert dizhi_utils.banhe(dz1, dz2) == banhe_table.get(DizhiCombo((dz1, dz2)), None)
+    assert dizhi_utils.banhe(dz1, dz2) == dizhi_utils.banhe(dz2, dz1)
+
+def test_search_xing() -> None:
+  xing_expected: list[dict[Dizhi, int]] = [ # 辰午酉亥自刑
+    {
+      dz : 2,
+    } for dz in [Dizhi.辰, Dizhi.午, Dizhi.酉, Dizhi.亥]
+  ] + [ # 其他相刑
+    { Dizhi.子 : 1, Dizhi.卯 : 1, },
+    { Dizhi.寅 : 1, Dizhi.巳 : 1, Dizhi.申 : 1, },
+    { Dizhi.丑 : 1, Dizhi.未 : 1, Dizhi.戌 : 1, },
+  ] + [ # LOOSE def.
+    { Dizhi.寅 : 1, Dizhi.巳 : 1, },
+    { Dizhi.巳 : 1, Dizhi.申 : 1, },
+    { Dizhi.寅 : 1, Dizhi.申 : 1, },
+    { Dizhi.丑 : 1, Dizhi.未 : 1, },
+    { Dizhi.未 : 1, Dizhi.戌 : 1, },
+    { Dizhi.丑 : 1, Dizhi.戌 : 1, },
+  ]
+
+  def __find_qualified(dizhis: list[Dizhi]) -> list[set[Dizhi]]:
+    ret: list[set[Dizhi]] = []
+    for required in xing_expected:
+      if all(
+        sum(dz == d for d in dizhis) >= required[dz]
+        for dz in required
+      ):
+        ret.append(set(required.keys()))
+    return ret
+
+  assert _dz_equal(
+    dizhi_utils.search([], DizhiRelation.刑),
+    [],
+  )
+  assert _dz_equal(
+    dizhi_utils.search([Dizhi.子, Dizhi.卯], DizhiRelation.刑),
+    [{Dizhi.子, Dizhi.卯}],
+  )
+  assert _dz_equal(
+    dizhi_utils.search([Dizhi.卯, Dizhi.子], DizhiRelation.刑),
+    [{Dizhi.子, Dizhi.卯}],
+  )
+  assert _dz_equal(
+    dizhi_utils.search(list(Dizhi), DizhiRelation.刑),
+    [{Dizhi.子, Dizhi.卯},
+     {Dizhi.寅, Dizhi.巳, Dizhi.申}, {Dizhi.寅, Dizhi.巳}, {Dizhi.巳, Dizhi.申}, {Dizhi.寅, Dizhi.申},
+     {Dizhi.丑, Dizhi.未, Dizhi.戌}, {Dizhi.丑, Dizhi.未}, {Dizhi.未, Dizhi.戌}, {Dizhi.丑, Dizhi.戌}],
+  )
+  assert _dz_equal(
+    dizhi_utils.search(list(Dizhi) + [Dizhi.辰, Dizhi.午, Dizhi.酉, Dizhi.亥], DizhiRelation.刑),
+    [set(d.keys()) for d in xing_expected]
+  )
+
+  for _ in range(500):
+    dizhis: list[Dizhi] = []
+    for _ in range(random.randint(1, 4)):
+      dizhis += random.sample(list(Dizhi), random.randint(0, len(Dizhi)))
+    result: DizhiRelationCombos = dizhi_utils.search(dizhis, DizhiRelation.刑)
+    expected_result: list[set[Dizhi]] = __find_qualified(dizhis)
+    assert _dz_equal(result, expected_result)
+
+def test_xing_negative() -> None:
+  with pytest.raises(AssertionError):
+    dizhi_utils.xing(Dizhi.子, Dizhi.辰, Dizhi.子, Dizhi.辰)
+  with pytest.raises(AssertionError):
+    dizhi_utils.xing((Dizhi.子, Dizhi.丑)) # type: ignore
+  with pytest.raises(AssertionError):
+    dizhi_utils.xing({Dizhi.子, Dizhi.丑}) # type: ignore
+  with pytest.raises(AssertionError):
+    dizhi_utils.xing([Dizhi.子, Dizhi.丑]) # type: ignore
+  with pytest.raises(AssertionError):
+    dizhi_utils.xing('亥', '子') # type: ignore
+  with pytest.raises(AssertionError):
+    dizhi_utils.xing(Dizhi.子, Dizhi.辰, DizhiRules.XingDef.LOOSE) # type: ignore
+  with pytest.raises(AssertionError):
+    dizhi_utils.xing(Dizhi.子, Dizhi.辰, definition='DizhiRules.X.NORMAL') # type: ignore
+
+  for dz in Dizhi:
+    assert dizhi_utils.xing(dz) is None
+    assert dizhi_utils.xing(dz, definition=DizhiRules.XingDef.STRICT) is None
+    assert dizhi_utils.xing(dz, definition=DizhiRules.XingDef.LOOSE) is None
+
+  for _ in range(500):
+    random_dizhis: list[Dizhi] = random.sample(list(Dizhi), random.randint(4, len(Dizhi)))
+    with pytest.raises(AssertionError):
+      assert dizhi_utils.xing(*random_dizhis) is None
+    with pytest.raises(AssertionError):
+      assert dizhi_utils.xing(*random_dizhis, definition=DizhiRules.XingDef.STRICT) is None
+    with pytest.raises(AssertionError):
+      assert dizhi_utils.xing(*random_dizhis, definition=DizhiRules.XingDef.LOOSE) is None
+
+@pytest.mark.slow
+def test_xing_strict() -> None:
+  assert dizhi_utils.xing() is None
+  assert dizhi_utils.xing(definition=DizhiRules.XingDef.STRICT) is None
+  assert dizhi_utils.xing(Dizhi.亥, definition=DizhiRules.XingDef.STRICT) is None
+  assert dizhi_utils.xing(Dizhi.亥, Dizhi.亥, definition=DizhiRules.XingDef.STRICT) == DizhiRules.XingSubType.自刑
+  assert dizhi_utils.xing(Dizhi.亥, Dizhi.亥, Dizhi.亥, definition=DizhiRules.XingDef.STRICT) is None
+  assert dizhi_utils.xing(Dizhi.子, Dizhi.卯, definition=DizhiRules.XingDef.STRICT) == DizhiRules.XingSubType.子卯刑
+  assert dizhi_utils.xing(Dizhi.卯, Dizhi.子, definition=DizhiRules.XingDef.STRICT) == DizhiRules.XingSubType.子卯刑
+  assert dizhi_utils.xing(Dizhi.子, Dizhi.卯, Dizhi.亥, definition=DizhiRules.XingDef.STRICT) is None
+  assert dizhi_utils.xing(Dizhi.寅, Dizhi.巳, Dizhi.申, definition=DizhiRules.XingDef.STRICT) == DizhiRules.XingSubType.三刑
+  assert dizhi_utils.xing(Dizhi.巳, Dizhi.寅, Dizhi.申, definition=DizhiRules.XingDef.STRICT) == DizhiRules.XingSubType.三刑
+  assert dizhi_utils.xing(Dizhi.寅, Dizhi.巳, definition=DizhiRules.XingDef.STRICT) is None
+  assert dizhi_utils.xing(Dizhi.巳, Dizhi.寅, definition=DizhiRules.XingDef.STRICT) is None
+
+  def __expected_strict_xing(dizhis: tuple[Dizhi, ...]) -> DizhiRules.XingSubType | None:
+    # In `XingDef.STRICT` mode, we don't care about the direction.
+    __fs: DizhiCombo = DizhiCombo(dizhis)
+    if __fs in [DizhiCombo((Dizhi.丑, Dizhi.戌, Dizhi.未)), DizhiCombo((Dizhi.寅, Dizhi.巳, Dizhi.申))]:
+      return DizhiRules.XingSubType.三刑
+    elif __fs == DizhiCombo((Dizhi.子, Dizhi.卯)):
+      return DizhiRules.XingSubType.子卯刑
+    elif len(__fs) == 1 and len(dizhis) == 2 and dizhis[0] in (Dizhi.辰, Dizhi.午, Dizhi.酉, Dizhi.亥):
+      return DizhiRules.XingSubType.自刑
+    return None
+
+  for dz in Dizhi:
+    assert dizhi_utils.xing(dz, definition=DizhiRules.XingDef.STRICT) is None
+
+  for dz1, dz2 in itertools.product(Dizhi, Dizhi):
+    strict_result: DizhiRules.XingSubType | None = dizhi_utils.xing(dz1, dz2, definition=DizhiRules.XingDef.STRICT)
+    strict_result2: DizhiRules.XingSubType | None = dizhi_utils.xing(dz2, dz1, definition=DizhiRules.XingDef.STRICT)
+    strict_result3: DizhiRules.XingSubType | None = dizhi_utils.xing(dz1, dz2, definition=DizhiRules.XingDef.STRICT)
+    assert strict_result == strict_result2
+    assert strict_result == strict_result3
+    assert strict_result == __expected_strict_xing((dz1, dz2))
+
+  for dz_tuple in itertools.product(Dizhi, Dizhi, Dizhi):
+    strict_result4: DizhiRules.XingSubType | None = dizhi_utils.xing(*dz_tuple, definition=DizhiRules.XingDef.STRICT)
+    for dz1, dz2, dz3 in itertools.permutations(dz_tuple, 3):
+      assert strict_result4 == dizhi_utils.xing(dz1, dz2, dz3, definition=DizhiRules.XingDef.STRICT)
+      assert strict_result4 == dizhi_utils.xing(dz1, dz2, dz3, definition=DizhiRules.XingDef.STRICT)
+
+def test_xing_loose() -> None:
+  assert dizhi_utils.xing(definition=DizhiRules.XingDef.LOOSE) is None
+  assert dizhi_utils.xing(Dizhi.亥, definition=DizhiRules.XingDef.LOOSE) is None
+  assert dizhi_utils.xing(Dizhi.亥, Dizhi.亥, definition=DizhiRules.XingDef.LOOSE) == DizhiRules.XingSubType.自刑
+  assert dizhi_utils.xing(Dizhi.亥, Dizhi.亥, Dizhi.亥, definition=DizhiRules.XingDef.LOOSE) is None
+  assert dizhi_utils.xing(Dizhi.子, Dizhi.卯, definition=DizhiRules.XingDef.LOOSE) == DizhiRules.XingSubType.子卯刑
+  assert dizhi_utils.xing(Dizhi.卯, Dizhi.子, definition=DizhiRules.XingDef.LOOSE) == DizhiRules.XingSubType.子卯刑
+  assert dizhi_utils.xing(Dizhi.子, Dizhi.卯, Dizhi.亥, definition=DizhiRules.XingDef.LOOSE) is None
+  assert dizhi_utils.xing(Dizhi.寅, Dizhi.巳, Dizhi.申, definition=DizhiRules.XingDef.LOOSE) == DizhiRules.XingSubType.三刑
+  assert dizhi_utils.xing(Dizhi.巳, Dizhi.寅, Dizhi.申, definition=DizhiRules.XingDef.LOOSE) == DizhiRules.XingSubType.三刑
+  assert dizhi_utils.xing(Dizhi.寅, Dizhi.巳, definition=DizhiRules.XingDef.LOOSE) == DizhiRules.XingSubType.三刑
+  assert dizhi_utils.xing(Dizhi.巳, Dizhi.寅, definition=DizhiRules.XingDef.LOOSE) is None
+
+  sanxing_list: list[tuple[Dizhi, ...]] = [
+    (Dizhi.丑, Dizhi.戌),
+    (Dizhi.戌, Dizhi.未),
+    (Dizhi.未, Dizhi.丑),
+    (Dizhi.寅, Dizhi.巳),
+    (Dizhi.巳, Dizhi.申),
+    (Dizhi.申, Dizhi.寅),
+    *(list(itertools.permutations((Dizhi.丑, Dizhi.戌, Dizhi.未)))),
+    *(list(itertools.permutations((Dizhi.寅, Dizhi.巳, Dizhi.申)))),
+  ]
+
+  zimaoxing_list: list[tuple[Dizhi, ...]] = [
+    (Dizhi.子, Dizhi.卯),
+    (Dizhi.卯, Dizhi.子),
+  ]
+
+  zixing_list: list[tuple[Dizhi, ...]] = [
+    (dz, dz) for dz in (Dizhi.辰, Dizhi.午, Dizhi.酉, Dizhi.亥)
+  ]
+
+  for dz in Dizhi:
+    assert dizhi_utils.xing(dz, definition=DizhiRules.XingDef.LOOSE) is None
+
+  dz_tuple: tuple[Dizhi, ...]
+  for dz_tuple in itertools.product(Dizhi, Dizhi):
+    loose_result: DizhiRules.XingSubType | None = dizhi_utils.xing(*dz_tuple, definition=DizhiRules.XingDef.LOOSE)
+    if loose_result is DizhiRules.XingSubType.三刑:
+      assert dz_tuple in sanxing_list
+    elif loose_result is DizhiRules.XingSubType.子卯刑:
+      assert dz_tuple in zimaoxing_list
+    elif loose_result is DizhiRules.XingSubType.自刑:
+      assert dz_tuple in zixing_list
+    else:
+      assert loose_result is None
+      assert dz_tuple not in sanxing_list
+      assert dz_tuple not in zimaoxing_list
+      assert dz_tuple not in zixing_list
+
+  for dz_tuple in itertools.product(Dizhi, Dizhi, Dizhi):
+    loose_result2: DizhiRules.XingSubType | None = dizhi_utils.xing(*dz_tuple, definition=DizhiRules.XingDef.LOOSE)
+    if loose_result2 is None:
+      assert dz_tuple not in sanxing_list
+      assert dz_tuple not in zimaoxing_list
+      assert dz_tuple not in zixing_list
+    else:
+      assert loose_result2 == DizhiRules.XingSubType.三刑
+      assert dz_tuple in sanxing_list
+
+def test_search_chong() -> None:
+  chong_table: list[set[Dizhi]] = [set(dz_tuple) for dz_tuple in zip(Dizhi.as_list()[:6], Dizhi.as_list()[6:])]
+
+  assert _dz_equal(
+    dizhi_utils.search([], DizhiRelation.冲),
+    [],
+  )
+  assert _dz_equal(
+    dizhi_utils.search(list(Dizhi), DizhiRelation.冲),
+    chong_table,
+  )
+
+  for _ in range(500):
+    dizhis: list[Dizhi] = random.sample(list(Dizhi), random.randint(0, len(Dizhi)))
+    result: DizhiRelationCombos = dizhi_utils.search(dizhis, DizhiRelation.冲)
+    expected_result: list[set[Dizhi]] = [c for c in chong_table if c.issubset(dizhis)]
+    assert _dz_equal(result, expected_result)
+
+def test_chong() -> None:
+  with pytest.raises(TypeError):
+    dizhi_utils.chong(Dizhi.子) # type: ignore
+  with pytest.raises(TypeError):
+    dizhi_utils.chong(Dizhi.子, Dizhi.辰, Dizhi.辰) # type: ignore
+  with pytest.raises(TypeError):
+    dizhi_utils.chong(Dizhi.子, Dizhi.辰, Dizhi.子, Dizhi.辰) # type: ignore
+  with pytest.raises(TypeError):
+    dizhi_utils.chong((Dizhi.亥, Dizhi.子, Dizhi.丑)) # type: ignore
+  with pytest.raises(TypeError):
+    dizhi_utils.chong({Dizhi.亥, Dizhi.子, Dizhi.丑}) # type: ignore
+  with pytest.raises(TypeError):
+    dizhi_utils.chong([Dizhi.亥, Dizhi.子, Dizhi.丑]) # type: ignore
+  with pytest.raises(AssertionError):
+    dizhi_utils.chong('亥', '子') # type: ignore
+  with pytest.raises(AssertionError):
+    dizhi_utils.chong(Tiangan.甲, '子') # type: ignore
+
+  chong_table: list[set[Dizhi]] = [set(dz_tuple) for dz_tuple in zip(Dizhi.as_list()[:6], Dizhi.as_list()[6:])]
+
+  for dz1, dz2 in itertools.product(Dizhi, repeat=2):
+    assert dizhi_utils.chong(dz1, dz2) == dizhi_utils.chong(dz2, dz1), 'CHONG (冲) is a bi-directional relation'
+    assert dizhi_utils.chong(dz1, dz2) == ({dz1, dz2} in chong_table)
+
+def _gen_po_table() -> list[set[Dizhi]]:
+  return [{
+    Dizhi.from_index(dz_idx), Dizhi.from_index((dz_idx - 3) % 12),
+  } for dz_idx in range(0, 12, 2)]
+
+def test_search_po() -> None:
+  po_table: list[set[Dizhi]] = _gen_po_table()
+
+  assert _dz_equal(
+    dizhi_utils.search([], DizhiRelation.破),
+    [],
+  )
+  assert _dz_equal(
+    dizhi_utils.search(list(Dizhi), DizhiRelation.破),
+    po_table,
+  )
+
+  for _ in range(500):
+    dizhis: list[Dizhi] = random.sample(list(Dizhi), random.randint(0, len(Dizhi)))
+    result: DizhiRelationCombos = dizhi_utils.search(dizhis, DizhiRelation.破)
+    expected_result: list[set[Dizhi]] = [c for c in po_table if c.issubset(dizhis)]
+    assert _dz_equal(result, expected_result)
+
+def test_po() -> None:
+  with pytest.raises(TypeError):
+    dizhi_utils.po(Dizhi.子) # type: ignore
+  with pytest.raises(TypeError):
+    dizhi_utils.po(Dizhi.子, Dizhi.辰, Dizhi.辰) # type: ignore
+  with pytest.raises(TypeError):
+    dizhi_utils.po(Dizhi.子, Dizhi.辰, Dizhi.子, Dizhi.辰) # type: ignore
+  with pytest.raises(TypeError):
+    dizhi_utils.po((Dizhi.亥, Dizhi.子, Dizhi.丑)) # type: ignore
+  with pytest.raises(TypeError):
+    dizhi_utils.po({Dizhi.亥, Dizhi.子, Dizhi.丑}) # type: ignore
+  with pytest.raises(TypeError):
+    dizhi_utils.po([Dizhi.亥, Dizhi.子, Dizhi.丑]) # type: ignore
+  with pytest.raises(AssertionError):
+    dizhi_utils.po([Dizhi.亥, Dizhi.子], [Dizhi.丑]) # type: ignore
+  with pytest.raises(AssertionError):
+    dizhi_utils.po('亥', '子') # type: ignore
+
+  po_table: list[set[Dizhi]] = _gen_po_table()
+
+  for dz1, dz2 in itertools.product(Dizhi, repeat=2):
+    assert dizhi_utils.po(dz1, dz2) == dizhi_utils.po(dz2, dz1), 'PO (破) is a bi-directional relation'
+    assert dizhi_utils.po(dz1, dz2) == ({dz1, dz2} in po_table)
+
+def _gen_hai_table() -> set[DizhiCombo]:
+  ret: set[DizhiCombo] = set()
+  for dz1, dz2 in itertools.combinations(Dizhi, 2):
+    if dizhi_utils.liuhe(dz1, dz2):
+      dz1_chong: Dizhi = Dizhi.from_index((dz1.index + 6) % 12)
+      dz2_chong: Dizhi = Dizhi.from_index((dz2.index + 6) % 12)
+      ret.add(DizhiCombo((dz1, dz2_chong)))
+      ret.add(DizhiCombo((dz1_chong, dz2)))
+  return ret
+
+def test_search_hai() -> None:
+  hai_set: set[DizhiCombo] = _gen_hai_table()
+
+  assert _dz_equal(
+    dizhi_utils.search([], DizhiRelation.害),
+    [],
+  )
+  assert _dz_equal(
+    dizhi_utils.search(list(Dizhi), DizhiRelation.害),
+    hai_set,
+  )
+  assert _dz_equal(
+    dizhi_utils.search(list(Dizhi) * 2, DizhiRelation.害),
+    hai_set,
+  )
+
+  for _ in range(500):
+    dizhis: list[Dizhi] = random.sample(list(Dizhi), random.randint(0, len(Dizhi)))
+    result: DizhiRelationCombos = dizhi_utils.search(dizhis, DizhiRelation.害)
+    expected_result: list[DizhiCombo] = [c for c in hai_set if c.issubset(dizhis)]
+    assert _dz_equal(result, expected_result)
+
+def test_hai() -> None:
+  with pytest.raises(TypeError):
+    dizhi_utils.hai(Dizhi.子) # type: ignore
+  with pytest.raises(TypeError):
+    dizhi_utils.hai(Dizhi.子, Dizhi.辰, Dizhi.辰) # type: ignore
+  with pytest.raises(TypeError):
+    dizhi_utils.hai((Dizhi.亥, Dizhi.子, Dizhi.丑)) # type: ignore
+  with pytest.raises(TypeError):
+    dizhi_utils.hai({Dizhi.亥, Dizhi.子, Dizhi.丑}) # type: ignore
+  with pytest.raises(AssertionError):
+    dizhi_utils.hai([Dizhi.亥], [Dizhi.丑]) # type: ignore
+  with pytest.raises(AssertionError):
+    dizhi_utils.hai('亥', '丑') # type: ignore
+
+  hai_set: set[DizhiCombo] = _gen_hai_table()
+
+  for dz1, dz2 in itertools.product(Dizhi, repeat=2):
+    assert dizhi_utils.hai(dz1, dz2) == dizhi_utils.hai(dz2, dz1), 'HAI (害) is a bi-directional relation'
+    assert dizhi_utils.hai(dz1, dz2) == (DizhiCombo((dz1, dz2)) in hai_set)
+
+def test_search_sheng_ke() -> None:
+  for _ in range(200):
+    dizhis: list[Dizhi] = random.sample(list(Dizhi), random.randint(0, len(Dizhi)))
+    sheng_result: DizhiRelationCombos = dizhi_utils.search(dizhis, DizhiRelation.生)
+    ke_result: DizhiRelationCombos = dizhi_utils.search(dizhis, DizhiRelation.克)
+
+    for fs in sheng_result:
+      for dz in fs:
+        assert dz in dizhis
+    for fs in ke_result:
+      for dz in fs:
+        assert dz in dizhis
+
+    for dz1, dz2 in itertools.combinations(dizhis, 2):
+      wx1, wx2 = bazi_utils.traits(dz1).wuxing, bazi_utils.traits(dz2).wuxing
+      if wx1.generates(wx2) or wx2.generates(wx1):
+        assert DizhiCombo((dz1, dz2)) in sheng_result
+      if wx1.destructs(wx2) or wx2.destructs(wx1):
+        assert DizhiCombo((dz1, dz2)) in ke_result
+
+def test_sheng() -> None:
+  with pytest.raises(TypeError):
+    dizhi_utils.sheng(Dizhi.子) # type: ignore
+  with pytest.raises(TypeError):
+    dizhi_utils.sheng(Dizhi.子, Dizhi.辰, Dizhi.辰) # type: ignore
+  with pytest.raises(TypeError):
+    dizhi_utils.sheng((Dizhi.亥, Dizhi.子, Dizhi.丑)) # type: ignore
+  with pytest.raises(TypeError):
+    dizhi_utils.sheng({Dizhi.亥, Dizhi.子, Dizhi.丑}) # type: ignore
+  with pytest.raises(AssertionError):
+    dizhi_utils.sheng([Dizhi.亥], [Dizhi.丑]) # type: ignore
+  with pytest.raises(AssertionError):
+    dizhi_utils.sheng('亥', '丑') # type: ignore
+
+  for dz1, dz2 in itertools.product(Dizhi, repeat=2):
+    wx1, wx2 = bazi_utils.traits(dz1).wuxing, bazi_utils.traits(dz2).wuxing
+    if wx1.generates(wx2):
+      assert dizhi_utils.sheng(dz1, dz2)
+      assert not dizhi_utils.sheng(dz2, dz1)
+    else:
+      assert not dizhi_utils.sheng(dz1, dz2)
+
+def test_ke() -> None:
+  with pytest.raises(TypeError):
+    dizhi_utils.ke(Dizhi.子) # type: ignore
+  with pytest.raises(TypeError):
+    dizhi_utils.ke(Dizhi.子, Dizhi.辰, Dizhi.辰) # type: ignore
+  with pytest.raises(TypeError):
+    dizhi_utils.ke((Dizhi.亥, Dizhi.子, Dizhi.丑)) # type: ignore
+  with pytest.raises(TypeError):
+    dizhi_utils.ke({Dizhi.亥, Dizhi.子, Dizhi.丑}) # type: ignore
+  with pytest.raises(AssertionError):
+    dizhi_utils.ke([Dizhi.亥], [Dizhi.丑]) # type: ignore
+  with pytest.raises(AssertionError):
+    dizhi_utils.ke('亥', '丑') # type: ignore
+
+  for dz1, dz2 in itertools.product(Dizhi, repeat=2):
+    wx1, wx2 = bazi_utils.traits(dz1).wuxing, bazi_utils.traits(dz2).wuxing
+    if wx1.destructs(wx2):
+      assert dizhi_utils.ke(dz1, dz2)
+      assert not dizhi_utils.ke(dz2, dz1)
+    else:
+      assert not dizhi_utils.ke(dz1, dz2)
+
+def test_search_negative() -> None:
+  with pytest.raises(TypeError):
+    dizhi_utils.search([Dizhi.子, Dizhi.午]) # type: ignore
+
+  for tg_relation in TianganRelation:
+    with pytest.raises(AssertionError):
+      dizhi_utils.search([Dizhi.子, Dizhi.午], tg_relation) # type: ignore
+
+  for relation in DizhiRelation:
+    with pytest.raises(AssertionError):
+      dizhi_utils.search(Dizhi.子, relation) # type: ignore
+    with pytest.raises(AssertionError):
+      dizhi_utils.search(['甲', '己'], relation) # type: ignore
+    with pytest.raises(AssertionError):
+      dizhi_utils.search([Dizhi.子, Dizhi.午], str(relation)) # type: ignore
+    with pytest.raises(AssertionError):
+      dizhi_utils.search({Dizhi.子, Dizhi.午}, relation) # type: ignore
+
+@pytest.mark.slow
+def test_search() -> None:
+  for relation in DizhiRelation:
+    for round in range(300):
       dizhis: list[Dizhi] = random.sample(list(Dizhi), random.randint(0, len(Dizhi)))
-      discovery: DizhiRelationDiscovery = dizhi_utils.discover(dizhis)
+      for _ in range(random.randint(0, 2)):
+        dizhis += random.sample(list(Dizhi), random.randint(0, len(Dizhi)))
 
-      self.assertEqual(discovery, discovery.filter(lambda rel, combos : True))
+      dizhi_counter: Counter[Dizhi] = Counter(dizhis)
+      result: DizhiRelationCombos = dizhi_utils.search(dizhis, relation)
+      for _ in range(2):
+        random.shuffle(dizhis)
+        copied: list[Dizhi] = copy.deepcopy(dizhis)
+        assert _dz_equal(result, dizhi_utils.search(dizhis, relation))
+        assert copied == dizhis # Ensure `search` has no effect on the input `dizhis`.
 
-      forbidden_dizhis: list[Dizhi] = random.sample(list(Dizhi), random.randint(0, len(Dizhi)))
-      forbidden_relations: list[DizhiRelation] = random.sample(list(DizhiRelation), random.randint(0, len(DizhiRelation)))
-      
-      def filter_func(rel: DizhiRelation, combo: DizhiCombo) -> bool:
-        if rel in forbidden_relations:
-          return False
-        return not any(dz in combo for dz in forbidden_dizhis)
-      
-      filtered = discovery.filter(filter_func)
+      result2: DizhiRelationCombos = dizhi_utils.search(dizhis + dizhis, relation)
+      result3: DizhiRelationCombos = dizhi_utils.search(dizhis + dizhis + dizhis, relation)
 
-      for rel in forbidden_relations:
-        self.assertNotIn(rel, filtered)
+      # Expectedly, `result2` and `result3` should be equal to `result1`.
+      # The only exception is 自刑。
+      result_patched: DizhiRelationCombos = copy.deepcopy(result)
+      if relation is DizhiRelation.刑:
+        for dz in (Dizhi.午, Dizhi.辰, Dizhi.酉, Dizhi.亥):
+          if dizhi_counter[dz] == 1:
+            fs = DizhiCombo((dz,))
+            assert fs not in result_patched
+            assert fs in result2
+            assert fs in result3
+            result_patched = result_patched + (fs,) # Patch it up.
 
-      for rel, combos in filtered.items():
-        for combo in combos:
-          self.assertTrue(all(dz not in combo for dz in forbidden_dizhis))
-          self.assertIn(combo, discovery[rel])
+      assert _dz_equal(result_patched, result2)
+      assert _dz_equal(result_patched, result3)
 
-  @pytest.mark.slow
-  def test_discovery_merge(self) -> None:
-    for _ in range(5):
-      dizhis1: list[Dizhi] = random.sample(list(Dizhi), random.randint(0, len(Dizhi)))
-      dizhis2: list[Dizhi] = random.sample(list(Dizhi), random.randint(0, len(Dizhi)))
-      
-      discovery1 = dizhi_utils.discover(dizhis1)
-      discovery2 = dizhi_utils.discover(dizhis2)
+def _run_all_relation_methods(dizhis: list[Dizhi]) -> list[Any]:
+  '''This test basically iterates all possible permutations of `dizhis` and invokes all relation checking methods.'''
+  dizhi_set: set[Dizhi] = set(dizhis)
+  sorted_dizhis: list[Dizhi] = sorted(dizhi_set, key=lambda dz : dz.index)
+  result: list[Any] = []
 
-      merged = discovery1.merge(discovery2)
+  result.append(dizhi_utils.xing(definition=DizhiRules.XingDef.STRICT))
+  result.append(dizhi_utils.xing(definition=DizhiRules.XingDef.LOOSE))
 
-      with self.subTest('merge consistency'):
-        merged_ = discovery2.merge(discovery1)
-        self.assertSetEqual(set(merged), set(merged_))
-        for rel, combos in merged.items():
-          self.assertIn(rel, merged_)
-          self.assertSetEqual(set(combos), set(merged_[rel]))
+  for dz in sorted_dizhis:
+    result.append(dizhi_utils.xing(dz, definition=DizhiRules.XingDef.STRICT))
+    result.append(dizhi_utils.xing(dz, definition=DizhiRules.XingDef.LOOSE))
 
-      with self.subTest('correctness'):
-        for rel, combos in discovery1.items():
-          self.assertIn(rel, merged)
-          for combo in combos:
-            self.assertIn(combo, merged[rel])
+  dz_tuple: tuple[Dizhi, ...]
+  for dz_tuple in itertools.permutations(sorted_dizhis, 2):
+    result.append(dizhi_utils.liuhe(*dz_tuple))
+    result.append(dizhi_utils.anhe(*dz_tuple, definition=DizhiRules.AnheDef.NORMAL))
+    result.append(dizhi_utils.anhe(*dz_tuple, definition=DizhiRules.AnheDef.NORMAL_EXTENDED))
+    result.append(dizhi_utils.anhe(*dz_tuple, definition=DizhiRules.AnheDef.MANGPAI))
+    result.append(dizhi_utils.tonghe(*dz_tuple))
+    result.append(dizhi_utils.tongluhe(*dz_tuple))
+    result.append(dizhi_utils.banhe(*dz_tuple))
+    result.append(dizhi_utils.xing(*dz_tuple, definition=DizhiRules.XingDef.STRICT))
+    result.append(dizhi_utils.xing(*dz_tuple, definition=DizhiRules.XingDef.LOOSE))
+    result.append(dizhi_utils.chong(*dz_tuple))
+    result.append(dizhi_utils.po(*dz_tuple))
+    result.append(dizhi_utils.hai(*dz_tuple))
+    result.append(dizhi_utils.sheng(*dz_tuple))
+    result.append(dizhi_utils.ke(*dz_tuple))
 
-        for rel, combos in discovery2.items():
-          self.assertIn(rel, merged)
-          for combo in combos:
-            self.assertIn(combo, merged[rel])
+  for dz_tuple in itertools.permutations(sorted_dizhis, 3):
+    result.append(dizhi_utils.sanhui(*dz_tuple)) # Mypy complains... # type: ignore
+    result.append(dizhi_utils.sanhe(*dz_tuple)) # Mypy complains... # type: ignore
+    result.append(dizhi_utils.xing(*dz_tuple, definition=DizhiRules.XingDef.STRICT)) # Mypy complains... # type: ignore
+    result.append(dizhi_utils.xing(*dz_tuple, definition=DizhiRules.XingDef.LOOSE)) # Mypy complains... # type: ignore
 
-        for rel, combos in merged.items():
-          expected = set(discovery1.get(rel, set())) | set(discovery2.get(rel, set()))
-          self.assertSetEqual(set(combos), expected)
+  return result
+
+@pytest.mark.slow
+def test_discover() -> None:
+  for _ in range(512):
+    dizhis: list[Dizhi] = random.sample(Dizhi.as_list(), random.randint(0, len(Dizhi))) + \
+                          random.sample(Dizhi.as_list(), random.randint(0, len(Dizhi)))
+    discovery: DizhiRelationDiscovery = dizhi_utils.discover(dizhis)
+
+    # correctness
+    for rel in DizhiRelation:
+      if rel in discovery:
+        assert set(discovery[rel]) == set(dizhi_utils.search(dizhis, rel))
+      else:
+        assert len(dizhi_utils.search(dizhis, rel)) == 0
+
+    # consistency
+    discovery2: DizhiRelationDiscovery = dizhi_utils.discover(dizhis)
+    assert discovery == discovery2
+
+@pytest.mark.slow
+def test_discover_mutual() -> None:
+  def __random_dz_lists() -> tuple[list[Dizhi], list[Dizhi]]:
+    dizhis1: list[Dizhi] = random.sample(Dizhi.as_list(), random.randint(0, len(Dizhi)))
+    dizhis2: list[Dizhi] = random.sample(Dizhi.as_list(), random.randint(0, len(Dizhi)))
+
+    if random.randint(0, 2) == 0:
+      dizhis1.extend(random.sample(Dizhi.as_list(), random.randint(0, len(Dizhi))))
+    if random.randint(0, 2) == 0:
+      dizhis2.extend(random.sample(Dizhi.as_list(), random.randint(0, len(Dizhi))))
+
+    return dizhis1, dizhis2
+
+  for _ in range(16):
+    dizhis1, dizhis2 = __random_dz_lists()
+    discovery: DizhiRelationDiscovery = dizhi_utils.discover_mutual(dizhis1, dizhis2)
+
+    assert discovery == dizhi_utils.discover_mutual(dizhis1, dizhis2) # Test consistency
+    assert discovery == dizhi_utils.discover_mutual(dizhis2, dizhis1) # Test symmetry/equivalence
+
+    expected: dict[DizhiRelation, set[DizhiCombo]] = {
+      rel : set() for rel in DizhiRelation
+    }
+
+    rules: list[tuple[DizhiRelation, Callable[..., Any], int]] = [
+      (DizhiRelation.三会, dizhi_utils.sanhui, 3),
+      (DizhiRelation.三合, dizhi_utils.sanhe, 3),
+      (DizhiRelation.刑, dizhi_utils.xing, 3),
+      (DizhiRelation.六合, dizhi_utils.liuhe, 2),
+      (DizhiRelation.暗合, dizhi_utils.anhe, 2),
+      (DizhiRelation.通合, dizhi_utils.tonghe, 2),
+      (DizhiRelation.通禄合, dizhi_utils.tongluhe, 2),
+      (DizhiRelation.半合, dizhi_utils.banhe, 2),
+      (DizhiRelation.刑, dizhi_utils.xing, 2),
+      (DizhiRelation.冲, dizhi_utils.chong, 2),
+      (DizhiRelation.破, dizhi_utils.po, 2),
+      (DizhiRelation.害, dizhi_utils.hai, 2),
+      (DizhiRelation.生, dizhi_utils.sheng, 2),
+      (DizhiRelation.克, dizhi_utils.ke, 2),
+    ]
+
+    # Fill `expected`...
+    dizhis1_set, dizhis2_set = set(dizhis1), set(dizhis2)
+    for rel, f, n in rules:
+      for dz_tuple in itertools.permutations(dizhis1 + dizhis2, n):
+        combo = DizhiCombo(dz_tuple)
+        if not f(*dz_tuple):
+          continue
+        if any(combo.isdisjoint(s) for s in (dizhis1_set, dizhis2_set)):
+          continue
+
+        assert combo in discovery[rel]
+        expected[rel].add(combo)
+
+    for rel, expected_combos in expected.items():
+      if rel in discovery:
+        for combo in discovery[rel]:
+          assert combo in expected_combos
+      else:
+        assert len(expected_combos) == 0
+
+def test_edge_cases() -> None:
+  '''Test `discover_mutual` on 三合、三会、三刑、自刑'''
+  for combo_fs in DizhiRules.DIZHI_SANHE:
+    part1 = [random.choice(list(combo_fs))]
+    part2 = list(combo_fs - set(part1))
+
+    assert DizhiRelation.三合 not in dizhi_utils.discover_mutual([], [*combo_fs])
+
+    assert (combo_fs,) == dizhi_utils.discover_mutual(part1, part2)[DizhiRelation.三合]
+    assert (dizhi_utils.discover_mutual(part1, part2) ==
+            dizhi_utils.discover_mutual(part2, part1))
+
+  for combo_fs in DizhiRules.DIZHI_SANHUI:
+    part1 = [random.choice(list(combo_fs))]
+    part2 = list(combo_fs - set(part1))
+
+    assert DizhiRelation.三会 not in dizhi_utils.discover_mutual([], [*combo_fs])
+
+    assert (combo_fs,) == dizhi_utils.discover_mutual(part1, part2)[DizhiRelation.三会]
+    assert (dizhi_utils.discover_mutual(part1, part2) ==
+            dizhi_utils.discover_mutual(part2, part1))
+
+  for combo_tuple in DizhiRules.DIZHI_XING[DizhiRules.XingDef.LOOSE]:
+    part1 = [random.choice(combo_tuple)]
+    part2 = list(combo_tuple)
+    part2.remove(part1[0])
+
+    assert DizhiRelation.刑 not in dizhi_utils.discover_mutual([], [*combo_tuple])
+
+    assert frozenset(combo_tuple) in dizhi_utils.discover_mutual(part1, part2)[DizhiRelation.刑]
+    assert (dizhi_utils.discover_mutual(part1, part2) ==
+            dizhi_utils.discover_mutual(part2, part1))
+
+  assert (frozenset({Dizhi.午}),) == dizhi_utils.discover_mutual([Dizhi.午], [Dizhi.午])[DizhiRelation.刑]
+
+@pytest.mark.slow
+def test_consistency() -> None:
+  '''This test mainly tests that staticmethods in `dizhi_utils` give consistent results.'''
+
+  def __split(dizhis: list[Dizhi]) -> tuple[list[Dizhi], list[Dizhi]]:
+    dz_idx_list: list[int] = [idx for idx, _ in enumerate(dizhis)]
+    part1_idx_list: list[int] = random.sample(dz_idx_list, random.randint(0, len(dz_idx_list)))
+    part2_idx_list: list[int] = [idx for idx in dz_idx_list if idx not in part1_idx_list]
+    assert len(part1_idx_list) + len(part2_idx_list) == len(dizhis)
+    assert len(set(part1_idx_list + part2_idx_list)) == len(dizhis)
+
+    part1_dizhis: list[Dizhi] = [dizhis[idx] for idx in part1_idx_list]
+    part2_dizhis: list[Dizhi] = [dizhis[idx] for idx in part2_idx_list]
+    assert len(part1_dizhis) + len(part2_dizhis) == len(dizhis)
+
+    return part1_dizhis, part2_dizhis
+
+  for attempt in range(8):
+    dizhis: list[Dizhi] = []
+    for _ in range(random.randint(0, 4)):
+      dizhis.extend(random.sample(list(Dizhi), random.randint(0, 5)))
+    copied_dizhis: list[Dizhi] = copy.deepcopy(dizhis)
+
+    for relation in DizhiRelation:
+      relation_results: list[list[Any]] = []
+      combo_results: list[DizhiRelationCombos] = []
+      discover_results: list[DizhiRelationDiscovery] = []
+      discover_mutual_results: list[DizhiRelationDiscovery] = []
+
+      dizhis_p1, dizhis_p2 = __split(dizhis)
+
+      for _ in range(5):
+        if random.randint(0, 1) == 0:
+          relation_results.append(_run_all_relation_methods(dizhis))
+        if random.randint(0, 1) == 0:
+          combo_results.append(dizhi_utils.search(dizhis, relation))
+        if random.randint(0, 1) == 0:
+          discover_results.append(dizhi_utils.discover(dizhis))
+        if random.randint(0, 1) == 0:
+          discover_mutual_results.append(dizhi_utils.discover_mutual(dizhis_p1, dizhis_p2))
+          discover_mutual_results.append(dizhi_utils.discover_mutual(dizhis_p2, dizhis_p1))
+
+      for rr1, rr2 in itertools.pairwise(relation_results):
+        assert rr1 == rr2
+      for cr1, cr2 in itertools.pairwise(combo_results):
+        assert cr1 == cr2
+      for dr1, dr2 in itertools.pairwise(discover_results):
+        assert dr1 == dr2
+      for dmr1, dmr2 in itertools.pairwise(discover_mutual_results):
+        assert dmr1 == dmr2
+
+    assert dizhis == copied_dizhis # Ensure the order of `dizhis` was not changed.
+
+def test_discovery_filter() -> None:
+  for _ in range(5):
+    dizhis: list[Dizhi] = random.sample(list(Dizhi), random.randint(0, len(Dizhi)))
+    discovery: DizhiRelationDiscovery = dizhi_utils.discover(dizhis)
+
+    assert discovery == discovery.filter(lambda rel, combos : True)
+
+    forbidden_dizhis: list[Dizhi] = random.sample(list(Dizhi), random.randint(0, len(Dizhi)))
+    forbidden_relations: list[DizhiRelation] = random.sample(list(DizhiRelation), random.randint(0, len(DizhiRelation)))
+
+    def filter_func(rel: DizhiRelation, combo: DizhiCombo) -> bool:
+      if rel in forbidden_relations:
+        return False
+      return not any(dz in combo for dz in forbidden_dizhis)
+
+    filtered = discovery.filter(filter_func)
+
+    for rel in forbidden_relations:
+      assert rel not in filtered
+
+    for rel, combos in filtered.items():
+      for combo in combos:
+        assert all(dz not in combo for dz in forbidden_dizhis)
+        assert combo in discovery[rel]
+
+@pytest.mark.slow
+def test_discovery_merge() -> None:
+  for _ in range(5):
+    dizhis1: list[Dizhi] = random.sample(list(Dizhi), random.randint(0, len(Dizhi)))
+    dizhis2: list[Dizhi] = random.sample(list(Dizhi), random.randint(0, len(Dizhi)))
+
+    discovery1 = dizhi_utils.discover(dizhis1)
+    discovery2 = dizhi_utils.discover(dizhis2)
+
+    merged = discovery1.merge(discovery2)
+
+    # merge consistency
+    merged_ = discovery2.merge(discovery1)
+    assert set(merged) == set(merged_)
+    for rel, combos in merged.items():
+      assert rel in merged_
+      assert set(combos) == set(merged_[rel])
+
+    # correctness
+    for rel, combos in discovery1.items():
+      assert rel in merged
+      for combo in combos:
+        assert combo in merged[rel]
+
+    for rel, combos in discovery2.items():
+      assert rel in merged
+      for combo in combos:
+        assert combo in merged[rel]
+
+    for rel, combos in merged.items():
+      expected = set(discovery1.get(rel, set())) | set(discovery2.get(rel, set()))
+      assert set(combos) == expected

--- a/tests/utils/test_dizhi_utils.py
+++ b/tests/utils/test_dizhi_utils.py
@@ -17,7 +17,9 @@ from src.utils import bazi_utils, tiangan_utils, dizhi_utils
 from src.utils.dizhi_utils import DizhiCombo, DizhiRelationCombos, DizhiRelationDiscovery
 
 
+'''Operand type of `_dz_equal`: dizhi combos as a list of sets or an iterable of `DizhiCombo`s.'''
 DzCmpType = list[set[Dizhi]] | Iterable[DizhiCombo]
+
 
 def _dz_equal(l1: DzCmpType, l2: DzCmpType) -> bool:
   _l1 = list(l1)
@@ -52,6 +54,7 @@ def test_search_sanhui() -> None:
     result: DizhiRelationCombos = dizhi_utils.search(dizhis, DizhiRelation.三会)
     expected_result: list[set[Dizhi]] = [set(c) for c in sanhui_combos if c.issubset(dizhis)]
     assert _dz_equal(result, expected_result)
+
 
 def test_sanhui() -> None:
   with pytest.raises(TypeError):
@@ -88,6 +91,7 @@ def test_sanhui() -> None:
       for combo in itertools.permutations(dizhis):
         assert dizhi_utils.sanhui(*dizhis) is None
 
+
 def test_search_liuhe() -> None:
   liuhe_combos: list[DizhiCombo] = [
     DizhiCombo((dz1, dz2)) for dz1, dz2 in itertools.combinations(Dizhi, 2) if (dz1.index + dz2.index) % 12 == 1
@@ -107,6 +111,7 @@ def test_search_liuhe() -> None:
     result: DizhiRelationCombos = dizhi_utils.search(dizhis, DizhiRelation.六合)
     expected_result: list[set[Dizhi]] = [set(c) for c in liuhe_combos if c.issubset(dizhis)]
     assert _dz_equal(result, expected_result)
+
 
 def test_liuhe() -> None:
   with pytest.raises(TypeError):
@@ -149,6 +154,7 @@ def test_liuhe() -> None:
     else:
       assert liuhe_result is None
 
+
 def test_search_anhe() -> None:
   anhe_combos: list[DizhiCombo] = [ # 天干五合对应的地支暗合，5组。
     DizhiCombo((bazi_utils.lu(tg1), bazi_utils.lu(tg2)))
@@ -171,6 +177,7 @@ def test_search_anhe() -> None:
     result: DizhiRelationCombos = dizhi_utils.search(dizhis, DizhiRelation.暗合)
     expected_result: list[set[Dizhi]] = [set(c) for c in anhe_combos if c.issubset(dizhis)]
     assert _dz_equal(result, expected_result)
+
 
 def test_anhe() -> None:
   with pytest.raises(TypeError):
@@ -221,6 +228,7 @@ def test_anhe() -> None:
     assert dizhi_utils.anhe(dz1, dz2) == (DizhiCombo((dz1, dz2)) in normal_extended_combos)
     assert dizhi_utils.anhe(dz1, dz2) == dizhi_utils.anhe(dz2, dz1)
 
+
 def test_search_tonghe() -> None:
   tonghe_combos: set[DizhiCombo] = set()
   for dz1, dz2 in itertools.product(Dizhi, Dizhi):
@@ -245,6 +253,7 @@ def test_search_tonghe() -> None:
     result: DizhiRelationCombos = dizhi_utils.search(dizhis, DizhiRelation.通合)
     expected_result: list[set[Dizhi]] = [set(c) for c in tonghe_combos if c.issubset(dizhis)]
     assert _dz_equal(result, expected_result)
+
 
 def test_tonghe() -> None:
   with pytest.raises(TypeError):
@@ -273,6 +282,7 @@ def test_tonghe() -> None:
     assert dizhi_utils.tonghe(dz1, dz2) == (DizhiCombo((dz1, dz2)) in tonghe_combos)
     assert dizhi_utils.tonghe(dz1, dz2) == dizhi_utils.tonghe(dz2, dz1)
 
+
 def test_search_tongluhe() -> None:
   tongluhe_combos: list[DizhiCombo] = [ # 天干五合对应的地支禄身。
     DizhiCombo((bazi_utils.lu(tg1), bazi_utils.lu(tg2)))
@@ -293,6 +303,7 @@ def test_search_tongluhe() -> None:
     result: DizhiRelationCombos = dizhi_utils.search(dizhis, DizhiRelation.通禄合)
     expected_result: list[set[Dizhi]] = [set(c) for c in tongluhe_combos if c.issubset(dizhis)]
     assert _dz_equal(result, expected_result)
+
 
 def test_tongluhe() -> None:
   with pytest.raises(TypeError):
@@ -317,6 +328,7 @@ def test_tongluhe() -> None:
     assert dizhi_utils.tongluhe(dz1, dz2) == (DizhiCombo((dz1, dz2)) in tongluhe_combos)
     assert dizhi_utils.tongluhe(dz1, dz2) == dizhi_utils.tongluhe(dz2, dz1)
 
+
 def _gen_sanhe_table() -> dict[DizhiCombo, Wuxing]:
   return {
     DizhiCombo((
@@ -326,6 +338,7 @@ def _gen_sanhe_table() -> dict[DizhiCombo, Wuxing]:
     )) : bazi_utils.traits(dz).wuxing
     for dz in [Dizhi('子'), Dizhi('午'), Dizhi('卯'), Dizhi('酉')]
   }
+
 
 def test_search_sanhe() -> None:
   sanhe_table: dict[DizhiCombo, Wuxing] = _gen_sanhe_table()
@@ -344,6 +357,7 @@ def test_search_sanhe() -> None:
     result: DizhiRelationCombos = dizhi_utils.search(dizhis, DizhiRelation.三合)
     expected_result: list[set[Dizhi]] = [set(c) for c in sanhe_table if c.issubset(dizhis)]
     assert _dz_equal(result, expected_result)
+
 
 def test_sanhe() -> None:
   with pytest.raises(TypeError):
@@ -372,6 +386,7 @@ def test_sanhe() -> None:
       for combo in itertools.permutations(dizhis):
         assert dizhi_utils.sanhe(*dizhis) is None
 
+
 def _gen_banhe_table() -> dict[DizhiCombo, Wuxing]:
   pivots: set[Dizhi] = {Dizhi('子'), Dizhi('午'), Dizhi('卯'), Dizhi('酉')} # 四中神
   sanhe_table: dict[DizhiCombo, Wuxing] = _gen_sanhe_table()
@@ -382,6 +397,7 @@ def _gen_banhe_table() -> dict[DizhiCombo, Wuxing]:
       if any(dz in pivots for dz in (dz1, dz2)): # 半合局需要出现中神
         d[DizhiCombo((dz1, dz2))] = wx
   return d
+
 
 def test_search_banhe() -> None:
   banhe_table: dict[DizhiCombo, Wuxing] = _gen_banhe_table()
@@ -400,6 +416,7 @@ def test_search_banhe() -> None:
     result: DizhiRelationCombos = dizhi_utils.search(dizhis, DizhiRelation.半合)
     expected_result: list[set[Dizhi]] = [set(c) for c in banhe_table if c.issubset(dizhis)]
     assert _dz_equal(result, expected_result)
+
 
 def test_banhe() -> None:
   with pytest.raises(TypeError):
@@ -420,6 +437,7 @@ def test_banhe() -> None:
   for dz1, dz2 in itertools.product(Dizhi, Dizhi):
     assert dizhi_utils.banhe(dz1, dz2) == banhe_table.get(DizhiCombo((dz1, dz2)), None)
     assert dizhi_utils.banhe(dz1, dz2) == dizhi_utils.banhe(dz2, dz1)
+
 
 def test_search_xing() -> None:
   xing_expected: list[dict[Dizhi, int]] = [ # 辰午酉亥自刑
@@ -480,6 +498,7 @@ def test_search_xing() -> None:
     expected_result: list[set[Dizhi]] = __find_qualified(dizhis)
     assert _dz_equal(result, expected_result)
 
+
 def test_xing_negative() -> None:
   with pytest.raises(AssertionError):
     dizhi_utils.xing(Dizhi.子, Dizhi.辰, Dizhi.子, Dizhi.辰)
@@ -509,6 +528,7 @@ def test_xing_negative() -> None:
       assert dizhi_utils.xing(*random_dizhis, definition=DizhiRules.XingDef.STRICT) is None
     with pytest.raises(AssertionError):
       assert dizhi_utils.xing(*random_dizhis, definition=DizhiRules.XingDef.LOOSE) is None
+
 
 @pytest.mark.slow
 def test_xing_strict() -> None:
@@ -552,6 +572,7 @@ def test_xing_strict() -> None:
     for dz1, dz2, dz3 in itertools.permutations(dz_tuple, 3):
       assert strict_result4 == dizhi_utils.xing(dz1, dz2, dz3, definition=DizhiRules.XingDef.STRICT)
       assert strict_result4 == dizhi_utils.xing(dz1, dz2, dz3, definition=DizhiRules.XingDef.STRICT)
+
 
 def test_xing_loose() -> None:
   assert dizhi_utils.xing(definition=DizhiRules.XingDef.LOOSE) is None
@@ -614,6 +635,7 @@ def test_xing_loose() -> None:
       assert loose_result2 == DizhiRules.XingSubType.三刑
       assert dz_tuple in sanxing_list
 
+
 def test_search_chong() -> None:
   chong_table: list[set[Dizhi]] = [set(dz_tuple) for dz_tuple in zip(Dizhi.as_list()[:6], Dizhi.as_list()[6:])]
 
@@ -631,6 +653,7 @@ def test_search_chong() -> None:
     result: DizhiRelationCombos = dizhi_utils.search(dizhis, DizhiRelation.冲)
     expected_result: list[set[Dizhi]] = [c for c in chong_table if c.issubset(dizhis)]
     assert _dz_equal(result, expected_result)
+
 
 def test_chong() -> None:
   with pytest.raises(TypeError):
@@ -656,10 +679,12 @@ def test_chong() -> None:
     assert dizhi_utils.chong(dz1, dz2) == dizhi_utils.chong(dz2, dz1), 'CHONG (冲) is a bi-directional relation'
     assert dizhi_utils.chong(dz1, dz2) == ({dz1, dz2} in chong_table)
 
+
 def _gen_po_table() -> list[set[Dizhi]]:
   return [{
     Dizhi.from_index(dz_idx), Dizhi.from_index((dz_idx - 3) % 12),
   } for dz_idx in range(0, 12, 2)]
+
 
 def test_search_po() -> None:
   po_table: list[set[Dizhi]] = _gen_po_table()
@@ -678,6 +703,7 @@ def test_search_po() -> None:
     result: DizhiRelationCombos = dizhi_utils.search(dizhis, DizhiRelation.破)
     expected_result: list[set[Dizhi]] = [c for c in po_table if c.issubset(dizhis)]
     assert _dz_equal(result, expected_result)
+
 
 def test_po() -> None:
   with pytest.raises(TypeError):
@@ -703,6 +729,7 @@ def test_po() -> None:
     assert dizhi_utils.po(dz1, dz2) == dizhi_utils.po(dz2, dz1), 'PO (破) is a bi-directional relation'
     assert dizhi_utils.po(dz1, dz2) == ({dz1, dz2} in po_table)
 
+
 def _gen_hai_table() -> set[DizhiCombo]:
   ret: set[DizhiCombo] = set()
   for dz1, dz2 in itertools.combinations(Dizhi, 2):
@@ -712,6 +739,7 @@ def _gen_hai_table() -> set[DizhiCombo]:
       ret.add(DizhiCombo((dz1, dz2_chong)))
       ret.add(DizhiCombo((dz1_chong, dz2)))
   return ret
+
 
 def test_search_hai() -> None:
   hai_set: set[DizhiCombo] = _gen_hai_table()
@@ -735,6 +763,7 @@ def test_search_hai() -> None:
     expected_result: list[DizhiCombo] = [c for c in hai_set if c.issubset(dizhis)]
     assert _dz_equal(result, expected_result)
 
+
 def test_hai() -> None:
   with pytest.raises(TypeError):
     dizhi_utils.hai(Dizhi.子) # type: ignore
@@ -755,6 +784,7 @@ def test_hai() -> None:
     assert dizhi_utils.hai(dz1, dz2) == dizhi_utils.hai(dz2, dz1), 'HAI (害) is a bi-directional relation'
     assert dizhi_utils.hai(dz1, dz2) == (DizhiCombo((dz1, dz2)) in hai_set)
 
+
 def test_search_sheng_ke() -> None:
   for _ in range(200):
     dizhis: list[Dizhi] = random.sample(list(Dizhi), random.randint(0, len(Dizhi)))
@@ -774,6 +804,7 @@ def test_search_sheng_ke() -> None:
         assert DizhiCombo((dz1, dz2)) in sheng_result
       if wx1.destructs(wx2) or wx2.destructs(wx1):
         assert DizhiCombo((dz1, dz2)) in ke_result
+
 
 def test_sheng() -> None:
   with pytest.raises(TypeError):
@@ -797,6 +828,7 @@ def test_sheng() -> None:
     else:
       assert not dizhi_utils.sheng(dz1, dz2)
 
+
 def test_ke() -> None:
   with pytest.raises(TypeError):
     dizhi_utils.ke(Dizhi.子) # type: ignore
@@ -819,6 +851,7 @@ def test_ke() -> None:
     else:
       assert not dizhi_utils.ke(dz1, dz2)
 
+
 def test_search_negative() -> None:
   with pytest.raises(TypeError):
     dizhi_utils.search([Dizhi.子, Dizhi.午]) # type: ignore
@@ -836,6 +869,7 @@ def test_search_negative() -> None:
       dizhi_utils.search([Dizhi.子, Dizhi.午], str(relation)) # type: ignore
     with pytest.raises(AssertionError):
       dizhi_utils.search({Dizhi.子, Dizhi.午}, relation) # type: ignore
+
 
 @pytest.mark.slow
 def test_search() -> None:
@@ -871,8 +905,9 @@ def test_search() -> None:
       assert _dz_equal(result_patched, result2)
       assert _dz_equal(result_patched, result3)
 
+
 def _run_all_relation_methods(dizhis: list[Dizhi]) -> list[Any]:
-  '''This test basically iterates all possible permutations of `dizhis` and invokes all relation checking methods.'''
+  '''Invokes every relation method over the given dizhis (all permutations) and returns the collected results.'''
   dizhi_set: set[Dizhi] = set(dizhis)
   sorted_dizhis: list[Dizhi] = sorted(dizhi_set, key=lambda dz : dz.index)
   result: list[Any] = []
@@ -909,6 +944,7 @@ def _run_all_relation_methods(dizhis: list[Dizhi]) -> list[Any]:
 
   return result
 
+
 @pytest.mark.slow
 def test_discover() -> None:
   for _ in range(512):
@@ -926,6 +962,7 @@ def test_discover() -> None:
     # consistency
     discovery2: DizhiRelationDiscovery = dizhi_utils.discover(dizhis)
     assert discovery == discovery2
+
 
 @pytest.mark.slow
 def test_discover_mutual() -> None:
@@ -988,6 +1025,7 @@ def test_discover_mutual() -> None:
       else:
         assert len(expected_combos) == 0
 
+
 def test_edge_cases() -> None:
   '''Test `discover_mutual` on 三合、三会、三刑、自刑'''
   for combo_fs in DizhiRules.DIZHI_SANHE:
@@ -1023,9 +1061,10 @@ def test_edge_cases() -> None:
 
   assert (frozenset({Dizhi.午}),) == dizhi_utils.discover_mutual([Dizhi.午], [Dizhi.午])[DizhiRelation.刑]
 
+
 @pytest.mark.slow
 def test_consistency() -> None:
-  '''This test mainly tests that staticmethods in `dizhi_utils` give consistent results.'''
+  '''Module-level functions in `dizhi_utils` must give consistent results across calls.'''
 
   def __split(dizhis: list[Dizhi]) -> tuple[list[Dizhi], list[Dizhi]]:
     dz_idx_list: list[int] = [idx for idx, _ in enumerate(dizhis)]
@@ -1076,6 +1115,7 @@ def test_consistency() -> None:
 
     assert dizhis == copied_dizhis # Ensure the order of `dizhis` was not changed.
 
+
 def test_discovery_filter() -> None:
   for _ in range(5):
     dizhis: list[Dizhi] = random.sample(list(Dizhi), random.randint(0, len(Dizhi)))
@@ -1100,6 +1140,7 @@ def test_discovery_filter() -> None:
       for combo in combos:
         assert all(dz not in combo for dz in forbidden_dizhis)
         assert combo in discovery[rel]
+
 
 @pytest.mark.slow
 def test_discovery_merge() -> None:

--- a/tests/utils/test_shensha_utils.py
+++ b/tests/utils/test_shensha_utils.py
@@ -1,89 +1,86 @@
 # Copyright (C) 2024 Ningqi Wang (0xf3cd) <https://github.com/0xf3cd>
 # test_shensha_utils.py
 
-import unittest
-
 import random
 
 from src.defines import Tiangan, Dizhi
 from src.utils import shensha_utils
 
 
-class TestShenshaUtils(unittest.TestCase):
-  def test_taohua(self) -> None:
-    expected_table: dict[Dizhi, Dizhi] = {
-      Dizhi(k_str) : Dizhi(v_str)
-      for k_strs, v_str in zip(['申子辰', '寅午戌', '亥卯未', '巳酉丑'], '酉卯子午')
-      for k_str in k_strs
-    }
+def test_taohua() -> None:
+  expected_table: dict[Dizhi, Dizhi] = {
+    Dizhi(k_str) : Dizhi(v_str)
+    for k_strs, v_str in zip(['申子辰', '寅午戌', '亥卯未', '巳酉丑'], '酉卯子午')
+    for k_str in k_strs
+  }
 
-    for _ in range(16):
-      dz1, dz2 = random.choices(Dizhi.as_list(), k=2)
-      self.assertEqual(shensha_utils.taohua(dz1, dz2), expected_table[dz1] is dz2)
-      self.assertEqual(shensha_utils.taohua(dz1, dz2), expected_table[dz1] is dz2, 'Result consistency')
+  for _ in range(16):
+    dz1, dz2 = random.choices(Dizhi.as_list(), k=2)
+    assert shensha_utils.taohua(dz1, dz2) == (expected_table[dz1] is dz2)
+    assert shensha_utils.taohua(dz1, dz2) == (expected_table[dz1] is dz2), 'Result consistency'
 
-  def test_hongyan(self) -> None:
-    expected_table: dict[Dizhi, list[Tiangan]] = {
-      Dizhi.午 : [Tiangan.甲],
-      Dizhi.申 : [Tiangan.乙, Tiangan.癸],
-      Dizhi.寅 : [Tiangan.丙],
-      Dizhi.未 : [Tiangan.丁],
-      Dizhi.辰 : [Tiangan.戊, Tiangan.己],
-      Dizhi.戌 : [Tiangan.庚],
-      Dizhi.酉 : [Tiangan.辛],
-      Dizhi.子 : [Tiangan.壬],
-    }
+def test_hongyan() -> None:
+  expected_table: dict[Dizhi, list[Tiangan]] = {
+    Dizhi.午 : [Tiangan.甲],
+    Dizhi.申 : [Tiangan.乙, Tiangan.癸],
+    Dizhi.寅 : [Tiangan.丙],
+    Dizhi.未 : [Tiangan.丁],
+    Dizhi.辰 : [Tiangan.戊, Tiangan.己],
+    Dizhi.戌 : [Tiangan.庚],
+    Dizhi.酉 : [Tiangan.辛],
+    Dizhi.子 : [Tiangan.壬],
+  }
 
-    for _ in range(16):
-      tg, dz = random.choice(Tiangan.as_list()), random.choice(Dizhi.as_list())
-      expected_result: bool = dz in expected_table and tg in expected_table[dz]
-      self.assertEqual(shensha_utils.hongyan(tg, dz), expected_result)
-      self.assertEqual(shensha_utils.hongyan(tg, dz), expected_result, 'Result consistency')
+  for _ in range(16):
+    tg, dz = random.choice(Tiangan.as_list()), random.choice(Dizhi.as_list())
+    expected_result: bool = dz in expected_table and tg in expected_table[dz]
+    assert shensha_utils.hongyan(tg, dz) == expected_result
+    assert shensha_utils.hongyan(tg, dz) == expected_result, 'Result consistency'
 
-  def test_hongluan(self) -> None:
-    expected_table: dict[Dizhi, Dizhi] = {}
-    for dz1, dz2 in [
-      (Dizhi.子, Dizhi.卯),
-      (Dizhi.丑, Dizhi.寅),
-      (Dizhi.辰, Dizhi.亥),
-      (Dizhi.巳, Dizhi.戌),
-      (Dizhi.午, Dizhi.酉),
-      (Dizhi.未, Dizhi.申),
-    ]:
-      expected_table[dz1] = dz2
-      expected_table[dz2] = dz1
+def test_hongluan() -> None:
+  expected_table: dict[Dizhi, Dizhi] = {}
+  for dz1, dz2 in [
+    (Dizhi.子, Dizhi.卯),
+    (Dizhi.丑, Dizhi.寅),
+    (Dizhi.辰, Dizhi.亥),
+    (Dizhi.巳, Dizhi.戌),
+    (Dizhi.午, Dizhi.酉),
+    (Dizhi.未, Dizhi.申),
+  ]:
+    expected_table[dz1] = dz2
+    expected_table[dz2] = dz1
 
-    for _ in range(16):
-      dz1, dz2 = random.choices(Dizhi.as_list(), k=2)
-      self.assertEqual(shensha_utils.hongluan(dz1, dz2), expected_table[dz1] is dz2)
-      self.assertEqual(shensha_utils.hongluan(dz1, dz2), expected_table[dz1] is dz2, 'Result consistency')
+  for _ in range(16):
+    dz1, dz2 = random.choices(Dizhi.as_list(), k=2)
+    assert shensha_utils.hongluan(dz1, dz2) == (expected_table[dz1] is dz2)
+    assert shensha_utils.hongluan(dz1, dz2) == (expected_table[dz1] is dz2), 'Result consistency'
 
-  def test_tianxi(self) -> None:
-    expected_table: dict[Dizhi, Dizhi] = {}
-    for dz1, dz2 in [
-      (Dizhi.子, Dizhi.酉),
-      (Dizhi.丑, Dizhi.申),
-      (Dizhi.未, Dizhi.寅),
-      (Dizhi.午, Dizhi.卯),
-      (Dizhi.辰, Dizhi.巳),
-      (Dizhi.戌, Dizhi.亥),
-    ]:
-      expected_table[dz1] = dz2
-      expected_table[dz2] = dz1
+def test_tianxi() -> None:
+  expected_table: dict[Dizhi, Dizhi] = {}
+  for dz1, dz2 in [
+    (Dizhi.子, Dizhi.酉),
+    (Dizhi.丑, Dizhi.申),
+    (Dizhi.未, Dizhi.寅),
+    (Dizhi.午, Dizhi.卯),
+    (Dizhi.辰, Dizhi.巳),
+    (Dizhi.戌, Dizhi.亥),
+  ]:
+    expected_table[dz1] = dz2
+    expected_table[dz2] = dz1
 
-    for _ in range(16):
-      dz1, dz2 = random.choices(Dizhi.as_list(), k=2)
-      self.assertEqual(shensha_utils.tianxi(dz1, dz2), expected_table[dz1] is dz2)
-      self.assertEqual(shensha_utils.tianxi(dz1, dz2), expected_table[dz1] is dz2, 'Result consistency')
+  for _ in range(16):
+    dz1, dz2 = random.choices(Dizhi.as_list(), k=2)
+    assert shensha_utils.tianxi(dz1, dz2) == (expected_table[dz1] is dz2)
+    assert shensha_utils.tianxi(dz1, dz2) == (expected_table[dz1] is dz2), 'Result consistency'
 
-  def test_yima(self) -> None:
-    expected_table: dict[Dizhi, Dizhi] = {
-      Dizhi(k_str) : Dizhi(v_str)
-      for k_strs, v_str in zip(['申子辰', '寅午戌', '亥卯未', '巳酉丑'], '寅申巳亥')
-      for k_str in k_strs
-    }
+def test_yima() -> None:
+  expected_table: dict[Dizhi, Dizhi] = {
+    Dizhi(k_str) : Dizhi(v_str)
+    for k_strs, v_str in zip(['申子辰', '寅午戌', '亥卯未', '巳酉丑'], '寅申巳亥')
+    for k_str in k_strs
+  }
 
-    for _ in range(16):
-      dz1, dz2 = random.choices(Dizhi.as_list(), k=2)
-      self.assertEqual(shensha_utils.yima(dz1, dz2), expected_table[dz1] is dz2)
-      self.assertEqual(shensha_utils.yima(dz1, dz2), expected_table[dz1] is dz2, 'Result consistency')
+  for _ in range(16):
+    dz1, dz2 = random.choices(Dizhi.as_list(), k=2)
+    assert shensha_utils.yima(dz1, dz2) == (expected_table[dz1] is dz2)
+    assert shensha_utils.yima(dz1, dz2) == (expected_table[dz1] is dz2), 'Result consistency'

--- a/tests/utils/test_shensha_utils.py
+++ b/tests/utils/test_shensha_utils.py
@@ -17,7 +17,8 @@ def test_taohua() -> None:
   for _ in range(16):
     dz1, dz2 = random.choices(Dizhi.as_list(), k=2)
     assert shensha_utils.taohua(dz1, dz2) == (expected_table[dz1] is dz2)
-    assert shensha_utils.taohua(dz1, dz2) == (expected_table[dz1] is dz2), 'Result consistency'
+    assert shensha_utils.taohua(dz1, dz2) == (expected_table[dz1] is dz2) # Second call must answer the same (determinism across calls).
+
 
 def test_hongyan() -> None:
   expected_table: dict[Dizhi, list[Tiangan]] = {
@@ -35,7 +36,8 @@ def test_hongyan() -> None:
     tg, dz = random.choice(Tiangan.as_list()), random.choice(Dizhi.as_list())
     expected_result: bool = dz in expected_table and tg in expected_table[dz]
     assert shensha_utils.hongyan(tg, dz) == expected_result
-    assert shensha_utils.hongyan(tg, dz) == expected_result, 'Result consistency'
+    assert shensha_utils.hongyan(tg, dz) == expected_result # Second call must answer the same (determinism across calls).
+
 
 def test_hongluan() -> None:
   expected_table: dict[Dizhi, Dizhi] = {}
@@ -53,7 +55,8 @@ def test_hongluan() -> None:
   for _ in range(16):
     dz1, dz2 = random.choices(Dizhi.as_list(), k=2)
     assert shensha_utils.hongluan(dz1, dz2) == (expected_table[dz1] is dz2)
-    assert shensha_utils.hongluan(dz1, dz2) == (expected_table[dz1] is dz2), 'Result consistency'
+    assert shensha_utils.hongluan(dz1, dz2) == (expected_table[dz1] is dz2) # Second call must answer the same (determinism across calls).
+
 
 def test_tianxi() -> None:
   expected_table: dict[Dizhi, Dizhi] = {}
@@ -71,7 +74,8 @@ def test_tianxi() -> None:
   for _ in range(16):
     dz1, dz2 = random.choices(Dizhi.as_list(), k=2)
     assert shensha_utils.tianxi(dz1, dz2) == (expected_table[dz1] is dz2)
-    assert shensha_utils.tianxi(dz1, dz2) == (expected_table[dz1] is dz2), 'Result consistency'
+    assert shensha_utils.tianxi(dz1, dz2) == (expected_table[dz1] is dz2) # Second call must answer the same (determinism across calls).
+
 
 def test_yima() -> None:
   expected_table: dict[Dizhi, Dizhi] = {
@@ -83,4 +87,4 @@ def test_yima() -> None:
   for _ in range(16):
     dz1, dz2 = random.choices(Dizhi.as_list(), k=2)
     assert shensha_utils.yima(dz1, dz2) == (expected_table[dz1] is dz2)
-    assert shensha_utils.yima(dz1, dz2) == (expected_table[dz1] is dz2), 'Result consistency'
+    assert shensha_utils.yima(dz1, dz2) == (expected_table[dz1] is dz2) # Second call must answer the same (determinism across calls).

--- a/tests/utils/test_tiangan_utils.py
+++ b/tests/utils/test_tiangan_utils.py
@@ -6,508 +6,506 @@ import itertools
 from collections.abc import Iterable
 
 import pytest
-import unittest
 
 from src.defines import Tiangan, Dizhi, Wuxing, TianganRelation, DizhiRelation
 from src.utils import bazi_utils, tiangan_utils
 from src.utils.tiangan_utils import TianganCombo, TianganRelationCombos, TianganRelationDiscovery
 
 
-class TestTianganUtils(unittest.TestCase):
-  TgCmpType = list[set[Tiangan]] | Iterable[TianganCombo]    
-  @staticmethod
-  def __tg_equal(l1: TgCmpType, l2: TgCmpType) -> bool:
-    _l1 = list(l1)
-    _l2 = list(l2)
-    if len(_l1) != len(_l2):
+TgCmpType = list[set[Tiangan]] | Iterable[TianganCombo]
+
+def _tg_equal(l1: TgCmpType, l2: TgCmpType) -> bool:
+  _l1 = list(l1)
+  _l2 = list(l2)
+  if len(_l1) != len(_l2):
+    return False
+  for s in _l1:
+    if s not in _l2:
       return False
-    for s in _l1:
-      if s not in _l2:
-        return False
-    return True
+  return True
 
-  def test_search_basic(self) -> None:
-    for relation in TianganRelation:
-      empty_result: TianganRelationCombos = tiangan_utils.search([], relation)
-      self.assertEqual(len(empty_result), 0)
 
-    self.assertTrue(self.__tg_equal(
-      tiangan_utils.search((Tiangan.甲, Tiangan.丙, Tiangan.丁, Tiangan.庚, Tiangan.辛), TianganRelation.合), 
-      [
-        {Tiangan.丙, Tiangan.辛},
-      ]
-    ))
+def test_search_basic() -> None:
+  for relation in TianganRelation:
+    empty_result: TianganRelationCombos = tiangan_utils.search([], relation)
+    assert len(empty_result) == 0
 
-    self.assertTrue(self.__tg_equal(
-      tiangan_utils.search((Tiangan.甲, Tiangan.丙, Tiangan.丁, Tiangan.庚, Tiangan.辛), TianganRelation.冲), 
-      [
-        {Tiangan.甲, Tiangan.庚},
-      ]
-    ))
+  assert _tg_equal(
+    tiangan_utils.search((Tiangan.甲, Tiangan.丙, Tiangan.丁, Tiangan.庚, Tiangan.辛), TianganRelation.合),
+    [
+      {Tiangan.丙, Tiangan.辛},
+    ]
+  )
 
-    self.assertTrue(self.__tg_equal(
-      tiangan_utils.search((Tiangan.甲, Tiangan.丙, Tiangan.丁, Tiangan.庚, Tiangan.辛), TianganRelation.生), 
-      [
-        {Tiangan.甲, Tiangan.丙},
-        {Tiangan.甲, Tiangan.丁},
-      ]
-    ))
+  assert _tg_equal(
+    tiangan_utils.search((Tiangan.甲, Tiangan.丙, Tiangan.丁, Tiangan.庚, Tiangan.辛), TianganRelation.冲),
+    [
+      {Tiangan.甲, Tiangan.庚},
+    ]
+  )
 
-    self.assertTrue(self.__tg_equal(
-      tiangan_utils.search((Tiangan.甲, Tiangan.丙, Tiangan.丁, Tiangan.庚, Tiangan.辛), TianganRelation.克), 
-      [
-        {Tiangan.庚, Tiangan.甲},
-        {Tiangan.辛, Tiangan.甲},
-        {Tiangan.丙, Tiangan.庚},
-        {Tiangan.丙, Tiangan.辛},
-        {Tiangan.丁, Tiangan.庚},
-        {Tiangan.丁, Tiangan.辛},
-      ]
-    ))
+  assert _tg_equal(
+    tiangan_utils.search((Tiangan.甲, Tiangan.丙, Tiangan.丁, Tiangan.庚, Tiangan.辛), TianganRelation.生),
+    [
+      {Tiangan.甲, Tiangan.丙},
+      {Tiangan.甲, Tiangan.丁},
+    ]
+  )
 
-    self.assertTrue(self.__tg_equal(
-      tiangan_utils.search((Tiangan.壬, Tiangan.戊, Tiangan.丁, Tiangan.辛), TianganRelation.合), 
-      [
-        {Tiangan.壬, Tiangan.丁},
-      ]
-    ))
+  assert _tg_equal(
+    tiangan_utils.search((Tiangan.甲, Tiangan.丙, Tiangan.丁, Tiangan.庚, Tiangan.辛), TianganRelation.克),
+    [
+      {Tiangan.庚, Tiangan.甲},
+      {Tiangan.辛, Tiangan.甲},
+      {Tiangan.丙, Tiangan.庚},
+      {Tiangan.丙, Tiangan.辛},
+      {Tiangan.丁, Tiangan.庚},
+      {Tiangan.丁, Tiangan.辛},
+    ]
+  )
 
-    self.assertTrue(self.__tg_equal(
-      tiangan_utils.search((Tiangan.壬, Tiangan.戊, Tiangan.丁, Tiangan.辛), TianganRelation.冲), 
-      []
-    ))
+  assert _tg_equal(
+    tiangan_utils.search((Tiangan.壬, Tiangan.戊, Tiangan.丁, Tiangan.辛), TianganRelation.合),
+    [
+      {Tiangan.壬, Tiangan.丁},
+    ]
+  )
 
-    self.assertTrue(self.__tg_equal(
-      tiangan_utils.search((Tiangan.壬, Tiangan.戊, Tiangan.丁, Tiangan.辛), TianganRelation.生), 
-      [
-        {Tiangan.丁, Tiangan.戊},
-        {Tiangan.戊, Tiangan.辛},
-        {Tiangan.辛, Tiangan.壬},
-      ]
-    ))
+  assert _tg_equal(
+    tiangan_utils.search((Tiangan.壬, Tiangan.戊, Tiangan.丁, Tiangan.辛), TianganRelation.冲),
+    []
+  )
 
-    self.assertTrue(self.__tg_equal(
-      tiangan_utils.search((Tiangan.壬, Tiangan.戊, Tiangan.丁, Tiangan.辛), TianganRelation.克), 
-      [
-        {Tiangan.戊, Tiangan.壬},
-        {Tiangan.壬, Tiangan.丁},
-        {Tiangan.丁, Tiangan.辛},
-      ]
-    ))
+  assert _tg_equal(
+    tiangan_utils.search((Tiangan.壬, Tiangan.戊, Tiangan.丁, Tiangan.辛), TianganRelation.生),
+    [
+      {Tiangan.丁, Tiangan.戊},
+      {Tiangan.戊, Tiangan.辛},
+      {Tiangan.辛, Tiangan.壬},
+    ]
+  )
 
-  def test_search_negative(self) -> None:
-    with self.assertRaises(TypeError):
-      tiangan_utils.search(Tiangan.辛, TianganRelation.合) # type: ignore
-    with self.assertRaises(TypeError):
-      tiangan_utils.search((Tiangan.甲, Dizhi.子)) # type: ignore
-    with self.assertRaises(AssertionError):
-      tiangan_utils.search((Tiangan.甲, Dizhi.子), TianganRelation.合) # type: ignore
-    with self.assertRaises(AssertionError):
-      tiangan_utils.search(('甲', '丙', '辛'), TianganRelation.合) # type: ignore
-    with self.assertRaises(AssertionError):
-      tiangan_utils.search((Tiangan.甲, Tiangan.丙, Tiangan.丁, Tiangan.庚, '辛'), TianganRelation.合) # type: ignore
-    with self.assertRaises(AssertionError):
-      tiangan_utils.search((Tiangan.甲, Tiangan.丙, Tiangan.丁, Tiangan.庚), '合') # type: ignore
-    with self.assertRaises(AssertionError):
-      tiangan_utils.search((Tiangan.甲, Tiangan.丙, Tiangan.丁, Tiangan.庚), 'HE') # type: ignore
+  assert _tg_equal(
+    tiangan_utils.search((Tiangan.壬, Tiangan.戊, Tiangan.丁, Tiangan.辛), TianganRelation.克),
+    [
+      {Tiangan.戊, Tiangan.壬},
+      {Tiangan.壬, Tiangan.丁},
+      {Tiangan.丁, Tiangan.辛},
+    ]
+  )
 
-    for dz_relation in DizhiRelation:
-      with self.assertRaises(AssertionError):
-        tiangan_utils.search((Tiangan.甲, Tiangan.丙, Tiangan.丁, Tiangan.庚), dz_relation) # type: ignore
+def test_search_negative() -> None:
+  with pytest.raises(TypeError):
+    tiangan_utils.search(Tiangan.辛, TianganRelation.合) # type: ignore
+  with pytest.raises(TypeError):
+    tiangan_utils.search((Tiangan.甲, Dizhi.子)) # type: ignore
+  with pytest.raises(AssertionError):
+    tiangan_utils.search((Tiangan.甲, Dizhi.子), TianganRelation.合) # type: ignore
+  with pytest.raises(AssertionError):
+    tiangan_utils.search(('甲', '丙', '辛'), TianganRelation.合) # type: ignore
+  with pytest.raises(AssertionError):
+    tiangan_utils.search((Tiangan.甲, Tiangan.丙, Tiangan.丁, Tiangan.庚, '辛'), TianganRelation.合) # type: ignore
+  with pytest.raises(AssertionError):
+    tiangan_utils.search((Tiangan.甲, Tiangan.丙, Tiangan.丁, Tiangan.庚), '合') # type: ignore
+  with pytest.raises(AssertionError):
+    tiangan_utils.search((Tiangan.甲, Tiangan.丙, Tiangan.丁, Tiangan.庚), 'HE') # type: ignore
 
-    for relation in TianganRelation:
-      with self.assertRaises(AssertionError):
-        tiangan_utils.search((Tiangan.甲, Tiangan.丙, Tiangan.丁, Tiangan.庚), str(relation)) # type: ignore
+  for dz_relation in DizhiRelation:
+    with pytest.raises(AssertionError):
+      tiangan_utils.search((Tiangan.甲, Tiangan.丙, Tiangan.丁, Tiangan.庚), dz_relation) # type: ignore
 
-    # Invoke the method and do bad things on the result.
-    # tiangan_utils.search((Tiangan.壬, Tiangan.戊, Tiangan.丁, Tiangan.辛), TianganRelation.合).clear()
-    # tiangan_utils.search((Tiangan.壬, Tiangan.戊, Tiangan.丁, Tiangan.辛), TianganRelation.冲).append(TianganCombo({Tiangan.壬, Tiangan.丁}))
-    # sheng_result = tiangan_utils.search((Tiangan.壬, Tiangan.戊, Tiangan.丁, Tiangan.辛), TianganRelation.生)
-    # sheng_result[0] = TianganCombo((Tiangan.丁,))
-    # sheng_result[1] = TianganCombo((Tiangan.壬, Tiangan.戊))
-    #
-    # No need to do bad things again since the return type `tuple` is immutable.
+  for relation in TianganRelation:
+    with pytest.raises(AssertionError):
+      tiangan_utils.search((Tiangan.甲, Tiangan.丙, Tiangan.丁, Tiangan.庚), str(relation)) # type: ignore
 
-    # Make sure the method still returns the correct result.
-    self.assertTrue(self.__tg_equal(
-      tiangan_utils.search((Tiangan.壬, Tiangan.戊, Tiangan.丁, Tiangan.辛), TianganRelation.合), 
-      [
-        {Tiangan.壬, Tiangan.丁},
-      ]
-    ))
+  # Invoke the method and do bad things on the result.
+  # tiangan_utils.search((Tiangan.壬, Tiangan.戊, Tiangan.丁, Tiangan.辛), TianganRelation.合).clear()
+  # tiangan_utils.search((Tiangan.壬, Tiangan.戊, Tiangan.丁, Tiangan.辛), TianganRelation.冲).append(TianganCombo({Tiangan.壬, Tiangan.丁}))
+  # sheng_result = tiangan_utils.search((Tiangan.壬, Tiangan.戊, Tiangan.丁, Tiangan.辛), TianganRelation.生)
+  # sheng_result[0] = TianganCombo((Tiangan.丁,))
+  # sheng_result[1] = TianganCombo((Tiangan.壬, Tiangan.戊))
+  #
+  # No need to do bad things again since the return type `tuple` is immutable.
 
-    self.assertTrue(self.__tg_equal(
-      tiangan_utils.search((Tiangan.壬, Tiangan.戊, Tiangan.丁, Tiangan.辛), TianganRelation.冲), 
-      []
-    ))
+  # Make sure the method still returns the correct result.
+  assert _tg_equal(
+    tiangan_utils.search((Tiangan.壬, Tiangan.戊, Tiangan.丁, Tiangan.辛), TianganRelation.合),
+    [
+      {Tiangan.壬, Tiangan.丁},
+    ]
+  )
 
-    self.assertTrue(self.__tg_equal(
-      tiangan_utils.search((Tiangan.壬, Tiangan.戊, Tiangan.丁, Tiangan.辛), TianganRelation.生), 
-      [
-        {Tiangan.丁, Tiangan.戊},
-        {Tiangan.戊, Tiangan.辛},
-        {Tiangan.辛, Tiangan.壬},
-      ]
-    ))
+  assert _tg_equal(
+    tiangan_utils.search((Tiangan.壬, Tiangan.戊, Tiangan.丁, Tiangan.辛), TianganRelation.冲),
+    []
+  )
 
-    self.assertTrue(self.__tg_equal(
-      tiangan_utils.search((Tiangan.壬, Tiangan.戊, Tiangan.丁, Tiangan.辛), TianganRelation.克), 
-      [
-        {Tiangan.戊, Tiangan.壬},
-        {Tiangan.壬, Tiangan.丁},
-        {Tiangan.丁, Tiangan.辛},
-      ]
-    ))
+  assert _tg_equal(
+    tiangan_utils.search((Tiangan.壬, Tiangan.戊, Tiangan.丁, Tiangan.辛), TianganRelation.生),
+    [
+      {Tiangan.丁, Tiangan.戊},
+      {Tiangan.戊, Tiangan.辛},
+      {Tiangan.辛, Tiangan.壬},
+    ]
+  )
 
-  @pytest.mark.slow
-  def test_search_correctness(self) -> None:
-    # Generate the expected relation combos/pairs, which are used later in this test.
-    expected_he:    set[TianganCombo] = set()
-    expected_chong: set[TianganCombo] = set()
-    expected_sheng: set[TianganCombo] = set()
-    expected_ke:    set[TianganCombo] = set()
-    for combo in itertools.product(Tiangan, Tiangan):
-      tg1, tg2 = combo
-      if tg1 == tg2:
-        continue
-      trait1, trait2 = [bazi_utils.tiangan_traits(tg) for tg in combo]
+  assert _tg_equal(
+    tiangan_utils.search((Tiangan.壬, Tiangan.戊, Tiangan.丁, Tiangan.辛), TianganRelation.克),
+    [
+      {Tiangan.戊, Tiangan.壬},
+      {Tiangan.壬, Tiangan.丁},
+      {Tiangan.丁, Tiangan.辛},
+    ]
+  )
+
+@pytest.mark.slow
+def test_search_correctness() -> None:
+  # Generate the expected relation combos/pairs, which are used later in this test.
+  expected_he:    set[TianganCombo] = set()
+  expected_chong: set[TianganCombo] = set()
+  expected_sheng: set[TianganCombo] = set()
+  expected_ke:    set[TianganCombo] = set()
+  for combo in itertools.product(Tiangan, Tiangan):
+    tg1, tg2 = combo
+    if tg1 == tg2:
+      continue
+    trait1, trait2 = [bazi_utils.tiangan_traits(tg) for tg in combo]
+    wx1, wx2 = trait1.wuxing, trait2.wuxing
+
+    if abs(tg1.index - tg2.index) == 5: # Check "He" relation. 合。
+      expected_he.add(TianganCombo(combo))
+    if all(wx is not Wuxing.土 for wx in [wx1, wx2]) and abs(tg1.index - tg2.index) == 6: # Check "Chong" relation. 冲。
+      expected_chong.add(TianganCombo(combo))
+    if wx1.generates(wx2) or wx2.generates(wx1): # Check "Sheng" relation. 生。
+      expected_sheng.add(TianganCombo(combo))
+    if wx1.destructs(wx2) or wx2.destructs(wx1): # Check "Ke" relation. 克。
+      expected_ke.add(TianganCombo(combo))
+
+  def __find_relation_combos(tiangans: list[Tiangan], relation: TianganRelation) -> list[set[Tiangan]]:
+    expected: set[TianganCombo] = expected_he
+    if relation is TianganRelation.冲:
+      expected = expected_chong
+    if relation is TianganRelation.生:
+      expected = expected_sheng
+    if relation is TianganRelation.克:
+      expected = expected_ke
+
+    result: list[set[Tiangan]] = []
+    for combo_tuple in itertools.combinations(tiangans, 2):
+      if TianganCombo(combo_tuple) in expected:
+        result.append(set(combo_tuple))
+    return result
+
+  for _ in range(512):
+    tiangans: list[Tiangan] = random.sample(Tiangan.as_list(), random.randint(0, len(Tiangan)))
+
+    for combo_fs in tiangan_utils.search(tiangans, TianganRelation.合):
+      assert len(combo_fs) == 2
+      tg1, tg2 = tuple(combo_fs)
+      assert tg1.index - tg2.index in [5, -5]
+
+    for combo_fs in tiangan_utils.search(tiangans, TianganRelation.冲):
+      assert len(combo_fs) == 2
+      trait1, trait2 = [bazi_utils.traits(tg) for tg in combo_fs]
+      # No Tiangan of `Wuxing.土` is involved in the "Chong" relation.
+      assert trait1.wuxing != Wuxing.土
+      assert trait2.wuxing != Wuxing.土
+      assert trait1.yinyang == trait2.yinyang
       wx1, wx2 = trait1.wuxing, trait2.wuxing
+      assert wx1.destructs(wx2) or wx2.destructs(wx1)
 
-      if abs(tg1.index - tg2.index) == 5: # Check "He" relation. 合。
-        expected_he.add(TianganCombo(combo))
-      if all(wx is not Wuxing.土 for wx in [wx1, wx2]) and abs(tg1.index - tg2.index) == 6: # Check "Chong" relation. 冲。
-        expected_chong.add(TianganCombo(combo))
-      if wx1.generates(wx2) or wx2.generates(wx1): # Check "Sheng" relation. 生。
-        expected_sheng.add(TianganCombo(combo))
-      if wx1.destructs(wx2) or wx2.destructs(wx1): # Check "Ke" relation. 克。
-        expected_ke.add(TianganCombo(combo))
+    for combo_fs in tiangan_utils.search(tiangans, TianganRelation.生):
+      assert len(combo_fs) == 2
+      # We don't care Tiangan's Yinyang when talking about the "Sheng" relation.
+      wx1, wx2 = [bazi_utils.traits(tg).wuxing for tg in combo_fs]
+      assert wx1.generates(wx2) or wx2.generates(wx1)
 
-    def __find_relation_combos(tiangans: list[Tiangan], relation: TianganRelation) -> list[set[Tiangan]]:
-      expected: set[TianganCombo] = expected_he
-      if relation is TianganRelation.冲:
-        expected = expected_chong
-      if relation is TianganRelation.生:
-        expected = expected_sheng
-      if relation is TianganRelation.克:
-        expected = expected_ke
+    for combo_fs in tiangan_utils.search(tiangans, TianganRelation.克):
+      assert len(combo_fs) == 2
+      # We don't care Tiangan's Yinyang when talking about the "Ke" relation.
+      wx1, wx2 = [bazi_utils.traits(tg).wuxing for tg in combo_fs]
+      assert wx1.destructs(wx2) or wx2.destructs(wx1)
 
-      result: list[set[Tiangan]] = []
-      for combo_tuple in itertools.combinations(tiangans, 2):
-        if TianganCombo(combo_tuple) in expected:
-          result.append(set(combo_tuple))
-      return result
+  for relation in TianganRelation:
+    tiangans = random.sample(Tiangan.as_list(), random.randint(0, len(Tiangan)))
+    combos1: TianganRelationCombos = tiangan_utils.search(tiangans, relation)
+    combos2: TianganRelationCombos = tiangan_utils.search(tiangans + tiangans, relation)
+    assert len(combos1) == len(combos2)
+    for combo_fs in combos1:
+      assert combo_fs in combos2
 
     for _ in range(512):
-      tiangans: list[Tiangan] = random.sample(Tiangan.as_list(), random.randint(0, len(Tiangan)))
+      combos: TianganRelationCombos = tiangan_utils.search(tiangans, relation)
+      expected_combos: list[set[Tiangan]] = __find_relation_combos(tiangans, relation)
+      assert len(expected_combos) == len(combos)
+      for combo_fs in combos:
+        assert combo_fs in expected_combos
 
-      for combo_fs in tiangan_utils.search(tiangans, TianganRelation.合):
-        self.assertEqual(len(combo_fs), 2)
-        tg1, tg2 = tuple(combo_fs)
-        self.assertIn(tg1.index - tg2.index, [5, -5])
+def test_he() -> None:
+  with pytest.raises(AssertionError):
+    tiangan_utils.he(Tiangan.甲, Dizhi.子) # type: ignore
+  with pytest.raises(AssertionError):
+    tiangan_utils.he(Dizhi.子, Tiangan.甲) # type: ignore
+  with pytest.raises(AssertionError):
+    tiangan_utils.he('甲', '己') # type: ignore
 
-      for combo_fs in tiangan_utils.search(tiangans, TianganRelation.冲):
-        self.assertEqual(len(combo_fs), 2)
-        trait1, trait2 = [bazi_utils.traits(tg) for tg in combo_fs]
-        # No Tiangan of `Wuxing.土` is involved in the "Chong" relation.
-        self.assertNotEqual(trait1.wuxing, Wuxing.土)
-        self.assertNotEqual(trait2.wuxing, Wuxing.土)
-        self.assertEqual(trait1.yinyang, trait2.yinyang)
-        wx1, wx2 = trait1.wuxing, trait2.wuxing
-        self.assertTrue(wx1.destructs(wx2) or wx2.destructs(wx1))
+  expected: dict[TianganCombo, Wuxing] = {
+    TianganCombo((Tiangan.甲, Tiangan.己)) : Wuxing.土,
+    TianganCombo((Tiangan.乙, Tiangan.庚)) : Wuxing.金,
+    TianganCombo((Tiangan.丙, Tiangan.辛)) : Wuxing.水,
+    TianganCombo((Tiangan.丁, Tiangan.壬)) : Wuxing.木,
+    TianganCombo((Tiangan.戊, Tiangan.癸)) : Wuxing.火,
+  }
 
-      for combo_fs in tiangan_utils.search(tiangans, TianganRelation.生):
-        self.assertEqual(len(combo_fs), 2)
-        # We don't care Tiangan's Yinyang when talking about the "Sheng" relation.
-        wx1, wx2 = [bazi_utils.traits(tg).wuxing for tg in combo_fs]
-        self.assertTrue(wx1.generates(wx2) or wx2.generates(wx1))
+  for tg1, tg2 in itertools.product(Tiangan, Tiangan):
+    tg_set: set[Tiangan] = {tg1, tg2}
+    if any(tg_set == s for s in expected):
+      assert tiangan_utils.he(tg1, tg2) == expected[TianganCombo(tg_set)]
+      assert tiangan_utils.he(tg2, tg1) == expected[TianganCombo(tg_set)]
+    else:
+      assert tiangan_utils.he(tg1, tg2) is None
+      assert tiangan_utils.he(tg2, tg1) is None
 
-      for combo_fs in tiangan_utils.search(tiangans, TianganRelation.克):
-        self.assertEqual(len(combo_fs), 2)
-        # We don't care Tiangan's Yinyang when talking about the "Ke" relation.
-        wx1, wx2 = [bazi_utils.traits(tg).wuxing for tg in combo_fs]
-        self.assertTrue(wx1.destructs(wx2) or wx2.destructs(wx1))
+def test_chong() -> None:
+  with pytest.raises(AssertionError):
+    tiangan_utils.chong(Tiangan.甲, Dizhi.子) # type: ignore
+  with pytest.raises(AssertionError):
+    tiangan_utils.chong(Dizhi.子, Tiangan.甲) # type: ignore
+  with pytest.raises(AssertionError):
+    tiangan_utils.chong('甲', '庚') # type: ignore
 
-    for relation in TianganRelation:
-      tiangans = random.sample(Tiangan.as_list(), random.randint(0, len(Tiangan)))
-      combos1: TianganRelationCombos = tiangan_utils.search(tiangans, relation)
-      combos2: TianganRelationCombos = tiangan_utils.search(tiangans + tiangans, relation)
-      self.assertEqual(len(combos1), len(combos2))
-      for combo_fs in combos1:
-        self.assertIn(combo_fs, combos2)
+  for tg1, tg2 in itertools.product(Tiangan, Tiangan):
+    wx1, wx2 = bazi_utils.traits(tg1).wuxing, bazi_utils.traits(tg2).wuxing
+    if all(wx is not Wuxing('土') for wx in [wx1, wx2]) and abs(tg1.index - tg2.index) == 6:
+      assert tiangan_utils.chong(tg1, tg2)
+      assert tiangan_utils.chong(tg2, tg1)
+      continue
+    # Else, the two Tiangans are not in CHONG relation.
+    assert not tiangan_utils.chong(tg1, tg2)
+    assert not tiangan_utils.chong(tg2, tg1)
 
-      for _ in range(512):
-        combos: TianganRelationCombos = tiangan_utils.search(tiangans, relation)
-        expected_combos: list[set[Tiangan]] = __find_relation_combos(tiangans, relation)
-        self.assertEqual(len(expected_combos), len(combos))
-        for combo_fs in combos:
-          self.assertIn(combo_fs, expected_combos)
+def test_sheng() -> None:
+  with pytest.raises(AssertionError):
+    tiangan_utils.sheng(Tiangan.甲, Dizhi.子) # type: ignore
+  with pytest.raises(AssertionError):
+    tiangan_utils.sheng(Dizhi.子, Tiangan.甲) # type: ignore
+  with pytest.raises(AssertionError):
+    tiangan_utils.sheng('甲', '庚') # type: ignore
 
-  def test_he(self) -> None:
-    with self.assertRaises(AssertionError):
-      tiangan_utils.he(Tiangan.甲, Dizhi.子) # type: ignore
-    with self.assertRaises(AssertionError):
-      tiangan_utils.he(Dizhi.子, Tiangan.甲) # type: ignore
-    with self.assertRaises(AssertionError):
-      tiangan_utils.he('甲', '己') # type: ignore
+  for tg1, tg2 in itertools.product(Tiangan, Tiangan):
+    wx1, wx2 = bazi_utils.traits(tg1).wuxing, bazi_utils.traits(tg2).wuxing
+    if wx1.generates(wx2):
+      assert tiangan_utils.sheng(tg1, tg2)
+      assert not tiangan_utils.sheng(tg2, tg1)
+    else:
+      assert not tiangan_utils.sheng(tg1, tg2)
 
-    expected: dict[TianganCombo, Wuxing] = {
-      TianganCombo((Tiangan.甲, Tiangan.己)) : Wuxing.土,
-      TianganCombo((Tiangan.乙, Tiangan.庚)) : Wuxing.金,
-      TianganCombo((Tiangan.丙, Tiangan.辛)) : Wuxing.水,
-      TianganCombo((Tiangan.丁, Tiangan.壬)) : Wuxing.木,
-      TianganCombo((Tiangan.戊, Tiangan.癸)) : Wuxing.火,
+def test_ke() -> None:
+  with pytest.raises(AssertionError):
+    tiangan_utils.ke(Tiangan.甲, Dizhi.子) # type: ignore
+  with pytest.raises(AssertionError):
+    tiangan_utils.ke(Dizhi.子, Tiangan.甲) # type: ignore
+  with pytest.raises(AssertionError):
+    tiangan_utils.ke('甲', '庚') # type: ignore
+
+  for tg1, tg2 in itertools.product(Tiangan, Tiangan):
+    wx1, wx2 = bazi_utils.traits(tg1).wuxing, bazi_utils.traits(tg2).wuxing
+    if wx1.destructs(wx2):
+      assert tiangan_utils.ke(tg1, tg2)
+      assert not tiangan_utils.ke(tg2, tg1)
+    else:
+      assert not tiangan_utils.ke(tg1, tg2)
+
+@pytest.mark.slow
+def test_discover() -> None:
+  for _ in range(512):
+    tiangans: list[Tiangan] = random.sample(Tiangan.as_list(), random.randint(0, len(Tiangan))) + \
+                              random.sample(Tiangan.as_list(), random.randint(0, len(Tiangan)))
+    discovery: TianganRelationDiscovery = tiangan_utils.discover(tiangans)
+
+    # correctness
+    for rel in TianganRelation:
+      if rel in discovery:
+        assert set(discovery[rel]) == set(tiangan_utils.search(tiangans, rel))
+      else:
+        assert len(tiangan_utils.search(tiangans, rel)) == 0
+
+    # consistency
+    discovery2: TianganRelationDiscovery = tiangan_utils.discover(tiangans)
+    assert discovery == discovery2
+
+@pytest.mark.slow
+def test_discover_mutual() -> None:
+  def __random_tg_lists() -> tuple[list[Tiangan], list[Tiangan]]:
+    tiangans1: list[Tiangan] = random.sample(Tiangan.as_list(), random.randint(0, len(Tiangan)))
+    tiangans2: list[Tiangan] = random.sample(Tiangan.as_list(), random.randint(0, len(Tiangan)))
+
+    if random.randint(0, 2) == 0:
+      tiangans1.extend(random.sample(Tiangan.as_list(), random.randint(0, len(Tiangan))))
+    if random.randint(0, 2) == 0:
+      tiangans2.extend(random.sample(Tiangan.as_list(), random.randint(0, len(Tiangan))))
+
+    return tiangans1, tiangans2
+
+  for _ in range(512):
+    tiangans1, tiangans2 = __random_tg_lists()
+    discovery: TianganRelationDiscovery = tiangan_utils.discover_mutual(tiangans1, tiangans2)
+
+    assert discovery == tiangan_utils.discover_mutual(tiangans1, tiangans2) # Test consistency
+    assert discovery == tiangan_utils.discover_mutual(tiangans2, tiangans1) # Test symmertry/equivalence
+
+    expected: dict[TianganRelation, list[TianganCombo]] = {
+      TianganRelation.合: [],
+      TianganRelation.冲: [],
+      TianganRelation.生: [],
+      TianganRelation.克: [],
     }
 
-    for tg1, tg2 in itertools.product(Tiangan, Tiangan):
-      tg_set: set[Tiangan] = {tg1, tg2}
-      if any(tg_set == s for s in expected):
-        self.assertEqual(tiangan_utils.he(tg1, tg2), expected[TianganCombo(tg_set)])
-        self.assertEqual(tiangan_utils.he(tg2, tg1), expected[TianganCombo(tg_set)])
+    for tg1, tg2 in itertools.product(tiangans1, tiangans2):
+      combo = TianganCombo((tg1, tg2))
+
+      if tiangan_utils.he(tg1, tg2):
+        assert combo in discovery[TianganRelation.合]
+        expected[TianganRelation.合].append(combo)
+
+      if tiangan_utils.chong(tg1, tg2):
+        assert combo in discovery[TianganRelation.冲]
+        expected[TianganRelation.冲].append(combo)
+
+      if tiangan_utils.sheng(tg1, tg2) or tiangan_utils.sheng(tg2, tg1):
+        assert combo in discovery[TianganRelation.生]
+        expected[TianganRelation.生].append(combo)
+
+      if tiangan_utils.ke(tg1, tg2) or tiangan_utils.ke(tg2, tg1):
+        assert combo in discovery[TianganRelation.克]
+        expected[TianganRelation.克].append(combo)
+
+    for rel, expected_combos in expected.items():
+      if rel in discovery:
+        for combo in discovery[rel]:
+          assert combo in expected_combos
       else:
-        self.assertIsNone(tiangan_utils.he(tg1, tg2))
-        self.assertIsNone(tiangan_utils.he(tg2, tg1))
+        assert len(expected_combos) == 0
 
-  def test_chong(self) -> None:
-    with self.assertRaises(AssertionError):
-      tiangan_utils.chong(Tiangan.甲, Dizhi.子) # type: ignore
-    with self.assertRaises(AssertionError):
-      tiangan_utils.chong(Dizhi.子, Tiangan.甲) # type: ignore
-    with self.assertRaises(AssertionError):
-      tiangan_utils.chong('甲', '庚') # type: ignore
+@pytest.mark.slow
+def test_results_matched() -> None:
+  '''Test that the results of different methods are the same.'''
+  for _ in range(512):
+    tiangans: list[Tiangan] = random.sample(Tiangan.as_list(), random.randint(0, len(Tiangan))) + \
+                              random.sample(Tiangan.as_list(), random.randint(0, len(Tiangan)))
+    discovery: TianganRelationDiscovery = tiangan_utils.discover(tiangans)
 
-    for tg1, tg2 in itertools.product(Tiangan, Tiangan):
-      wx1, wx2 = bazi_utils.traits(tg1).wuxing, bazi_utils.traits(tg2).wuxing
-      if all(wx is not Wuxing('土') for wx in [wx1, wx2]) and abs(tg1.index - tg2.index) == 6:
-        self.assertTrue(tiangan_utils.chong(tg1, tg2))
-        self.assertTrue(tiangan_utils.chong(tg2, tg1))
-        continue
-      # Else, the two Tiangans are not in CHONG relation.
-      self.assertFalse(tiangan_utils.chong(tg1, tg2))
-      self.assertFalse(tiangan_utils.chong(tg2, tg1))
+    # HE / 合 — Non-directional relation
+    if TianganRelation.合 in discovery:
+      for combo in discovery[TianganRelation.合]:
+        assert len(combo) == 2
+        assert tiangan_utils.he(*combo)
 
-  def test_sheng(self) -> None:
-    with self.assertRaises(AssertionError):
-      tiangan_utils.sheng(Tiangan.甲, Dizhi.子) # type: ignore
-    with self.assertRaises(AssertionError):
-      tiangan_utils.sheng(Dizhi.子, Tiangan.甲) # type: ignore
-    with self.assertRaises(AssertionError):
-      tiangan_utils.sheng('甲', '庚') # type: ignore
+    # CHONG / 冲 — Non-directional relation
+    if TianganRelation.冲 in discovery:
+      for combo in discovery[TianganRelation.冲]:
+        assert len(combo) == 2
+        assert tiangan_utils.chong(*combo)
 
-    for tg1, tg2 in itertools.product(Tiangan, Tiangan):
-      wx1, wx2 = bazi_utils.traits(tg1).wuxing, bazi_utils.traits(tg2).wuxing
-      if wx1.generates(wx2):
-        self.assertTrue(tiangan_utils.sheng(tg1, tg2))
-        self.assertFalse(tiangan_utils.sheng(tg2, tg1))
+    # SHENG / 生 — Directional relation
+    if TianganRelation.生 in discovery:
+      for combo in discovery[TianganRelation.生]:
+        assert len(combo) == 2
+        tg1, tg2 = combo
+        r1, r2 = tiangan_utils.sheng(tg1, tg2), tiangan_utils.sheng(tg2, tg1)
+        assert r1 or r2
+        assert not (r1 and r2)
+
+    # KE / 克 — Directional relation
+    if TianganRelation.克 in discovery:
+      for combo in discovery[TianganRelation.克]:
+        assert len(combo) == 2
+        tg1, tg2 = combo
+        r1, r2 = tiangan_utils.ke(tg1, tg2), tiangan_utils.ke(tg2, tg1)
+        assert r1 or r2
+        assert not (r1 and r2)
+
+    tiangans_part1: set[Tiangan] = set(random.sample(tiangans, random.randint(0, len(tiangans))))
+    tiangans_part2: set[Tiangan] = set(tiangans) - tiangans_part1
+    mutual_discovery: TianganRelationDiscovery = tiangan_utils.discover_mutual(list(tiangans_part1), list(tiangans_part2))
+
+    for rel, mutual_combos in mutual_discovery.items():
+      expected = discovery[rel]
+      for combo in mutual_combos:
+        assert combo in expected
+      assert len(expected) >= len(mutual_combos)
+
+    # discover / discover_mutual consistency
+    part1_discoverty: TianganRelationDiscovery = tiangan_utils.discover(list(tiangans_part1))
+    part2_discoverty: TianganRelationDiscovery = tiangan_utils.discover(list(tiangans_part2))
+
+    for rel in TianganRelation:
+      actual: set[TianganCombo] = set()
+      if rel in part1_discoverty:
+        actual.update(part1_discoverty[rel])
+      if rel in part2_discoverty:
+        actual.update(part2_discoverty[rel])
+      if rel in mutual_discovery:
+        actual.update(mutual_discovery[rel])
+
+      if rel in discovery:
+        assert set(discovery[rel]) == actual
       else:
-        self.assertFalse(tiangan_utils.sheng(tg1, tg2))
+        assert len(actual) == 0
 
-  def test_ke(self) -> None:
-    with self.assertRaises(AssertionError):
-      tiangan_utils.ke(Tiangan.甲, Dizhi.子) # type: ignore
-    with self.assertRaises(AssertionError):
-      tiangan_utils.ke(Dizhi.子, Tiangan.甲) # type: ignore
-    with self.assertRaises(AssertionError):
-      tiangan_utils.ke('甲', '庚') # type: ignore
+def test_discovery_filter() -> None:
+  for _ in range(5):
+    tiangans: list[Tiangan] = random.sample(list(Tiangan), random.randint(0, len(Tiangan)))
+    discovery: TianganRelationDiscovery = tiangan_utils.discover(tiangans)
 
-    for tg1, tg2 in itertools.product(Tiangan, Tiangan):
-      wx1, wx2 = bazi_utils.traits(tg1).wuxing, bazi_utils.traits(tg2).wuxing
-      if wx1.destructs(wx2):
-        self.assertTrue(tiangan_utils.ke(tg1, tg2))
-        self.assertFalse(tiangan_utils.ke(tg2, tg1))
-      else:
-        self.assertFalse(tiangan_utils.ke(tg1, tg2))
+    assert discovery == discovery.filter(lambda rel, combo : True)
 
-  @pytest.mark.slow
-  def test_discover(self) -> None:
-    for _ in range(512):
-      tiangans: list[Tiangan] = random.sample(Tiangan.as_list(), random.randint(0, len(Tiangan))) + \
-                                random.sample(Tiangan.as_list(), random.randint(0, len(Tiangan)))
-      discovery: TianganRelationDiscovery = tiangan_utils.discover(tiangans)
+    forbidden_tiangans: list[Tiangan] = random.sample(list(Tiangan), random.randint(0, len(Tiangan)))
+    forbidden_relations: list[TianganRelation] = random.sample(list(TianganRelation), random.randint(0, len(TianganRelation)))
 
-      with self.subTest('correctness'):
-        for rel in TianganRelation:
-          if rel in discovery:
-            self.assertSetEqual(set(discovery[rel]), set(tiangan_utils.search(tiangans, rel)))
-          else:
-            self.assertEqual(len(tiangan_utils.search(tiangans, rel)), 0)
+    def filter_func(rel: TianganRelation, combo: TianganCombo) -> bool:
+      if rel in forbidden_relations:
+        return False
+      return not any(tg in combo for tg in forbidden_tiangans)
 
-      with self.subTest('consistency'):
-        discovery2: TianganRelationDiscovery = tiangan_utils.discover(tiangans)
-        self.assertEqual(discovery, discovery2)
+    filtered = discovery.filter(filter_func)
 
-  @pytest.mark.slow
-  def test_discover_mutual(self) -> None:
-    def __random_tg_lists() -> tuple[list[Tiangan], list[Tiangan]]:
-      tiangans1: list[Tiangan] = random.sample(Tiangan.as_list(), random.randint(0, len(Tiangan)))
-      tiangans2: list[Tiangan] = random.sample(Tiangan.as_list(), random.randint(0, len(Tiangan)))
+    for rel in forbidden_relations:
+      assert rel not in filtered
 
-      if random.randint(0, 2) == 0:
-        tiangans1.extend(random.sample(Tiangan.as_list(), random.randint(0, len(Tiangan))))
-      if random.randint(0, 2) == 0:
-        tiangans2.extend(random.sample(Tiangan.as_list(), random.randint(0, len(Tiangan))))
+    for rel, combos in filtered.items():
+      for combo in combos:
+        assert all(tg not in combo for tg in forbidden_tiangans)
+        assert combo in discovery[rel]
 
-      return tiangans1, tiangans2
+def test_discovery_merge() -> None:
+  for _ in range(3):
+    tiangans1: list[Tiangan] = random.sample(list(Tiangan), random.randint(0, len(Tiangan)))
+    discovery1: TianganRelationDiscovery = tiangan_utils.discover(tiangans1)
 
-    for _ in range(512):
-      tiangans1, tiangans2 = __random_tg_lists()
-      discovery: TianganRelationDiscovery = tiangan_utils.discover_mutual(tiangans1, tiangans2)
+    tiangans2: list[Tiangan] = random.sample(list(Tiangan), random.randint(0, len(Tiangan)))
+    discovery2: TianganRelationDiscovery = tiangan_utils.discover(tiangans2)
 
-      self.assertEqual(discovery, tiangan_utils.discover_mutual(tiangans1, tiangans2)) # Test consistency
-      self.assertEqual(discovery, tiangan_utils.discover_mutual(tiangans2, tiangans1)) # Test symmertry/equivalence
+    merged = discovery1.merge(discovery2)
 
-      expected: dict[TianganRelation, list[TianganCombo]] = {
-        TianganRelation.合: [],
-        TianganRelation.冲: [],
-        TianganRelation.生: [],
-        TianganRelation.克: [],
-      }
+    # merge consistency
+    merged_ = discovery2.merge(discovery1)
+    assert set(merged) == set(merged_)
+    for rel, combos in merged.items():
+      assert rel in merged_
+      assert set(combos) == set(merged_[rel])
 
-      for tg1, tg2 in itertools.product(tiangans1, tiangans2):
-        combo = TianganCombo((tg1, tg2))
+    # correctness
+    for rel, combos in discovery1.items():
+      assert rel in merged
+      for combo in combos:
+        assert combo in merged[rel]
 
-        if tiangan_utils.he(tg1, tg2):
-          self.assertIn(combo, discovery[TianganRelation.合])
-          expected[TianganRelation.合].append(combo)
-          
-        if tiangan_utils.chong(tg1, tg2):
-          self.assertIn(combo, discovery[TianganRelation.冲])
-          expected[TianganRelation.冲].append(combo)
+    for rel, combos in discovery2.items():
+      assert rel in merged
+      for combo in combos:
+        assert combo in merged[rel]
 
-        if tiangan_utils.sheng(tg1, tg2) or tiangan_utils.sheng(tg2, tg1):
-          self.assertIn(combo, discovery[TianganRelation.生])
-          expected[TianganRelation.生].append(combo)
-
-        if tiangan_utils.ke(tg1, tg2) or tiangan_utils.ke(tg2, tg1):
-          self.assertIn(combo, discovery[TianganRelation.克])
-          expected[TianganRelation.克].append(combo)
-
-      for rel, expected_combos in expected.items():
-        if rel in discovery:
-          for combo in discovery[rel]:
-            self.assertIn(combo, expected_combos)
-        else:
-          self.assertEqual(len(expected_combos), 0)
-
-  @pytest.mark.slow
-  def test_results_matched(self) -> None:
-    '''Test that the results of different methods are the same.'''
-    for _ in range(512):
-      tiangans: list[Tiangan] = random.sample(Tiangan.as_list(), random.randint(0, len(Tiangan))) + \
-                                random.sample(Tiangan.as_list(), random.randint(0, len(Tiangan)))
-      discovery: TianganRelationDiscovery = tiangan_utils.discover(tiangans)
-
-      with self.subTest('HE / 合'): # Non-directional relation
-        if TianganRelation.合 in discovery:
-          for combo in discovery[TianganRelation.合]:
-            self.assertEqual(len(combo), 2)
-            self.assertTrue(tiangan_utils.he(*combo))
-
-      with self.subTest('CHONG / 冲'): # Non-directional relation
-        if TianganRelation.冲 in discovery:
-          for combo in discovery[TianganRelation.冲]:
-            self.assertEqual(len(combo), 2)
-            self.assertTrue(tiangan_utils.chong(*combo))
-
-      with self.subTest('SHENG / 生'): # Directional relation
-        if TianganRelation.生 in discovery:
-          for combo in discovery[TianganRelation.生]:
-            self.assertEqual(len(combo), 2)
-            tg1, tg2 = combo
-            r1, r2 = tiangan_utils.sheng(tg1, tg2), tiangan_utils.sheng(tg2, tg1)
-            self.assertTrue(r1 or r2)
-            self.assertFalse(r1 and r2)
-
-      with self.subTest('KE / 克'): # Directional relation
-        if TianganRelation.克 in discovery:
-          for combo in discovery[TianganRelation.克]:
-            self.assertEqual(len(combo), 2)
-            tg1, tg2 = combo
-            r1, r2 = tiangan_utils.ke(tg1, tg2), tiangan_utils.ke(tg2, tg1)
-            self.assertTrue(r1 or r2)
-            self.assertFalse(r1 and r2)
-
-      tiangans_part1: set[Tiangan] = set(random.sample(tiangans, random.randint(0, len(tiangans))))
-      tiangans_part2: set[Tiangan] = set(tiangans) - tiangans_part1
-      mutual_discovery: TianganRelationDiscovery = tiangan_utils.discover_mutual(list(tiangans_part1), list(tiangans_part2))
-
-      for rel, mutual_combos in mutual_discovery.items():
-        expected = discovery[rel]
-        for combo in mutual_combos:
-          self.assertIn(combo, expected)
-        self.assertGreaterEqual(len(expected), len(mutual_combos))
-
-      with self.subTest('discover / discover_mutual consistency'):
-        part1_discoverty: TianganRelationDiscovery = tiangan_utils.discover(list(tiangans_part1))
-        part2_discoverty: TianganRelationDiscovery = tiangan_utils.discover(list(tiangans_part2))
-
-        for rel in TianganRelation:
-          actual: set[TianganCombo] = set()
-          if rel in part1_discoverty:
-            actual.update(part1_discoverty[rel])
-          if rel in part2_discoverty:
-            actual.update(part2_discoverty[rel])
-          if rel in mutual_discovery:
-            actual.update(mutual_discovery[rel])
-
-          if rel in discovery:
-            self.assertSetEqual(set(discovery[rel]), actual)
-          else:
-            self.assertEqual(len(actual), 0)
-
-  def test_discovery_filter(self) -> None:
-    for _ in range(5):
-      tiangans: list[Tiangan] = random.sample(list(Tiangan), random.randint(0, len(Tiangan)))
-      discovery: TianganRelationDiscovery = tiangan_utils.discover(tiangans)
-
-      self.assertEqual(discovery, 
-                       discovery.filter(lambda rel, combo : True))
-      
-      forbidden_tiangans: list[Tiangan] = random.sample(list(Tiangan), random.randint(0, len(Tiangan)))
-      forbidden_relations: list[TianganRelation] = random.sample(list(TianganRelation), random.randint(0, len(TianganRelation)))
-      
-      def filter_func(rel: TianganRelation, combo: TianganCombo) -> bool:
-        if rel in forbidden_relations:
-          return False
-        return not any(tg in combo for tg in forbidden_tiangans)
-      
-      filtered = discovery.filter(filter_func)
-
-      for rel in forbidden_relations:
-        self.assertNotIn(rel, filtered)
-
-      for rel, combos in filtered.items():
-        for combo in combos:
-          self.assertTrue(all(tg not in combo for tg in forbidden_tiangans))
-          self.assertIn(combo, discovery[rel])
-
-  def test_discovery_merge(self) -> None:
-    for _ in range(3):
-      tiangans1: list[Tiangan] = random.sample(list(Tiangan), random.randint(0, len(Tiangan)))
-      discovery1: TianganRelationDiscovery = tiangan_utils.discover(tiangans1)
-
-      tiangans2: list[Tiangan] = random.sample(list(Tiangan), random.randint(0, len(Tiangan)))
-      discovery2: TianganRelationDiscovery = tiangan_utils.discover(tiangans2)
-
-      merged = discovery1.merge(discovery2)
-
-      with self.subTest('merge consistency'):
-        merged_ = discovery2.merge(discovery1)
-        self.assertSetEqual(set(merged), set(merged_))
-        for rel, combos in merged.items():
-          self.assertIn(rel, merged_)
-          self.assertSetEqual(set(combos), set(merged_[rel]))
-
-      with self.subTest('correctness'):
-        for rel, combos in discovery1.items():
-          self.assertIn(rel, merged)
-          for combo in combos:
-            self.assertIn(combo, merged[rel])
-
-        for rel, combos in discovery2.items():
-          self.assertIn(rel, merged)
-          for combo in combos:
-            self.assertIn(combo, merged[rel])
-
-        for rel, combos in merged.items():
-          expected = set(discovery1.get(rel, set())) | set(discovery2.get(rel, set()))
-          self.assertSetEqual(set(combos), expected)
+    for rel, combos in merged.items():
+      expected = set(discovery1.get(rel, set())) | set(discovery2.get(rel, set()))
+      assert set(combos) == expected

--- a/tests/utils/test_tiangan_utils.py
+++ b/tests/utils/test_tiangan_utils.py
@@ -12,7 +12,9 @@ from src.utils import bazi_utils, tiangan_utils
 from src.utils.tiangan_utils import TianganCombo, TianganRelationCombos, TianganRelationDiscovery
 
 
+'''Operand type of `_tg_equal`: tiangan combos as a list of sets or an iterable of `TianganCombo`s.'''
 TgCmpType = list[set[Tiangan]] | Iterable[TianganCombo]
+
 
 def _tg_equal(l1: TgCmpType, l2: TgCmpType) -> bool:
   _l1 = list(l1)
@@ -94,6 +96,7 @@ def test_search_basic() -> None:
     ]
   )
 
+
 def test_search_negative() -> None:
   with pytest.raises(TypeError):
     tiangan_utils.search(Tiangan.辛, TianganRelation.合) # type: ignore
@@ -118,14 +121,7 @@ def test_search_negative() -> None:
     with pytest.raises(AssertionError):
       tiangan_utils.search((Tiangan.甲, Tiangan.丙, Tiangan.丁, Tiangan.庚), str(relation)) # type: ignore
 
-  # Invoke the method and do bad things on the result.
-  # tiangan_utils.search((Tiangan.壬, Tiangan.戊, Tiangan.丁, Tiangan.辛), TianganRelation.合).clear()
-  # tiangan_utils.search((Tiangan.壬, Tiangan.戊, Tiangan.丁, Tiangan.辛), TianganRelation.冲).append(TianganCombo({Tiangan.壬, Tiangan.丁}))
-  # sheng_result = tiangan_utils.search((Tiangan.壬, Tiangan.戊, Tiangan.丁, Tiangan.辛), TianganRelation.生)
-  # sheng_result[0] = TianganCombo((Tiangan.丁,))
-  # sheng_result[1] = TianganCombo((Tiangan.壬, Tiangan.戊))
-  #
-  # No need to do bad things again since the return type `tuple` is immutable.
+  # No need to mutate the result: the returned tuple is immutable.
 
   # Make sure the method still returns the correct result.
   assert _tg_equal(
@@ -157,6 +153,7 @@ def test_search_negative() -> None:
       {Tiangan.丁, Tiangan.辛},
     ]
   )
+
 
 @pytest.mark.slow
 def test_search_correctness() -> None:
@@ -241,6 +238,7 @@ def test_search_correctness() -> None:
       for combo_fs in combos:
         assert combo_fs in expected_combos
 
+
 def test_he() -> None:
   with pytest.raises(AssertionError):
     tiangan_utils.he(Tiangan.甲, Dizhi.子) # type: ignore
@@ -266,6 +264,7 @@ def test_he() -> None:
       assert tiangan_utils.he(tg1, tg2) is None
       assert tiangan_utils.he(tg2, tg1) is None
 
+
 def test_chong() -> None:
   with pytest.raises(AssertionError):
     tiangan_utils.chong(Tiangan.甲, Dizhi.子) # type: ignore
@@ -284,6 +283,7 @@ def test_chong() -> None:
     assert not tiangan_utils.chong(tg1, tg2)
     assert not tiangan_utils.chong(tg2, tg1)
 
+
 def test_sheng() -> None:
   with pytest.raises(AssertionError):
     tiangan_utils.sheng(Tiangan.甲, Dizhi.子) # type: ignore
@@ -300,6 +300,7 @@ def test_sheng() -> None:
     else:
       assert not tiangan_utils.sheng(tg1, tg2)
 
+
 def test_ke() -> None:
   with pytest.raises(AssertionError):
     tiangan_utils.ke(Tiangan.甲, Dizhi.子) # type: ignore
@@ -315,6 +316,7 @@ def test_ke() -> None:
       assert not tiangan_utils.ke(tg2, tg1)
     else:
       assert not tiangan_utils.ke(tg1, tg2)
+
 
 @pytest.mark.slow
 def test_discover() -> None:
@@ -333,6 +335,7 @@ def test_discover() -> None:
     # consistency
     discovery2: TianganRelationDiscovery = tiangan_utils.discover(tiangans)
     assert discovery == discovery2
+
 
 @pytest.mark.slow
 def test_discover_mutual() -> None:
@@ -387,6 +390,7 @@ def test_discover_mutual() -> None:
       else:
         assert len(expected_combos) == 0
 
+
 @pytest.mark.slow
 def test_results_matched() -> None:
   '''Test that the results of different methods are the same.'''
@@ -395,19 +399,19 @@ def test_results_matched() -> None:
                               random.sample(Tiangan.as_list(), random.randint(0, len(Tiangan)))
     discovery: TianganRelationDiscovery = tiangan_utils.discover(tiangans)
 
-    # HE / 合 — Non-directional relation
+    # HE / 合 -- Non-directional relation
     if TianganRelation.合 in discovery:
       for combo in discovery[TianganRelation.合]:
         assert len(combo) == 2
         assert tiangan_utils.he(*combo)
 
-    # CHONG / 冲 — Non-directional relation
+    # CHONG / 冲 -- Non-directional relation
     if TianganRelation.冲 in discovery:
       for combo in discovery[TianganRelation.冲]:
         assert len(combo) == 2
         assert tiangan_utils.chong(*combo)
 
-    # SHENG / 生 — Directional relation
+    # SHENG / 生 -- Directional relation
     if TianganRelation.生 in discovery:
       for combo in discovery[TianganRelation.生]:
         assert len(combo) == 2
@@ -416,7 +420,7 @@ def test_results_matched() -> None:
         assert r1 or r2
         assert not (r1 and r2)
 
-    # KE / 克 — Directional relation
+    # KE / 克 -- Directional relation
     if TianganRelation.克 in discovery:
       for combo in discovery[TianganRelation.克]:
         assert len(combo) == 2
@@ -453,6 +457,7 @@ def test_results_matched() -> None:
       else:
         assert len(actual) == 0
 
+
 def test_discovery_filter() -> None:
   for _ in range(5):
     tiangans: list[Tiangan] = random.sample(list(Tiangan), random.randint(0, len(Tiangan)))
@@ -477,6 +482,7 @@ def test_discovery_filter() -> None:
       for combo in combos:
         assert all(tg not in combo for tg in forbidden_tiangans)
         assert combo in discovery[rel]
+
 
 def test_discovery_merge() -> None:
   for _ in range(3):


### PR DESCRIPTION
#102 批次 PR-A(两 PR 之一,先行):#90 item1+item3 纯写法迁移,为 assert→raise 本体(PR-B)铺路。

## 内容

- 59 个 TestCase 类平铺为模块级 `test_*` 函数;`self.assert*` → 裸 assert;`assertRaises` → `pytest.raises`,**异常类型逐条原样**(184 处 AssertionError 钉住面留待 PR-B 改型)。
- subTest:字面量表且逐参独立处转 parametrize,其余平循环。收集数 **334 → 361**(+28 = test_bazi +27、test_bazi_chart +1;-1 = 删 test_conformance)。
- 删除 `test_hko_data_utils.test_conformance`(#90 item3):runtime_checkable isinstance 只查成员存在性,已被 test_backend 以 `calendar_utils_of` 返回契约钉住;test_backend 两处保留(主语不同)。
- 唯一 setUp 改 fixture + `tmp_path`;`assertAlmostEqual` 容差逐条保真(`pytest.approx`)。
- AGENTS.md §Tests 条文同步 pytest 风格(消除违宪窗口)。

## 验收

- 门禁全绿(测试/覆盖率 100%/ruff/mypy/demo/interpreter)。
- 零 src 改动;#90 item2(导入耦合/布局)拆新 issue 另行处理。

批次蓝图:`.review/102/brief-v2.md`(kimi 计划审 GO-WITH-CHANGES 已修订)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)