### PR TITLE
refactor: #102 公开边界 assert→显式 raise + -O 契约冒烟(PR-B)

### DIFF
--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Testing, linting, and statc type checking
         run: |
           chmod +x ./run_tests.py
-          ./run_tests.py -v -s -hko -c -cr 100 -ruff -mypy -d -i
+          ./run_tests.py -v -s -hko -c -cr 100 -ruff -mypy -d -i -osmoke
 
   test-on-macos:
     runs-on: macos-latest
@@ -49,7 +49,7 @@ jobs:
       - name: Testing, linting, and statc type checking
         run: |
           chmod +x ./run_tests.py
-          ./run_tests.py -v -s -hko -c -cr 100 -ruff -mypy -d -i
+          ./run_tests.py -v -s -hko -c -cr 100 -ruff -mypy -d -i -osmoke
 
   test-on-windows:
     runs-on: windows-latest
@@ -73,4 +73,4 @@ jobs:
         run: |
           chcp.com 65001
           $env:PYTHONIOENCODING = "utf-8"
-          python ./run_tests.py -v -s -hko -c -cr 100 -ruff -mypy -d -i
+          python ./run_tests.py -v -s -hko -c -cr 100 -ruff -mypy -d -i -osmoke

--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Testing, linting, and statc type checking
         run: |
           chmod +x ./run_tests.py
-          ./run_tests.py -ruff -mypy -d
+          ./run_tests.py -ruff -mypy -d -osmoke
 
   test-on-macos:
     runs-on: macos-latest
@@ -49,7 +49,7 @@ jobs:
       - name: Testing, linting, and statc type checking
         run: |
           chmod +x ./run_tests.py
-          ./run_tests.py -ruff -mypy -d
+          ./run_tests.py -ruff -mypy -d -osmoke
 
   test-on-windows:
     runs-on: windows-latest
@@ -73,4 +73,4 @@ jobs:
         run: |
           chcp.com 65001
           $env:PYTHONIOENCODING = "utf-8"
-          python ./run_tests.py -ruff -mypy -d
+          python ./run_tests.py -ruff -mypy -d -osmoke

--- a/.github/workflows/pypy_compatibility.yml
+++ b/.github/workflows/pypy_compatibility.yml
@@ -28,4 +28,4 @@ jobs:
           pypy -m pip install -r requirements-pypy.txt
       - name: Testing
         run: |
-          pypy ./run_tests.py -s -hko -d -i
+          pypy ./run_tests.py -s -hko -d -i -osmoke

--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ okx_logs/
 nohup.out
 
 node_modules/
+
+# Review-round scratch (task briefs, diffs, reviewer probes) -- see AGENTS.md PR workflow.
+.review/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,14 +45,16 @@ those, don't restate them here. Two rules the README doesn't spell out:
   (`per-file-ignores`, rationale included) where a family only fights one tree.
 - Not a pip package — code runs with `src.` on path via the `run_*.py` scripts.
 - Before opening a PR, verify locally with the **same gates CI runs** — the PR
-  workflow invokes `run_tests.py -v -s -hko -c -cr 100 -ruff -mypy -d -i`.
-  Quick local equivalent (run all three, they are all hard gates):
+  workflow invokes `run_tests.py -v -s -hko -c -cr 100 -ruff -mypy -d -i -osmoke`.
+  Quick local equivalent (run all four, they are all hard gates):
   - `ruff check .`
   - `python -m mypy . --check-untyped-defs --warn-redundant-casts --warn-unused-ignores --warn-return-any --warn-unreachable`
     (flags come from `run_tests.py`; a bare `mypy .` misses `--warn-unreachable`)
   - `python -m coverage run --omit='*/__init__.py,*/run_tests.py,*/tests/*,src/calendar/hko_data/encoder.py,src/calendar/celestial_data/generator.py' -m pytest tests/`
     then `python -m coverage report --show-missing` — must stay at **100%**
     (intentionally unreachable lines carry `# pragma: no cover` + a reason).
+  - `python -O tests/o_smoke.py` — the public fail-fast contract must survive `-O`
+    (see Idioms below; the script refuses to run without `-O`).
 
 ## PR workflow
 - Branch from `main`; PR body in Chinese, four sections (内容 / 测试 / 验证 / 范围说明);
@@ -116,7 +118,11 @@ Bilingual is mandatory in knowledge-dense layers (`rules` / `defines` / `utils` 
 - Document type aliases with a string literal above them.
 
 ## Idioms to keep
-- Defensive `assert isinstance(...)` / `assert callable(...)` at function entry.
+- Defensive `assert isinstance(...)` / `assert callable(...)` at function entry —
+  for **internal helpers only** (callers inside `src/` already validated the values).
+  Public-boundary input checks are explicit `raise TypeError/ValueError`: the
+  fail-fast contract must survive `python -O` (canonical note: `hko_data/decoder.py`;
+  gate: `tests/o_smoke.py`).
 - FP where it reads well (map/filter/starmap/product/compress, walrus, functools).
 - Expose computed results as `@property` (use `functools.cached_property` for
   expensive immutable results).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,9 +120,11 @@ Bilingual is mandatory in knowledge-dense layers (`rules` / `defines` / `utils` 
 ## Idioms to keep
 - Defensive `assert isinstance(...)` / `assert callable(...)` at function entry —
   for **internal helpers only** (callers inside `src/` already validated the values).
-  Public-boundary input checks are explicit `raise TypeError/ValueError`: the
-  fail-fast contract must survive `python -O` (canonical note: `hko_data/decoder.py`;
-  gate: `tests/o_smoke.py`).
+  Public-boundary input checks are explicit `raise TypeError/ValueError` —
+  `isinstance`/`callable` failures are `TypeError`; bad values, ranges and members
+  are `ValueError`; messages follow `Expected X, got {type(x)}` /
+  `Unsupported ...: {value}`. The fail-fast contract must survive `python -O`
+  (canonical note: `hko_data/decoder.py`; gate: `tests/o_smoke.py`).
 - FP where it reads well (map/filter/starmap/product/compress, walrus, functools).
 - Expose computed results as `@property` (use `functools.cached_property` for
   expensive immutable results).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,8 +122,9 @@ Bilingual is mandatory in knowledge-dense layers (`rules` / `defines` / `utils` 
   for **internal helpers only** (callers inside `src/` already validated the values).
   Public-boundary input checks are explicit `raise TypeError/ValueError` —
   `isinstance`/`callable` failures are `TypeError`; bad values, ranges and members
-  are `ValueError`; messages follow `Expected X, got {type(x)}` /
-  `Unsupported ...: {value}`. The fail-fast contract must survive `python -O`
+  are `ValueError` (the type follows the check as written: an exhausted `else` over
+  a public enum argument is a membership check, hence `ValueError`); messages follow
+  `Expected X, got {type(x)}` / `Unsupported ...: {value}`. The fail-fast contract must survive `python -O`
   (canonical note: `hko_data/decoder.py`; gate: `tests/o_smoke.py`).
 - FP where it reads well (map/filter/starmap/product/compress, walrus, functools).
 - Expose computed results as `@property` (use `functools.cached_property` for

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
     * `ruff` and `mypy` won't run;
     * demo and interpreter won't run.
   * Arguments:
-    * Add `-a`/`--all` to run everything: all tests (including hkodata and slow tests), coverage, linter, static type check, demo and interpreter. This takes precedence over `-nt` and `-k`.
+    * Add `-a`/`--all` to run everything: all tests (including hkodata and slow tests), coverage, linter, static type check, demo, interpreter, and the `python -O` contract smoke. This takes precedence over `-nt` and `-k`.
     * Add `-nt`/`--no-test` to skip tests and coverage.
     * Add `-hko` to also run hkodata tests, like: `./run_tests.py -hko`.
     * Add `-s` to also run slow tests, like: `./run_tests.py -s`.
@@ -24,4 +24,5 @@
     * Add `-r`/`--ruff` to run the linter after tests.
     * Add `-m`/`-mypy`/`--mypy` to run mypy static type checker after tests.
     * Add `-d` to run `./run_demo.py` after tests.
-    * Add `-i` to run `./run_interpreter.py` after tests. 
+    * Add `-i` to run `./run_interpreter.py` after tests.
+    * Add `-osmoke`/`--o-smoke` to run the `python -O` public-contract smoke script (`tests/o_smoke.py`) after tests.

--- a/run_tests.py
+++ b/run_tests.py
@@ -58,6 +58,10 @@ argparser.add_argument('-m', '-mypy', '--mypy', action='store_true', help='Wheth
 argparser.add_argument('-d', '--demo', action='store_true', help='Whether or not to run demo code.')
 argparser.add_argument('-i', '--interpreter', action='store_true', help='Whether or not to run interpreter.')
 
+# `python -O` public-contract smoke.
+argparser.add_argument('-osmoke', '--o-smoke', action='store_true',
+                       help='Whether or not to run the `python -O` public-contract smoke script (tests/o_smoke.py).')
+
 args = argparser.parse_args()
 
 all_the_way: Final[bool] = args.all
@@ -75,6 +79,8 @@ do_mypy: Final[bool] = args.mypy or all_the_way
 
 do_demo: Final[bool] = args.demo or all_the_way
 do_interpreter: Final[bool] = args.interpreter or all_the_way
+
+do_osmoke: Final[bool] = args.o_smoke or all_the_way
 
 term_width: Final[int] = shutil.get_terminal_size().columns
 
@@ -179,6 +185,8 @@ def print_args() -> None:
 
   print(f'-- do_demo:          {colored(do_demo)}')
   print(f'-- do_interpreter:   {colored(do_interpreter)}')
+
+  print(f'-- do_osmoke:        {colored(do_osmoke)}')
 
 
 def print_sysinfo() -> None:
@@ -360,6 +368,22 @@ def run_interpreter() -> int:
   return ret
 
 
+def run_o_smoke() -> int:
+  '''Run the `python -O` public-contract smoke script (`tests/o_smoke.py`).'''
+  print('\n' + devider())
+  bold_print('>> Running -O contract smoke...')
+
+  ret: int = run_proc_and_print([
+    sys.executable, '-O', str(Path(__file__).parent / 'tests' / 'o_smoke.py')
+  ], print_details=True)
+
+  if ret == 0:
+    green_print(f'>> {next(emoji_pair)} -O contract smoke passed!')
+  else:
+    red_print(f'>> {next(emoji_pair)} -O contract smoke failed!')
+  return ret
+
+
 class SubTaskStatuses:
   def __init__(self) -> None:
     self._retcodes: Final[dict[str, int]] = {}
@@ -403,6 +427,9 @@ def run_subtasks() -> SubTaskStatuses:
 
   if do_interpreter:
     run_subtask('interpreter', run_interpreter)
+
+  if do_osmoke:
+    run_subtask('-O smoke', run_o_smoke)
 
   if do_ruff:
     run_subtask('ruff', run_ruff)

--- a/run_tests.py
+++ b/run_tests.py
@@ -37,7 +37,7 @@ if isinstance(sys.stdout, io.TextIOWrapper):
 argparser = argparse.ArgumentParser()
 
 argparser.add_argument('-a', '--all', action='store_true', 
-                       help='Run all tests; run coverage, lint and static type check; and run demo and interpreter.')
+                       help='Run all tests; run coverage, lint and static type check; run demo and interpreter; and run the `python -O` contract smoke.')
 
 # Test related.
 argparser.add_argument('-nt', '--no-test', action='store_true', help='If set, no test and coverage will run.')
@@ -371,16 +371,16 @@ def run_interpreter() -> int:
 def run_o_smoke() -> int:
   '''Run the `python -O` public-contract smoke script (`tests/o_smoke.py`).'''
   print('\n' + devider())
-  bold_print('>> Running -O contract smoke...')
+  bold_print('>> Running o_smoke (`python -O` contract smoke)...')
 
   ret: int = run_proc_and_print([
     sys.executable, '-O', str(Path(__file__).parent / 'tests' / 'o_smoke.py')
   ], print_details=True)
 
   if ret == 0:
-    green_print(f'>> {next(emoji_pair)} -O contract smoke passed!')
+    green_print(f'>> {next(emoji_pair)} o_smoke passed!')
   else:
-    red_print(f'>> {next(emoji_pair)} -O contract smoke failed!')
+    red_print(f'>> {next(emoji_pair)} o_smoke failed!')
   return ret
 
 
@@ -429,7 +429,7 @@ def run_subtasks() -> SubTaskStatuses:
     run_subtask('interpreter', run_interpreter)
 
   if do_osmoke:
-    run_subtask('-O smoke', run_o_smoke)
+    run_subtask('o_smoke', run_o_smoke)
 
   if do_ruff:
     run_subtask('ruff', run_ruff)

--- a/src/analyzer/relationship.py
+++ b/src/analyzer/relationship.py
@@ -190,7 +190,8 @@ class TransitAnalysis:
     - (ShenshaAnalysis) The analysis of the relationship-related Shenshas of the given transits.
     '''
 
-    assert self.support(gz_year, options)
+    if not self.support(gz_year, options):
+      raise ValueError(f'Inputs not supported. gz_year: {gz_year}, options: {options}')
     transit_ganzhis = self._transit_chart.ganzhis(TransitMoment(gz_year), options)
     transit_dizhis = tuple(gz.dizhi for gz in transit_ganzhis)
 
@@ -216,7 +217,8 @@ class TransitAnalysis:
     Returns: (tiangan_utils.TianganRelationDiscovery) The Tiangan relations that the day master and other transit Tiangans form.
     '''
 
-    assert self.support(gz_year, options)
+    if not self.support(gz_year, options):
+      raise ValueError(f'Inputs not supported. gz_year: {gz_year}, options: {options}')
     transit_ganzhis = self._transit_chart.ganzhis(TransitMoment(gz_year), options)
     transit_tiangans = tuple(gz.tiangan for gz in transit_ganzhis)
 
@@ -235,7 +237,8 @@ class TransitAnalysis:
     Returns: (dizhi_utils.DizhiRelationDiscovery) The Dizhi relations that the House of Relationship and other transit Dizhis form.
     '''
 
-    assert self.support(gz_year, options)
+    if not self.support(gz_year, options):
+      raise ValueError(f'Inputs not supported. gz_year: {gz_year}, options: {options}')
     transit_ganzhis = self._transit_chart.ganzhis(TransitMoment(gz_year), options)
     transit_dizhis = [gz.dizhi for gz in transit_ganzhis]
 
@@ -298,8 +301,10 @@ class TransitAnalysis:
     Returns: (GanzhiData[tiangan_utils.TianganRelationDiscovery, dizhi_utils.DizhiRelationDiscovery]) The Tiangan and Dizhi relations that the Star(s) of Relationship and other transit Ganzhis form.
     '''
 
-    assert level in TransitAnalysis.Level
-    assert self.support(gz_year, options)
+    if level not in TransitAnalysis.Level:
+      raise ValueError(f'Unsupported level: {level}')
+    if not self.support(gz_year, options):
+      raise ValueError(f'Inputs not supported. gz_year: {gz_year}, options: {options}')
 
     transit_ganzhis = self._transit_chart.ganzhis(TransitMoment(gz_year), options)
     transit_tg = tuple(gz.tiangan for gz in transit_ganzhis)
@@ -336,7 +341,8 @@ class TransitAnalysis:
     Returns: (GanzhiData[bool, bool]) Whether the transits' Tiangans and Dizhis contain Zhengyin (正印).
     '''
 
-    assert self.support(gz_year, options)
+    if not self.support(gz_year, options):
+      raise ValueError(f'Inputs not supported. gz_year: {gz_year}, options: {options}')
   
     f = functools.partial(bazi_utils.shishen, self._chart.bazi.day_master)
     transit_ganzhis = self._transit_chart.ganzhis(TransitMoment(gz_year), options)
@@ -359,7 +365,8 @@ class TransitAnalysis:
     Returns: (GanzhiData[bool, bool]) Whether the transits' Tiangans and Dizhis contain the Star(s) of Relationship.
     '''
 
-    assert self.support(gz_year, options)
+    if not self.support(gz_year, options):
+      raise ValueError(f'Inputs not supported. gz_year: {gz_year}, options: {options}')
 
     stars = self._chart.relationship_stars
     transit_ganzhis = self._transit_chart.ganzhis(TransitMoment(gz_year), options)

--- a/src/analyzer/relationship.py
+++ b/src/analyzer/relationship.py
@@ -191,7 +191,7 @@ class TransitAnalysis:
     '''
 
     if not self.support(gz_year, options):
-      raise ValueError(f'Inputs not supported. gz_year: {gz_year}, options: {options}')
+      raise ValueError(f'Inputs not supported. Year: {gz_year}, options: {options}')
     transit_ganzhis = self._transit_chart.ganzhis(TransitMoment(gz_year), options)
     transit_dizhis = tuple(gz.dizhi for gz in transit_ganzhis)
 
@@ -218,7 +218,7 @@ class TransitAnalysis:
     '''
 
     if not self.support(gz_year, options):
-      raise ValueError(f'Inputs not supported. gz_year: {gz_year}, options: {options}')
+      raise ValueError(f'Inputs not supported. Year: {gz_year}, options: {options}')
     transit_ganzhis = self._transit_chart.ganzhis(TransitMoment(gz_year), options)
     transit_tiangans = tuple(gz.tiangan for gz in transit_ganzhis)
 
@@ -238,7 +238,7 @@ class TransitAnalysis:
     '''
 
     if not self.support(gz_year, options):
-      raise ValueError(f'Inputs not supported. gz_year: {gz_year}, options: {options}')
+      raise ValueError(f'Inputs not supported. Year: {gz_year}, options: {options}')
     transit_ganzhis = self._transit_chart.ganzhis(TransitMoment(gz_year), options)
     transit_dizhis = [gz.dizhi for gz in transit_ganzhis]
 
@@ -282,6 +282,9 @@ class TransitAnalysis:
     # Analyze all effects, basically all of above. 分析所有影响。
     ALL                  = TRANSITS_ONLY | MUTUAL
 
+  '''The constant level space for the `level` gate. `level` 闸的常量级别空间。'''
+  _ALL_LEVELS: Final[tuple[Level, ...]] = (Level.TRANSITS_ONLY, Level.MUTUAL, Level.ALL)
+
   def star_relations(
     self, 
     gz_year: int, 
@@ -301,10 +304,12 @@ class TransitAnalysis:
     Returns: (GanzhiData[tiangan_utils.TianganRelationDiscovery, dizhi_utils.DizhiRelationDiscovery]) The Tiangan and Dizhi relations that the Star(s) of Relationship and other transit Ganzhis form.
     '''
 
-    if level not in TransitAnalysis.Level:
+    if not isinstance(level, TransitAnalysis.Level):
+      raise TypeError(f'Expected Level, got {type(level)}')
+    if level not in TransitAnalysis._ALL_LEVELS:
       raise ValueError(f'Unsupported level: {level}')
     if not self.support(gz_year, options):
-      raise ValueError(f'Inputs not supported. gz_year: {gz_year}, options: {options}')
+      raise ValueError(f'Inputs not supported. Year: {gz_year}, options: {options}')
 
     transit_ganzhis = self._transit_chart.ganzhis(TransitMoment(gz_year), options)
     transit_tg = tuple(gz.tiangan for gz in transit_ganzhis)
@@ -342,7 +347,7 @@ class TransitAnalysis:
     '''
 
     if not self.support(gz_year, options):
-      raise ValueError(f'Inputs not supported. gz_year: {gz_year}, options: {options}')
+      raise ValueError(f'Inputs not supported. Year: {gz_year}, options: {options}')
   
     f = functools.partial(bazi_utils.shishen, self._chart.bazi.day_master)
     transit_ganzhis = self._transit_chart.ganzhis(TransitMoment(gz_year), options)
@@ -366,7 +371,7 @@ class TransitAnalysis:
     '''
 
     if not self.support(gz_year, options):
-      raise ValueError(f'Inputs not supported. gz_year: {gz_year}, options: {options}')
+      raise ValueError(f'Inputs not supported. Year: {gz_year}, options: {options}')
 
     stars = self._chart.relationship_stars
     transit_ganzhis = self._transit_chart.ganzhis(TransitMoment(gz_year), options)

--- a/src/bazi.py
+++ b/src/bazi.py
@@ -184,19 +184,23 @@ class Bazi:
     - backend: (CalendarBackend) The calendar backend used for all calendar conversions.
     '''
 
-    assert isinstance(birth_time, datetime)
-    assert isinstance(gender, BaziGender)
-    assert isinstance(precision, BaziPrecision)
-    assert isinstance(backend, CalendarBackend)
+    if not isinstance(birth_time, datetime):
+      raise TypeError(f'Expected datetime, got {type(birth_time)}')
+    if not isinstance(gender, BaziGender):
+      raise TypeError(f'Expected BaziGender, got {type(gender)}')
+    if not isinstance(precision, BaziPrecision):
+      raise TypeError(f'Expected BaziPrecision, got {type(precision)}')
+    if not isinstance(backend, CalendarBackend):
+      raise TypeError(f'Expected CalendarBackend, got {type(backend)}')
 
     self._backend: Final[CalendarBackend] = backend
     utils: Final[CalendarUtilsProtocol] = calendar_utils_of(backend)
 
     self._birth_time: Final[datetime] = birth_time
-    assert self._birth_time.tzinfo is None, 'Timezone should be well-processed outside of this class.'
+    if self._birth_time.tzinfo is not None:
+      raise ValueError('Timezone should be well-processed outside of this class.')
 
     self._solar_date: Final[CalendarDate] = utils.to_solar(self._birth_time)
-    assert utils.is_valid_solar_date(self._solar_date) # Here we are also checking if the date falls into the supported range.
 
     self._gender: Final[BaziGender] = gender
     self._precision: Final[BaziPrecision] = precision
@@ -274,7 +278,8 @@ class Bazi:
     assert isinstance(birth_time, (datetime, str))
     _birth_time: datetime = birth_time if isinstance(birth_time, datetime) else datetime.fromisoformat(birth_time)
 
-    assert _birth_time.tzinfo is None, 'Timezone should be well-processed outside of this class.'
+    if _birth_time.tzinfo is not None:
+      raise ValueError('Timezone should be well-processed outside of this class.')
 
     _gender: BaziGender
     if isinstance(gender, BaziGender):
@@ -339,10 +344,14 @@ class Bazi:
         - Supported values: the member names and values of `CalendarBackend` (e.g. "HKO"/"hko", case insensitive).
     '''
 
-    assert isinstance(birth_time, (datetime, str))
-    assert isinstance(gender, (BaziGender, str))
-    assert isinstance(precision, (BaziPrecision, str))
-    assert isinstance(backend, (CalendarBackend, str))
+    if not isinstance(birth_time, (datetime, str)):
+      raise TypeError(f'Expected datetime or str, got {type(birth_time)}')
+    if not isinstance(gender, (BaziGender, str)):
+      raise TypeError(f'Expected BaziGender or str, got {type(gender)}')
+    if not isinstance(precision, (BaziPrecision, str)):
+      raise TypeError(f'Expected BaziPrecision or str, got {type(precision)}')
+    if not isinstance(backend, (CalendarBackend, str)):
+      raise TypeError(f'Expected CalendarBackend or str, got {type(backend)}')
 
     _birth_time, _gender, _precision, _backend = Bazi.__parse_bazi_args(birth_time, gender, precision, backend)
     bazi: Bazi = Bazi(

--- a/src/bazi.py
+++ b/src/bazi.py
@@ -200,6 +200,7 @@ class Bazi:
     if self._birth_time.tzinfo is not None:
       raise ValueError('Timezone should be well-processed outside of this class.')
 
+    # `to_solar` is also the window gate: an out-of-window birth time raises ValueError here.
     self._solar_date: Final[CalendarDate] = utils.to_solar(self._birth_time)
 
     self._gender: Final[BaziGender] = gender

--- a/src/bazi_chart.py
+++ b/src/bazi_chart.py
@@ -95,7 +95,8 @@ class BaziChart:
   '''
 
   def __init__(self, bazi: Bazi) -> None:
-    assert isinstance(bazi, Bazi)
+    if not isinstance(bazi, Bazi):
+      raise TypeError(f'Expected Bazi, got {type(bazi)}')
     # `Bazi` is not frozen (private state can be reassigned), so keep an isolated copy --
     # `test_malicious` pins that poisoning the caller's object never reaches the chart.
     # `Bazi` 并非 frozen（私有状态可被改写），故持隔离副本；test_malicious 钉住污染不透传。

--- a/src/calendar/backend.py
+++ b/src/calendar/backend.py
@@ -51,7 +51,8 @@ class CalendarBackend(Enum):
     Args:
     - s: (str) The string to parse. Raises `ValueError` if it matches no backend.
     '''
-    assert isinstance(s, str)
+    if not isinstance(s, str):
+      raise TypeError(f'Expected str, got {type(s)}')
     for member in CalendarBackend:
       if s.lower() in (member.name.lower(), member.value.lower()):
         return member
@@ -64,7 +65,8 @@ def calendar_utils_of(backend: CalendarBackend | str) -> CalendarUtilsProtocol:
   The resolved utils conform to `CalendarUtilsProtocol`.
   把历法后端声明解析成实际的历法工具（懒加载），解析结果遵循 `CalendarUtilsProtocol`。
   '''
-  assert isinstance(backend, (CalendarBackend, str))
+  if not isinstance(backend, (CalendarBackend, str)):
+    raise TypeError(f'Expected CalendarBackend or str, got {type(backend)}')
   _backend: CalendarBackend = backend if isinstance(backend, CalendarBackend) else CalendarBackend.from_str(backend)
 
   if _backend is CalendarBackend.HKO:

--- a/src/calendar/celestial_utils.py
+++ b/src/calendar/celestial_utils.py
@@ -64,9 +64,10 @@ class CelestialCalendarUtils:
       return CalendarDate(first.year, first.month, first.day, CalendarType.SOLAR)
     elif date_type == CalendarType.LUNAR:
       return self.solar_to_lunar(self.get_min_supported_date(CalendarType.SOLAR))
-    else:
-      assert date_type == CalendarType.GANZHI
+    elif date_type == CalendarType.GANZHI:
       return self.solar_to_ganzhi(self.get_min_supported_date(CalendarType.SOLAR))
+    else:
+      raise ValueError(f'Unsupported date_type: {date_type}')
 
   @functools.lru_cache(maxsize=512)
   def get_max_supported_date(self, date_type: CalendarType) -> CalendarDate:
@@ -78,9 +79,10 @@ class CelestialCalendarUtils:
       return CalendarDate(last_year, 12, 31, CalendarType.SOLAR)
     elif date_type == CalendarType.LUNAR:
       return self.solar_to_lunar(self.get_max_supported_date(CalendarType.SOLAR))
-    else:
-      assert date_type == CalendarType.GANZHI
+    elif date_type == CalendarType.GANZHI:
       return self.solar_to_ganzhi(self.get_max_supported_date(CalendarType.SOLAR))
+    else:
+      raise ValueError(f'Unsupported date_type: {date_type}')
 
   # -- Validity --------------------------------------------------------------------
 
@@ -180,8 +182,11 @@ class CelestialCalendarUtils:
   @functools.lru_cache(maxsize=512)
   def __days_counts_in_ganzhi_year(self, ganzhi_year: int) -> tuple[int, ...]:
     # A ganzhi year needs the 立春 of the next solar year to close its last month.
-    assert ganzhi_year in self._jieqi_table.supported_year_range()
-    assert ganzhi_year + 1 in self._jieqi_table.supported_year_range()
+    if ganzhi_year not in self._jieqi_table.supported_year_range():
+      raise ValueError(f'Ganzhi year {ganzhi_year} is out of the supported range {self._jieqi_table.supported_year_range()}')
+    if ganzhi_year + 1 not in self._jieqi_table.supported_year_range():
+      raise ValueError(f'Ganzhi year {ganzhi_year} needs jieqi data of year {ganzhi_year + 1}, '
+                       f'which is out of the supported range {self._jieqi_table.supported_year_range()}')
 
     jies: list[Jieqi] = Jieqi.as_list()[::2] # Pick the Jieqis when new months start.
     assert jies[0] is Jieqi.立春
@@ -201,8 +206,11 @@ class CelestialCalendarUtils:
 
   @functools.lru_cache(maxsize=512)
   def lunar_to_solar(self, lunar_date: CalendarDate) -> CalendarDate:
-    assert lunar_date.date_type == CalendarType.LUNAR
-    assert self.is_valid(lunar_date)
+    if lunar_date.date_type != CalendarType.LUNAR:
+      raise ValueError(f'Expected a LUNAR date, got {lunar_date}')
+    if not self.is_valid(lunar_date):
+      raise ValueError(f'"{lunar_date}" is not a valid {lunar_date.date_type.name} date in the supported range '
+                       f'[{self.get_min_supported_date(lunar_date.date_type)}, {self.get_max_supported_date(lunar_date.date_type)}]')
 
     info: LunarYearInfo = self._lunar_table.get(lunar_date.year)
     passed_days: int = sum(info['days_counts'][:lunar_date.month - 1]) + lunar_date.day - 1
@@ -211,8 +219,11 @@ class CelestialCalendarUtils:
 
   @functools.lru_cache(maxsize=512)
   def solar_to_lunar(self, solar_date: CalendarDate) -> CalendarDate:
-    assert solar_date.date_type == CalendarType.SOLAR
-    assert self.is_valid(solar_date)
+    if solar_date.date_type != CalendarType.SOLAR:
+      raise ValueError(f'Expected a SOLAR date, got {solar_date}')
+    if not self.is_valid(solar_date):
+      raise ValueError(f'"{solar_date}" is not a valid {solar_date.date_type.name} date in the supported range '
+                       f'[{self.get_min_supported_date(solar_date.date_type)}, {self.get_max_supported_date(solar_date.date_type)}]')
     solar: date = date(solar_date.year, solar_date.month, solar_date.day)
 
     # A solar date early in the year still belongs to the previous lunar year.
@@ -227,8 +238,11 @@ class CelestialCalendarUtils:
 
   @functools.lru_cache(maxsize=512)
   def ganzhi_to_solar(self, ganzhi_date: CalendarDate) -> CalendarDate:
-    assert ganzhi_date.date_type == CalendarType.GANZHI
-    assert self.is_valid(ganzhi_date)
+    if ganzhi_date.date_type != CalendarType.GANZHI:
+      raise ValueError(f'Expected a GANZHI date, got {ganzhi_date}')
+    if not self.is_valid(ganzhi_date):
+      raise ValueError(f'"{ganzhi_date}" is not a valid {ganzhi_date.date_type.name} date in the supported range '
+                       f'[{self.get_min_supported_date(ganzhi_date.date_type)}, {self.get_max_supported_date(ganzhi_date.date_type)}]')
 
     days_counts: list[int] = self.days_counts_in_ganzhi_year(ganzhi_date.year)
     passed_days: int = sum(days_counts[:ganzhi_date.month - 1]) + ganzhi_date.day - 1
@@ -237,8 +251,11 @@ class CelestialCalendarUtils:
 
   @functools.lru_cache(maxsize=512)
   def solar_to_ganzhi(self, solar_date: CalendarDate) -> CalendarDate:
-    assert solar_date.date_type == CalendarType.SOLAR
-    assert self.is_valid(solar_date)
+    if solar_date.date_type != CalendarType.SOLAR:
+      raise ValueError(f'Expected a SOLAR date, got {solar_date}')
+    if not self.is_valid(solar_date):
+      raise ValueError(f'"{solar_date}" is not a valid {solar_date.date_type.name} date in the supported range '
+                       f'[{self.get_min_supported_date(solar_date.date_type)}, {self.get_max_supported_date(solar_date.date_type)}]')
     solar: date = date(solar_date.year, solar_date.month, solar_date.day)
 
     # A solar date before 立春 still belongs to the previous ganzhi year.
@@ -252,14 +269,20 @@ class CelestialCalendarUtils:
 
   @functools.lru_cache(maxsize=512)
   def lunar_to_ganzhi(self, lunar_date: CalendarDate) -> CalendarDate:
-    assert lunar_date.date_type == CalendarType.LUNAR
-    assert self.is_valid(lunar_date)
+    if lunar_date.date_type != CalendarType.LUNAR:
+      raise ValueError(f'Expected a LUNAR date, got {lunar_date}')
+    if not self.is_valid(lunar_date):
+      raise ValueError(f'"{lunar_date}" is not a valid {lunar_date.date_type.name} date in the supported range '
+                       f'[{self.get_min_supported_date(lunar_date.date_type)}, {self.get_max_supported_date(lunar_date.date_type)}]')
     return self.solar_to_ganzhi(self.lunar_to_solar(lunar_date))
 
   @functools.lru_cache(maxsize=512)
   def ganzhi_to_lunar(self, ganzhi_date: CalendarDate) -> CalendarDate:
-    assert ganzhi_date.date_type == CalendarType.GANZHI
-    assert self.is_valid(ganzhi_date)
+    if ganzhi_date.date_type != CalendarType.GANZHI:
+      raise ValueError(f'Expected a GANZHI date, got {ganzhi_date}')
+    if not self.is_valid(ganzhi_date):
+      raise ValueError(f'"{ganzhi_date}" is not a valid {ganzhi_date.date_type.name} date in the supported range '
+                       f'[{self.get_min_supported_date(ganzhi_date.date_type)}, {self.get_max_supported_date(ganzhi_date.date_type)}]')
     return self.solar_to_lunar(self.ganzhi_to_solar(ganzhi_date))
 
   @staticmethod
@@ -277,11 +300,14 @@ class CelestialCalendarUtils:
   def __to_calendardate(self, d: date | CalendarDate) -> CalendarDate:
     if isinstance(d, date):
       ret = CalendarDate(d.year, d.month, d.day, CalendarType.SOLAR)
-    else:
-      assert isinstance(d, CalendarDate)
+    elif isinstance(d, CalendarDate):
       ret = d
+    else:
+      raise TypeError(f'Expected date or CalendarDate, got {type(d)}')
 
-    assert self.is_valid(ret)
+    if not self.is_valid(ret):
+      raise ValueError(f'"{ret}" is not a valid {ret.date_type.name} date in the supported range '
+                       f'[{self.get_min_supported_date(ret.date_type)}, {self.get_max_supported_date(ret.date_type)}]')
     return ret
 
   @functools.lru_cache(maxsize=512)
@@ -408,9 +434,12 @@ class CelestialCalendarUtils:
     Return: (datetime) The accurate moment of the Jieqi in the given solar year.
     '''
 
-    assert isinstance(solar_year, int)
-    assert isinstance(jieqi, Jieqi)
-    assert solar_year in self._jieqi_table.supported_year_range()
+    if not isinstance(solar_year, int):
+      raise TypeError(f'Expected int, got {type(solar_year)}')
+    if not isinstance(jieqi, Jieqi):
+      raise TypeError(f'Expected Jieqi, got {type(jieqi)}')
+    if solar_year not in self._jieqi_table.supported_year_range():
+      raise ValueError(f'Year {solar_year} is out of the supported range {self._jieqi_table.supported_year_range()}')
     return self._jieqi_table.get(solar_year, jieqi)
 
   # maxsize=2, not 1: the cache is class-level, so `ALGO1` and `ALGO2` are two distinct
@@ -450,7 +479,8 @@ class CelestialCalendarUtils:
     Return: (JieqiTime) The previous Jie (节), and its solar datetime.
     '''
 
-    assert isinstance(dt, datetime)
+    if not isinstance(dt, datetime):
+      raise TypeError(f'Expected datetime, got {type(dt)}')
     self.__check_jie_range(dt)
 
     # Walk the year's 节 backwards; `dt` sits in the last interval whose start is <= it.
@@ -480,7 +510,8 @@ class CelestialCalendarUtils:
     Return: (JieqiTime) The next Jie (节), and its solar datetime.
     '''
 
-    assert isinstance(dt, datetime)
+    if not isinstance(dt, datetime):
+      raise TypeError(f'Expected datetime, got {type(dt)}')
     self.__check_jie_range(dt)
 
     for jie in Jieqi.as_list(ganzhi_year=False)[::2]:

--- a/src/calendar/dates.py
+++ b/src/calendar/dates.py
@@ -61,10 +61,14 @@ class CalendarDate:
 
   def __post_init__(self) -> None:
     # Type check at runtime.
-    assert isinstance(self.year, int)
-    assert isinstance(self.month, int)
-    assert isinstance(self.day, int)
-    assert isinstance(self.date_type, CalendarType)
+    if not isinstance(self.year, int):
+      raise TypeError(f'Expected int, got {type(self.year)}')
+    if not isinstance(self.month, int):
+      raise TypeError(f'Expected int, got {type(self.month)}')
+    if not isinstance(self.day, int):
+      raise TypeError(f'Expected int, got {type(self.day)}')
+    if not isinstance(self.date_type, CalendarType):
+      raise TypeError(f'Expected CalendarType, got {type(self.date_type)}')
 
   def __str__(self) -> str:
     return f'({self.year}-{self.month}-{self.day}, {self.date_type.name})'

--- a/src/calendar/dates.py
+++ b/src/calendar/dates.py
@@ -80,7 +80,7 @@ class CalendarDate:
     if not isinstance(other, CalendarDate):
       raise TypeError('Not a CalendarDate object.')
     if self.date_type != other.date_type:
-      raise TypeError('objects not of the same CalenderType.')
+      raise TypeError('objects not of the same CalendarType.')
     return (self.year, self.month, self.day), (other.year, other.month, other.day)
 
   def __lt__(self, other: object) -> bool:

--- a/src/calendar/hko_data/decoder.py
+++ b/src/calendar/hko_data/decoder.py
@@ -73,7 +73,8 @@ class DecodedJieqiDates:
 
   def __getitem__(self, year: int) -> JieqiDates:
     '''Note: `year` means Gregorian/Solar year / 公历年'''
-    assert year in self.supported_year_range()
+    if year not in self.supported_year_range():
+      raise ValueError(f'Year {year} is out of the supported range {self.supported_year_range()}')
 
     # Extract the bytes for the input `year`.
     year_bytes: bytes = self._bytes[(year - self.start_year) * 24 * DecodedJieqiDates.date_bytes_len : (year - self.start_year + 1) * 24 * DecodedJieqiDates.date_bytes_len]
@@ -89,7 +90,8 @@ class DecodedJieqiDates:
 
     Note: `year` means Gregorian/Solar year / 公历年
     '''
-    assert year in self.supported_year_range()
+    if year not in self.supported_year_range():
+      raise ValueError(f'Year {year} is out of the supported range {self.supported_year_range()}')
     return self[year][jieqi]
   
   def supported_year_range(self) -> range:
@@ -149,8 +151,10 @@ class DecodedLunarYears:
     return self._bytes[(lunar_year - self.start_year) * 8 : (lunar_year - self.start_year + 1) * 8]
   
   def __getitem__(self, lunar_year: int) -> LunarYearInfo:
-    assert isinstance(lunar_year, int)
-    assert lunar_year in self.supported_year_range()
+    if not isinstance(lunar_year, int):
+      raise TypeError(f'Expected int, got {type(lunar_year)}')
+    if lunar_year not in self.supported_year_range():
+      raise ValueError(f'Year {lunar_year} is out of the supported range {self.supported_year_range()}')
 
     data_bytes: bytes = self.__read_bytes_for_lunar_year(lunar_year)
     assert len(data_bytes) == 8
@@ -188,8 +192,10 @@ class DecodedLunarYears:
     The returned record is rebuilt per call (with a fresh `days_counts` list), so mutating
     it cannot poison the cache. The other values are immutable and safe to share.
     '''
-    assert isinstance(lunar_year, int)
-    assert lunar_year in self.supported_year_range()
+    if not isinstance(lunar_year, int):
+      raise TypeError(f'Expected int, got {type(lunar_year)}')
+    if lunar_year not in self.supported_year_range():
+      raise ValueError(f'Year {lunar_year} is out of the supported range {self.supported_year_range()}')
     info: LunarYearInfo = self.__cached_info(lunar_year)
     return LunarYearInfo(
       first_solar_day=info['first_solar_day'],

--- a/src/calendar/hko_data/decoder.py
+++ b/src/calendar/hko_data/decoder.py
@@ -73,6 +73,8 @@ class DecodedJieqiDates:
 
   def __getitem__(self, year: int) -> JieqiDates:
     '''Note: `year` means Gregorian/Solar year / 公历年'''
+    if not isinstance(year, int):
+      raise TypeError(f'Expected int, got {type(year)}')
     if year not in self.supported_year_range():
       raise ValueError(f'Year {year} is out of the supported range {self.supported_year_range()}')
 
@@ -90,6 +92,8 @@ class DecodedJieqiDates:
 
     Note: `year` means Gregorian/Solar year / 公历年
     '''
+    if not isinstance(year, int):
+      raise TypeError(f'Expected int, got {type(year)}')
     if year not in self.supported_year_range():
       raise ValueError(f'Year {year} is out of the supported range {self.supported_year_range()}')
     return self[year][jieqi]

--- a/src/calendar/hko_data_utils.py
+++ b/src/calendar/hko_data_utils.py
@@ -170,7 +170,8 @@ def days_counts_in_ganzhi_year(ganzhi_year: int) -> list[int]:
 @functools.lru_cache(maxsize=512)
 def __days_counts_in_ganzhi_year(ganzhi_year: int) -> tuple[int, ...]:
   if ganzhi_year > get_max_supported_date(CalendarType.GANZHI).year:
-    raise ValueError(f'Ganzhi year {ganzhi_year} is out of the supported range (last supported: {get_max_supported_date(CalendarType.GANZHI).year})')
+    raise ValueError(f'Ganzhi year {ganzhi_year} is out of the supported range '
+                     f'[{get_min_supported_date(CalendarType.GANZHI).year}, {get_max_supported_date(CalendarType.GANZHI).year}]')
 
   jieqi_list: list[Jieqi] = Jieqi.as_list()[::2] # Pick the Jieqis when new months start.
   assert jieqi_list[0] == Jieqi.立春 # The first jieqi in every year should be 立春.

--- a/src/calendar/hko_data_utils.py
+++ b/src/calendar/hko_data_utils.py
@@ -24,9 +24,10 @@ def get_min_supported_date(date_type: CalendarType) -> CalendarDate:
     return CalendarDate(1901, 2, 19, CalendarType.SOLAR)
   elif date_type == CalendarType.LUNAR:
     return CalendarDate(1901, 1, 1, CalendarType.LUNAR)
-  else:
-    assert date_type == CalendarType.GANZHI
+  elif date_type == CalendarType.GANZHI:
     return CalendarDate(1901, 1, 16, CalendarType.GANZHI)
+  else:
+    raise ValueError(f'Unsupported date_type: {date_type}')
   
 
 @functools.lru_cache(maxsize=512)
@@ -36,9 +37,10 @@ def get_max_supported_date(date_type: CalendarType) -> CalendarDate:
     return CalendarDate(2099, 12, 31, CalendarType.SOLAR)
   elif date_type == CalendarType.LUNAR:
     return CalendarDate(2099, 12, 20, CalendarType.LUNAR) # 2099 is a leap year on lunar calendar.
-  else:
-    assert date_type == CalendarType.GANZHI
+  elif date_type == CalendarType.GANZHI:
     return CalendarDate(2099, 11, 25, CalendarType.GANZHI)
+  else:
+    raise ValueError(f'Unsupported date_type: {date_type}')
 
 
 @functools.lru_cache(maxsize=512)
@@ -167,7 +169,8 @@ def days_counts_in_ganzhi_year(ganzhi_year: int) -> list[int]:
 
 @functools.lru_cache(maxsize=512)
 def __days_counts_in_ganzhi_year(ganzhi_year: int) -> tuple[int, ...]:
-  assert ganzhi_year <= get_max_supported_date(CalendarType.GANZHI).year
+  if ganzhi_year > get_max_supported_date(CalendarType.GANZHI).year:
+    raise ValueError(f'Ganzhi year {ganzhi_year} is out of the supported range (last supported: {get_max_supported_date(CalendarType.GANZHI).year})')
 
   jieqi_list: list[Jieqi] = Jieqi.as_list()[::2] # Pick the Jieqis when new months start.
   assert jieqi_list[0] == Jieqi.立春 # The first jieqi in every year should be 立春.
@@ -188,8 +191,11 @@ def __days_counts_in_ganzhi_year(ganzhi_year: int) -> tuple[int, ...]:
 
 @functools.lru_cache(maxsize=512)
 def lunar_to_solar(lunar_date: CalendarDate) -> CalendarDate:
-  assert lunar_date.date_type == CalendarType.LUNAR
-  assert is_valid(lunar_date)
+  if lunar_date.date_type != CalendarType.LUNAR:
+    raise ValueError(f'Expected a LUNAR date, got {lunar_date}')
+  if not is_valid(lunar_date):
+    raise ValueError(f'"{lunar_date}" is not a valid {lunar_date.date_type.name} date in the supported range '
+                     f'[{get_min_supported_date(lunar_date.date_type)}, {get_max_supported_date(lunar_date.date_type)}]')
   info: LunarYearInfo = lunar_years_db.get(lunar_date.year)
 
   passed_days_count: int = -1
@@ -204,8 +210,11 @@ def lunar_to_solar(lunar_date: CalendarDate) -> CalendarDate:
 
 @functools.lru_cache(maxsize=512)
 def solar_to_lunar(solar_date: CalendarDate) -> CalendarDate:
-  assert solar_date.date_type == CalendarType.SOLAR
-  assert is_valid(solar_date)
+  if solar_date.date_type != CalendarType.SOLAR:
+    raise ValueError(f'Expected a SOLAR date, got {solar_date}')
+  if not is_valid(solar_date):
+    raise ValueError(f'"{solar_date}" is not a valid {solar_date.date_type.name} date in the supported range '
+                     f'[{get_min_supported_date(solar_date.date_type)}, {get_max_supported_date(solar_date.date_type)}]')
 
   # First, figure out the solar date falls into which lunar year.
   lunar_year: int = solar_date.year
@@ -232,8 +241,11 @@ def solar_to_lunar(solar_date: CalendarDate) -> CalendarDate:
 
 @functools.lru_cache(maxsize=512)
 def ganzhi_to_solar(ganzhi_date: CalendarDate) -> CalendarDate:
-  assert ganzhi_date.date_type == CalendarType.GANZHI
-  assert is_valid(ganzhi_date)
+  if ganzhi_date.date_type != CalendarType.GANZHI:
+    raise ValueError(f'Expected a GANZHI date, got {ganzhi_date}')
+  if not is_valid(ganzhi_date):
+    raise ValueError(f'"{ganzhi_date}" is not a valid {ganzhi_date.date_type.name} date in the supported range '
+                     f'[{get_min_supported_date(ganzhi_date.date_type)}, {get_max_supported_date(ganzhi_date.date_type)}]')
 
   # Figure out how many days have passed in the ganzhi year.
   days_counts: list[int] = days_counts_in_ganzhi_year(ganzhi_date.year)
@@ -250,8 +262,11 @@ def ganzhi_to_solar(ganzhi_date: CalendarDate) -> CalendarDate:
 
 @functools.lru_cache(maxsize=512)
 def solar_to_ganzhi(solar_date: CalendarDate) -> CalendarDate:
-  assert solar_date.date_type == CalendarType.SOLAR
-  assert is_valid(solar_date)
+  if solar_date.date_type != CalendarType.SOLAR:
+    raise ValueError(f'Expected a SOLAR date, got {solar_date}')
+  if not is_valid(solar_date):
+    raise ValueError(f'"{solar_date}" is not a valid {solar_date.date_type.name} date in the supported range '
+                     f'[{get_min_supported_date(solar_date.date_type)}, {get_max_supported_date(solar_date.date_type)}]')
 
   # Figure out the ganzhi date falls into which ganzhi year.
   ganzhi_year: int = solar_date.year
@@ -276,8 +291,11 @@ def solar_to_ganzhi(solar_date: CalendarDate) -> CalendarDate:
 
 @functools.lru_cache(maxsize=512)
 def lunar_to_ganzhi(lunar_date: CalendarDate) -> CalendarDate:
-  assert lunar_date.date_type == CalendarType.LUNAR
-  assert is_valid(lunar_date)
+  if lunar_date.date_type != CalendarType.LUNAR:
+    raise ValueError(f'Expected a LUNAR date, got {lunar_date}')
+  if not is_valid(lunar_date):
+    raise ValueError(f'"{lunar_date}" is not a valid {lunar_date.date_type.name} date in the supported range '
+                     f'[{get_min_supported_date(lunar_date.date_type)}, {get_max_supported_date(lunar_date.date_type)}]')
 
   solar_date: CalendarDate = lunar_to_solar(lunar_date)
   return solar_to_ganzhi(solar_date)
@@ -285,8 +303,11 @@ def lunar_to_ganzhi(lunar_date: CalendarDate) -> CalendarDate:
 
 @functools.lru_cache(maxsize=512)
 def ganzhi_to_lunar(ganzhi_date: CalendarDate) -> CalendarDate:
-  assert ganzhi_date.date_type == CalendarType.GANZHI
-  assert is_valid(ganzhi_date)
+  if ganzhi_date.date_type != CalendarType.GANZHI:
+    raise ValueError(f'Expected a GANZHI date, got {ganzhi_date}')
+  if not is_valid(ganzhi_date):
+    raise ValueError(f'"{ganzhi_date}" is not a valid {ganzhi_date.date_type.name} date in the supported range '
+                     f'[{get_min_supported_date(ganzhi_date.date_type)}, {get_max_supported_date(ganzhi_date.date_type)}]')
 
   solar_date: CalendarDate = ganzhi_to_solar(ganzhi_date)
   return solar_to_lunar(solar_date)
@@ -296,11 +317,14 @@ def ganzhi_to_lunar(ganzhi_date: CalendarDate) -> CalendarDate:
 def __to_calendardate(d: date | CalendarDate) -> CalendarDate:
   if isinstance(d, date):
     ret = CalendarDate(d.year, d.month, d.day, CalendarType.SOLAR)
-  else:
-    assert isinstance(d, CalendarDate)
+  elif isinstance(d, CalendarDate):
     ret = d
+  else:
+    raise TypeError(f'Expected date or CalendarDate, got {type(d)}')
 
-  assert is_valid(ret)
+  if not is_valid(ret):
+    raise ValueError(f'"{ret}" is not a valid {ret.date_type.name} date in the supported range '
+                     f'[{get_min_supported_date(ret.date_type)}, {get_max_supported_date(ret.date_type)}]')
   return ret
 
 
@@ -403,10 +427,13 @@ def jieqi_date(solar_year: int, jieqi: Jieqi) -> date:
   Return: (date) The date of the Jieqi in the given solar/gregorian year.
   '''
 
-  assert isinstance(solar_year, int)
-  assert isinstance(jieqi, Jieqi)
+  if not isinstance(solar_year, int):
+    raise TypeError(f'Expected int, got {type(solar_year)}')
+  if not isinstance(jieqi, Jieqi):
+    raise TypeError(f'Expected Jieqi, got {type(jieqi)}')
 
-  assert solar_year in jieqi_dates_db.supported_year_range()
+  if solar_year not in jieqi_dates_db.supported_year_range():
+    raise ValueError(f'Year {solar_year} is out of the supported range {jieqi_dates_db.supported_year_range()}')
   return jieqi_dates_db.get(solar_year, jieqi)
 
 
@@ -428,10 +455,13 @@ def jieqi_moment(solar_year: int, jieqi: Jieqi) -> datetime:
   Return: (datetime) The accurate moment of the Jieqi in the given solar/gregorian year.
   '''
 
-  assert isinstance(solar_year, int)
-  assert isinstance(jieqi, Jieqi)
+  if not isinstance(solar_year, int):
+    raise TypeError(f'Expected int, got {type(solar_year)}')
+  if not isinstance(jieqi, Jieqi):
+    raise TypeError(f'Expected Jieqi, got {type(jieqi)}')
 
-  assert solar_year in jieqi_dates_db.supported_year_range()
+  if solar_year not in jieqi_dates_db.supported_year_range():
+    raise ValueError(f'Year {solar_year} is out of the supported range {jieqi_dates_db.supported_year_range()}')
   dt: date = jieqi_dates_db.get(solar_year, jieqi)
   return datetime.combine(dt, time(0, 0, 0))
 
@@ -471,7 +501,8 @@ def prev_jie(dt: datetime) -> JieqiTime:
     - return: (Jieqi.大雪, jieqi_moment(2023, Jieqi.大雪))
   '''
 
-  assert isinstance(dt, datetime)
+  if not isinstance(dt, datetime):
+    raise TypeError(f'Expected datetime, got {type(dt)}')
 
   supported_jie_range: tuple[datetime, datetime] = supported_jie_boundaries()
   if dt < supported_jie_range[0]:
@@ -515,7 +546,8 @@ def next_jie(dt: datetime) -> JieqiTime:
     - return: (Jieqi.小寒, jieqi_moment(2024, Jieqi.小寒))
   '''
 
-  assert isinstance(dt, datetime)
+  if not isinstance(dt, datetime):
+    raise TypeError(f'Expected datetime, got {type(dt)}')
 
   supported_jie_range: tuple[datetime, datetime] = supported_jie_boundaries()
   if dt < supported_jie_range[0]:

--- a/src/defines/enum_base.py
+++ b/src/defines/enum_base.py
@@ -35,10 +35,11 @@ class BaziEnum(Enum):
 
   @classmethod
   def from_str(cls, s: str) -> Self:
-    assert isinstance(s, str)
+    if not isinstance(s, str):
+      raise TypeError(f'Expected str, got {type(s)}')
     expected_len = cls._str_len()
-    if expected_len is not None:
-      assert len(s) == expected_len
+    if expected_len is not None and len(s) != expected_len:
+      raise ValueError(f'Unsupported {cls.__name__} string: {s}')
     return cls(s)
 
   @classmethod

--- a/src/defines/ganzhi.py
+++ b/src/defines/ganzhi.py
@@ -19,7 +19,8 @@ class Ganzhi(NamedTuple):
   
   @classmethod
   def from_str(cls, tiangan_dizhi_str: str) -> 'Ganzhi':
-    assert len(tiangan_dizhi_str) == 2
+    if len(tiangan_dizhi_str) != 2:
+      raise ValueError(f'Unsupported Ganzhi string: {tiangan_dizhi_str}')
     return cls(Tiangan.from_str(tiangan_dizhi_str[0]), Dizhi.from_str(tiangan_dizhi_str[1]))
   
   def __str__(self) -> str:
@@ -51,13 +52,15 @@ class Ganzhi(NamedTuple):
 
   @functools.lru_cache(maxsize=1024)
   def next(self, step: int = 1) -> 'Ganzhi':
-    assert isinstance(step, int)
+    if not isinstance(step, int):
+      raise TypeError(f'Expected int, got {type(step)}')
     cycle: list[Ganzhi] = Ganzhi.list_sexagenary_cycle()
     return cycle[(cycle.index(self) + step) % 60]
 
   @functools.lru_cache(maxsize=1024)
   def prev(self, step: int = 1) -> 'Ganzhi':
-    assert isinstance(step, int)
+    if not isinstance(step, int):
+      raise TypeError(f'Expected int, got {type(step)}')
     cycle: list[Ganzhi] = Ganzhi.list_sexagenary_cycle()
     return cycle[(cycle.index(self) - step) % 60]
 

--- a/src/defines/shishen.py
+++ b/src/defines/shishen.py
@@ -52,12 +52,15 @@ class Shishen(BaziEnum):
   def from_str(cls, s: str) -> Self:
     # Overrides the base: also accepts the single-char aliases (e.g. '比' -> 比肩).
     # 覆盖基类：额外接受单字别名。
-    assert isinstance(s, str)
-    assert len(s) in [1, 2]
+    if not isinstance(s, str):
+      raise TypeError(f'Expected str, got {type(s)}')
+    if len(s) not in [1, 2]:
+      raise ValueError(f'Unsupported Shishen string: {s}')
 
     if len(s) == 1:
       t: dict[str, str] = Shishen.str_mapping_table()
-      assert s in t
+      if s not in t:
+        raise ValueError(f'Unsupported Shishen string: {s}')
       s = t[s]
 
     return cls(s)

--- a/src/interpreter.py
+++ b/src/interpreter.py
@@ -32,7 +32,8 @@ class Interpreter:
     Returns:
     - (ShishenDescription) A deep copy of the corpus entry. / 语料库对应条目的深拷贝。
     '''
-    assert isinstance(shishen, Shishen)
+    if not isinstance(shishen, Shishen):
+      raise TypeError(f'Expected Shishen, got {type(shishen)}')
     return copy.deepcopy(SHISHEN_DESCRIPTIONS[shishen])
 
   @staticmethod
@@ -47,5 +48,6 @@ class Interpreter:
     Returns:
     - (TianganDescription) A deep copy of the corpus entry. / 语料库对应条目的深拷贝。
     '''
-    assert isinstance(tg, Tiangan)
+    if not isinstance(tg, Tiangan):
+      raise TypeError(f'Expected Tiangan, got {type(tg)}')
     return copy.deepcopy(TIANGAN_DESCRIPTIONS[tg])

--- a/src/transit_chart.py
+++ b/src/transit_chart.py
@@ -26,7 +26,8 @@ class TransitChart:
     - `bazi_chart`: (BaziChart) The bazi chart (原盘) to generate the transit chart from.
     '''
 
-    assert isinstance(bazi_chart, BaziChart)
+    if not isinstance(bazi_chart, BaziChart):
+      raise TypeError(f'Expected BaziChart, got {type(bazi_chart)}')
     self._bazi_chart: Final[BaziChart] = bazi_chart
     self._transit_db: Final[TransitDatabase] = TransitDatabase(self._bazi_chart)
 
@@ -51,10 +52,13 @@ class TransitChart:
     Note: raises `NotImplementedError` for month/day-granularity moments until #48. / 注意：#48 落地前，月/日粒度的 moment 会抛 `NotImplementedError`。
     '''
 
-    assert isinstance(moment, TransitMoment)
-    assert isinstance(options, TransitOptions)
+    if not isinstance(moment, TransitMoment):
+      raise TypeError(f'Expected TransitMoment, got {type(moment)}')
+    if not isinstance(options, TransitOptions):
+      raise TypeError(f'Expected TransitOptions, got {type(options)}')
     # `options in TransitOptions` rejects unnamed composites on Python 3.11; check the enumerated space instead.
-    assert options in _ALL_OPTIONS
+    if options not in _ALL_OPTIONS:
+      raise ValueError(f'Unsupported options: {options}')
     return self._transit_db.support(moment, options)
 
   def ganzhis(self, moment: TransitMoment, options: TransitOptions) -> tuple[Ganzhi, ...]:
@@ -71,10 +75,13 @@ class TransitChart:
     Note: raises `NotImplementedError` for month/day-granularity moments until #48 (via `TransitDatabase`). / 注意：#48 落地前，月/日粒度的 moment 会抛 `NotImplementedError`（经 `TransitDatabase` 冒出）。
     '''
 
-    assert isinstance(moment, TransitMoment)
-    assert isinstance(options, TransitOptions)
+    if not isinstance(moment, TransitMoment):
+      raise TypeError(f'Expected TransitMoment, got {type(moment)}')
+    if not isinstance(options, TransitOptions):
+      raise TypeError(f'Expected TransitOptions, got {type(options)}')
     # `options in TransitOptions` rejects unnamed composites on Python 3.11; check the enumerated space instead.
-    assert options in _ALL_OPTIONS
+    if options not in _ALL_OPTIONS:
+      raise ValueError(f'Unsupported options: {options}')
     return self._transit_db.ganzhis(moment, options)
 
 

--- a/src/transits.py
+++ b/src/transits.py
@@ -24,8 +24,10 @@ class DayunDatabase:
     self._step: Final[int] = 1 if chart.dayun_order else -1
 
   def __getitem__(self, gz_year: int) -> DayunTuple:
-    assert isinstance(gz_year, int)
-    assert gz_year >= self._first_dayun.ganzhi_year
+    if not isinstance(gz_year, int):
+      raise TypeError(f'Expected int, got {type(gz_year)}')
+    if gz_year < self._first_dayun.ganzhi_year:
+      raise ValueError(f'Year {gz_year} is before the first dayun year {self._first_dayun.ganzhi_year}')
 
     # Dayuns are arithmetic: each lasts 10 years and steps the sexagenary cycle by one.
     # 大运是等差序列：每运十年，六十甲子进（退）一位，直接按下标闭式计算。
@@ -60,12 +62,16 @@ class TransitMoment:
     # semantics (a `datetime` never equals a `date`, and their hashes differ), so require
     # the exact type here. 运行时类型检查。datetime 是 date 的子类但破坏值语义（不相等、
     # hash 不同），故此处要求精确类型。
-    assert isinstance(self.gz_year, int)
-    assert self.gz_month is None or isinstance(self.gz_month, Dizhi)
-    assert self.solar_date is None or type(self.solar_date) is date
+    if not isinstance(self.gz_year, int):
+      raise TypeError(f'Expected int, got {type(self.gz_year)}')
+    if self.gz_month is not None and not isinstance(self.gz_month, Dizhi):
+      raise TypeError(f'Expected Dizhi, got {type(self.gz_month)}')
+    if self.solar_date is not None and type(self.solar_date) is not date:
+      raise TypeError(f'Expected date (not datetime), got {type(self.solar_date)}')
     # The month and day granularities are mutually exclusive: a day's Ganzhi is fully
     # determined by `solar_date`, no `gz_month` needed. 月粒度与日粒度互斥（日柱由 solar_date 唯一确定）。
-    assert not (self.gz_month is not None and self.solar_date is not None)
+    if self.gz_month is not None and self.solar_date is not None:
+      raise ValueError(f'gz_month and solar_date are mutually exclusive: {self}')
 
 
 def _ensure_year_moment(moment: TransitMoment) -> None:
@@ -140,11 +146,14 @@ class TransitDatabase:
     Note: raises `NotImplementedError` for month/day-granularity moments until #48. / 注意：#48 落地前，月/日粒度的 moment 会抛 `NotImplementedError`。
     '''
 
-    assert isinstance(moment, TransitMoment)
-    assert isinstance(options, TransitOptions)
+    if not isinstance(moment, TransitMoment):
+      raise TypeError(f'Expected TransitMoment, got {type(moment)}')
+    if not isinstance(options, TransitOptions):
+      raise TypeError(f'Expected TransitOptions, got {type(options)}')
     # `options in TransitOptions` rejects unnamed composites (e.g. XIAOYUN|DAYUN) on
     # Python 3.11 (EnumType.__contains__ semantics), so check the enumerated space instead.
-    assert options in _ALL_OPTIONS
+    if options not in _ALL_OPTIONS:
+      raise ValueError(f'Unsupported options: {options}')
     _ensure_year_moment(moment)
 
     gz_year: Final[int] = moment.gz_year
@@ -172,10 +181,13 @@ class TransitDatabase:
     Note: raises `NotImplementedError` for month/day-granularity moments until #48 (via `support`). / 注意：#48 落地前，月/日粒度的 moment 会抛 `NotImplementedError`（经 `support` 冒出）。
     '''
 
-    assert isinstance(moment, TransitMoment)
-    assert isinstance(options, TransitOptions)
+    if not isinstance(moment, TransitMoment):
+      raise TypeError(f'Expected TransitMoment, got {type(moment)}')
+    if not isinstance(options, TransitOptions):
+      raise TypeError(f'Expected TransitOptions, got {type(options)}')
     # See `support` for why `_ALL_OPTIONS` instead of `options in TransitOptions` (3.11 semantics).
-    assert options in _ALL_OPTIONS
+    if options not in _ALL_OPTIONS:
+      raise ValueError(f'Unsupported options: {options}')
 
     if not self.support(moment, options):
       raise ValueError(f'Inputs not supported. Moment: {moment}, options: {options}')

--- a/src/utils/bazi_utils.py
+++ b/src/utils/bazi_utils.py
@@ -19,7 +19,8 @@ def ganzhi_of_day(dt: date) -> Ganzhi:
   Return: (Ganzhi) The Day Ganzhi (日柱).
   '''
 
-  assert isinstance(dt, date)
+  if not isinstance(dt, date):
+    raise TypeError(f'Expected date, got {type(dt)}')
   if isinstance(dt, datetime):
     # `dt` is a datetime object. Convert it to a date object.
     dt = date(dt.year, dt.month, dt.day)
@@ -40,7 +41,8 @@ def ganzhi_of_year(ganzhi_year: int) -> Ganzhi:
   Return: (Ganzhi) The Ganzhi of the given ganzhi year in the sexagenary cycle.
   '''
 
-  assert isinstance(ganzhi_year, int)
+  if not isinstance(ganzhi_year, int):
+    raise TypeError(f'Expected int, got {type(ganzhi_year)}')
   return Ganzhi(Tiangan.甲, Dizhi.子).next(ganzhi_year - 1984) # 1984 is the year of "甲子".
 
 
@@ -56,8 +58,10 @@ def month_tiangan(year_tiangan: Tiangan, month_dizhi: Dizhi) -> Tiangan:
   Return: (Tiangan) The Tiangan of the Month Ganzhi (月柱天干).
   '''
 
-  assert isinstance(year_tiangan, Tiangan)
-  assert isinstance(month_dizhi, Dizhi)
+  if not isinstance(year_tiangan, Tiangan):
+    raise TypeError(f'Expected Tiangan, got {type(year_tiangan)}')
+  if not isinstance(month_dizhi, Dizhi):
+    raise TypeError(f'Expected Dizhi, got {type(month_dizhi)}')
 
   month_index: int = (month_dizhi.index - 2) % 12 # First month is "寅".
   first_month_tiangan: Tiangan = BaziRules.YEAR_TO_MONTH_TABLE[year_tiangan]
@@ -77,8 +81,10 @@ def hour_tiangan(day_tiangan: Tiangan, hour_dizhi: Dizhi) -> Tiangan:
   Return: (Tiangan) The Tiangan of the Hour Ganzhi (时柱天干).
   '''
 
-  assert isinstance(day_tiangan, Tiangan)
-  assert isinstance(hour_dizhi, Dizhi)
+  if not isinstance(day_tiangan, Tiangan):
+    raise TypeError(f'Expected Tiangan, got {type(day_tiangan)}')
+  if not isinstance(hour_dizhi, Dizhi):
+    raise TypeError(f'Expected Dizhi, got {type(hour_dizhi)}')
 
   hour_index: int = hour_dizhi.index
   first_hour_tiangan: Tiangan = BaziRules.DAY_TO_HOUR_TABLE[day_tiangan]
@@ -97,7 +103,8 @@ def tiangan_traits(tg: Tiangan) -> TraitTuple:
   Return: (TraitTuple) The Wuxing and Yinyang of the given Tiangan.
   '''
 
-  assert isinstance(tg, Tiangan)
+  if not isinstance(tg, Tiangan):
+    raise TypeError(f'Expected Tiangan, got {type(tg)}')
   return BaziRules.TIANGAN_TRAITS[tg]
 
 
@@ -112,7 +119,8 @@ def dizhi_traits(dz: Dizhi) -> TraitTuple:
   Return: (TraitTuple) The Wuxing and Yinyang of the given Dizhi.
   '''
 
-  assert isinstance(dz, Dizhi)
+  if not isinstance(dz, Dizhi):
+    raise TypeError(f'Expected Dizhi, got {type(dz)}')
   return BaziRules.DIZHI_TRAITS[dz]
 
 
@@ -127,7 +135,8 @@ def traits(tg_or_dz: Tiangan | Dizhi) -> TraitTuple:
   Return: (TraitTuple) The Wuxing and Yinyang of the given Tiangan or Dizhi.
   '''
 
-  assert isinstance(tg_or_dz, (Tiangan, Dizhi))
+  if not isinstance(tg_or_dz, (Tiangan, Dizhi)):
+    raise TypeError(f'Expected Tiangan or Dizhi, got {type(tg_or_dz)}')
   if isinstance(tg_or_dz, Tiangan):
     return tiangan_traits(tg_or_dz)
   else:
@@ -146,7 +155,8 @@ def hidden_tiangans(dz: Dizhi) -> HiddenTianganDict:
   Return: (HiddenTianganDict) The percentage of hidden Tiangans in the given Dizhi.
   '''
 
-  assert isinstance(dz, Dizhi)
+  if not isinstance(dz, Dizhi):
+    raise TypeError(f'Expected Dizhi, got {type(dz)}')
   return BaziRules.HIDDEN_TIANGANS[dz]
 
 
@@ -167,8 +177,10 @@ def shishen(day_master: Tiangan, other: Tiangan | Dizhi) -> Shishen:
   - shishen(Tiangan("壬"), Dizhi("戌")) -> Shishen("七杀")  # "戌" is the "七杀" of "壬".
   '''
 
-  assert isinstance(day_master, Tiangan)
-  assert isinstance(other, (Tiangan, Dizhi))
+  if not isinstance(day_master, Tiangan):
+    raise TypeError(f'Expected Tiangan, got {type(day_master)}')
+  if not isinstance(other, (Tiangan, Dizhi)):
+    raise TypeError(f'Expected Tiangan or Dizhi, got {type(other)}')
 
   def __find_tg() -> Tiangan:
     if isinstance(other, Tiangan):
@@ -229,7 +241,8 @@ def nayin_str(gz: Ganzhi) -> str:
   - nayin_str(Ganzhi.from_str("甲子")) -> "海中金"
   '''
 
-  assert isinstance(gz, Ganzhi)
+  if not isinstance(gz, Ganzhi):
+    raise TypeError(f'Expected Ganzhi, got {type(gz)}')
   
   tg, dz = gz
   tg_traits, dz_traits = traits(tg), traits(dz)
@@ -255,8 +268,10 @@ def shier_zhangsheng(tg: Tiangan, dz: Dizhi) -> ShierZhangsheng:
   - shier_zhangsheng(Tiangan.辛, Dizhi.丑) -> ShierZhangsheng.养
   '''
   
-  assert isinstance(tg, Tiangan)
-  assert isinstance(dz, Dizhi)
+  if not isinstance(tg, Tiangan):
+    raise TypeError(f'Expected Tiangan, got {type(tg)}')
+  if not isinstance(dz, Dizhi):
+    raise TypeError(f'Expected Dizhi, got {type(dz)}')
 
   tg_yinyang: Yinyang = traits(tg).yinyang
   zhangsheng_place: Dizhi = BaziRules.TIANGAN_ZHANGSHENG[tg]
@@ -288,8 +303,10 @@ def from_shier_zhangsheng(tg: Tiangan, place: ShierZhangsheng) -> Dizhi:
   - from_shier_zhangsheng(Tiangan.辛, ShierZhangsheng.养) -> Dizhi.丑
   '''
 
-  assert isinstance(tg, Tiangan)
-  assert isinstance(place, ShierZhangsheng)
+  if not isinstance(tg, Tiangan):
+    raise TypeError(f'Expected Tiangan, got {type(tg)}')
+  if not isinstance(place, ShierZhangsheng):
+    raise TypeError(f'Expected ShierZhangsheng, got {type(place)}')
 
   tg_yinyang: Yinyang = traits(tg).yinyang
   zhangsheng_dizhi: Dizhi = BaziRules.TIANGAN_ZHANGSHENG[tg]
@@ -311,5 +328,6 @@ def lu(tg: Tiangan) -> Dizhi:
   - lu(Tiangan.甲) -> Dizhi.寅
   '''
 
-  assert isinstance(tg, Tiangan)
+  if not isinstance(tg, Tiangan):
+    raise TypeError(f'Expected Tiangan, got {type(tg)}')
   return BaziRules.TIANGAN_LU[tg]

--- a/src/utils/dizhi_utils.py
+++ b/src/utils/dizhi_utils.py
@@ -465,7 +465,8 @@ def search(dizhis: Sequence[Dizhi], relation: DizhiRelation) -> DizhiRelationCom
   - 举例来说，即使输入中只有丑、未，也符合相刑关系（缺少戌，但 `LOOSE` 定义只要求三个地支中出现两个）。
 
   Args:
-  - dizhis: (Sequence[Dizhi]) The Dizhis to check.
+  - dizhis: (Sequence[Dizhi]) The Dizhis to check. A sequence rather than a set --
+    the frequency of Dizhis matters.
   - relation: (DizhiRelation) The relation to check.
 
   Return: (DizhiRelationCombos) The result containing all matching Dizhi combos.
@@ -490,7 +491,7 @@ def search(dizhis: Sequence[Dizhi], relation: DizhiRelation) -> DizhiRelationCom
   if not isinstance(relation, DizhiRelation):
     raise TypeError(f'Expected DizhiRelation, got {type(relation)}')
   if not isinstance(dizhis, Sequence):
-    raise TypeError(f"Expected a Sequence, got {type(dizhis)} (non-sequence input loses the info of Dizhis' frequency)")
+    raise TypeError(f'Expected a Sequence, got {type(dizhis)}')
   if not all(isinstance(dz, Dizhi) for dz in dizhis):
     raise TypeError(f'Expected all Dizhi, got {[type(dz) for dz in dizhis]}')
 

--- a/src/utils/dizhi_utils.py
+++ b/src/utils/dizhi_utils.py
@@ -49,7 +49,8 @@ def sanhui(dz1: Dizhi, dz2: Dizhi, dz3: Dizhi) -> Wuxing | None:
     - return: None
   '''
 
-  assert all(isinstance(dz, Dizhi) for dz in (dz1, dz2, dz3))
+  if not all(isinstance(dz, Dizhi) for dz in (dz1, dz2, dz3)):
+    raise TypeError(f'Expected all Dizhi, got {[type(dz) for dz in (dz1, dz2, dz3)]}')
   combo: DizhiCombo = DizhiCombo((dz1, dz2, dz3))
   return DizhiRules.DIZHI_SANHUI.get(combo, None)
 
@@ -74,7 +75,8 @@ def liuhe(dz1: Dizhi, dz2: Dizhi) -> Wuxing | None:
     - return: None
   '''
 
-  assert all(isinstance(dz, Dizhi) for dz in (dz1, dz2))
+  if not all(isinstance(dz, Dizhi) for dz in (dz1, dz2)):
+    raise TypeError(f'Expected all Dizhi, got {[type(dz) for dz in (dz1, dz2)]}')
   combo: DizhiCombo = DizhiCombo((dz1, dz2))
   return DizhiRules.DIZHI_LIUHE.get(combo, None)
 
@@ -104,8 +106,10 @@ def anhe(dz1: Dizhi, dz2: Dizhi, *, definition: DizhiRules.AnheDef = DizhiRules.
     - return: False
   '''
 
-  assert all(isinstance(dz, Dizhi) for dz in (dz1, dz2))
-  assert isinstance(definition, DizhiRules.AnheDef)
+  if not all(isinstance(dz, Dizhi) for dz in (dz1, dz2)):
+    raise TypeError(f'Expected all Dizhi, got {[type(dz) for dz in (dz1, dz2)]}')
+  if not isinstance(definition, DizhiRules.AnheDef):
+    raise TypeError(f'Expected AnheDef, got {type(definition)}')
   combo: DizhiCombo = DizhiCombo((dz1, dz2))
   return combo in DizhiRules.DIZHI_ANHE[definition]
 
@@ -129,7 +133,8 @@ def tonghe(dz1: Dizhi, dz2: Dizhi) -> bool:
     - return: True
   '''
 
-  assert all(isinstance(dz, Dizhi) for dz in (dz1, dz2))
+  if not all(isinstance(dz, Dizhi) for dz in (dz1, dz2)):
+    raise TypeError(f'Expected all Dizhi, got {[type(dz) for dz in (dz1, dz2)]}')
   combo: DizhiCombo = DizhiCombo((dz1, dz2))
   return combo in DizhiRules.DIZHI_TONGHE
 
@@ -153,7 +158,8 @@ def tongluhe(dz1: Dizhi, dz2: Dizhi) -> bool:
     - return: False
   '''
 
-  assert all(isinstance(dz, Dizhi) for dz in (dz1, dz2))
+  if not all(isinstance(dz, Dizhi) for dz in (dz1, dz2)):
+    raise TypeError(f'Expected all Dizhi, got {[type(dz) for dz in (dz1, dz2)]}')
   combo: DizhiCombo = DizhiCombo((dz1, dz2))
   return combo in DizhiRules.DIZHI_TONGLUHE
 
@@ -177,7 +183,8 @@ def sanhe(dz1: Dizhi, dz2: Dizhi, dz3: Dizhi) -> Wuxing | None:
     - return: None
   '''
 
-  assert all(isinstance(dz, Dizhi) for dz in (dz1, dz2, dz3))
+  if not all(isinstance(dz, Dizhi) for dz in (dz1, dz2, dz3)):
+    raise TypeError(f'Expected all Dizhi, got {[type(dz) for dz in (dz1, dz2, dz3)]}')
   combo: DizhiCombo = DizhiCombo((dz1, dz2, dz3))
   return DizhiRules.DIZHI_SANHE.get(combo, None)
 
@@ -202,7 +209,8 @@ def banhe(dz1: Dizhi, dz2: Dizhi) -> Wuxing | None:
     - return: None
   '''
 
-  assert all(isinstance(dz, Dizhi) for dz in (dz1, dz2))
+  if not all(isinstance(dz, Dizhi) for dz in (dz1, dz2)):
+    raise TypeError(f'Expected all Dizhi, got {[type(dz) for dz in (dz1, dz2)]}')
   combo: DizhiCombo = DizhiCombo((dz1, dz2))
   return DizhiRules.DIZHI_BANHE.get(combo, None)
 
@@ -248,9 +256,12 @@ def xing(*dizhis: Dizhi, definition: DizhiRules.XingDef = DizhiRules.XingDef.LOO
     - return: None
   '''
 
-  assert all(isinstance(dz, Dizhi) for dz in dizhis)
-  assert len(dizhis) <= 3
-  assert isinstance(definition, DizhiRules.XingDef)
+  if not all(isinstance(dz, Dizhi) for dz in dizhis):
+    raise TypeError(f'Expected all Dizhi, got {[type(dz) for dz in dizhis]}')
+  if len(dizhis) > 3:
+    raise ValueError(f'Expected at most 3 Dizhis, got {len(dizhis)}')
+  if not isinstance(definition, DizhiRules.XingDef):
+    raise TypeError(f'Expected XingDef, got {type(definition)}')
 
   xing_rules: frozendict[tuple[Dizhi, ...], DizhiRules.XingSubType] = DizhiRules.DIZHI_XING[definition]
   return xing_rules.get(dizhis, None)
@@ -276,7 +287,8 @@ def chong(dz1: Dizhi, dz2: Dizhi) -> bool:
     - return: False
   '''
 
-  assert all(isinstance(dz, Dizhi) for dz in (dz1, dz2))
+  if not all(isinstance(dz, Dizhi) for dz in (dz1, dz2)):
+    raise TypeError(f'Expected all Dizhi, got {[type(dz) for dz in (dz1, dz2)]}')
   return DizhiCombo((dz1, dz2)) in DizhiRules.DIZHI_CHONG
 
 
@@ -302,7 +314,8 @@ def po(dz1: Dizhi, dz2: Dizhi) -> bool:
     - return: True
   '''
 
-  assert all(isinstance(dz, Dizhi) for dz in (dz1, dz2))
+  if not all(isinstance(dz, Dizhi) for dz in (dz1, dz2)):
+    raise TypeError(f'Expected all Dizhi, got {[type(dz) for dz in (dz1, dz2)]}')
   return DizhiCombo((dz1, dz2)) in DizhiRules.DIZHI_PO
 
 
@@ -328,7 +341,8 @@ def hai(dz1: Dizhi, dz2: Dizhi) -> bool:
     - return: True
   '''
 
-  assert all(isinstance(dz, Dizhi) for dz in (dz1, dz2))
+  if not all(isinstance(dz, Dizhi) for dz in (dz1, dz2)):
+    raise TypeError(f'Expected all Dizhi, got {[type(dz) for dz in (dz1, dz2)]}')
   return DizhiCombo((dz1, dz2)) in DizhiRules.DIZHI_HAI
 
 
@@ -358,7 +372,8 @@ def sheng(dz1: Dizhi, dz2: Dizhi) -> bool:
     - return: True
   '''
 
-  assert all(isinstance(dz, Dizhi) for dz in (dz1, dz2))
+  if not all(isinstance(dz, Dizhi) for dz in (dz1, dz2)):
+    raise TypeError(f'Expected all Dizhi, got {[type(dz) for dz in (dz1, dz2)]}')
   return (dz1, dz2) in DizhiRules.DIZHI_SHENG
 
 
@@ -388,7 +403,8 @@ def ke(dz1: Dizhi, dz2: Dizhi) -> bool:
     - return: False
   '''
 
-  assert all(isinstance(dz, Dizhi) for dz in (dz1, dz2))
+  if not all(isinstance(dz, Dizhi) for dz in (dz1, dz2)):
+    raise TypeError(f'Expected all Dizhi, got {[type(dz) for dz in (dz1, dz2)]}')
   return (dz1, dz2) in DizhiRules.DIZHI_KE
 
 
@@ -471,9 +487,12 @@ def search(dizhis: Sequence[Dizhi], relation: DizhiRelation) -> DizhiRelationCom
     - `DizhiRules.XingDef.LOOSE` is used.
   '''
 
-  assert isinstance(relation, DizhiRelation), f'Unexpected type of relation: {type(relation)}'
-  assert isinstance(dizhis, Sequence), "Non-sequence input loses the info of Dizhis' frequency."
-  assert all(isinstance(dz, Dizhi) for dz in dizhis)
+  if not isinstance(relation, DizhiRelation):
+    raise TypeError(f'Expected DizhiRelation, got {type(relation)}')
+  if not isinstance(dizhis, Sequence):
+    raise TypeError(f"Expected a Sequence, got {type(dizhis)} (non-sequence input loses the info of Dizhis' frequency)")
+  if not all(isinstance(dz, Dizhi) for dz in dizhis):
+    raise TypeError(f'Expected all Dizhi, got {[type(dz) for dz in dizhis]}')
 
   if relation is DizhiRelation.刑:
     # Multiset-sensitive, so plain subset tests don't apply: 自刑 needs the same Dizhi twice.
@@ -523,7 +542,8 @@ def discover(dizhis: Sequence[Dizhi]) -> DizhiRelationDiscovery:
   Return: (DizhiRelationDiscovery) The result containing all matching Dizhi combos. Note that returned combos don't reveal the directions.
   '''
 
-  assert all(isinstance(dz, Dizhi) for dz in dizhis)
+  if not all(isinstance(dz, Dizhi) for dz in dizhis):
+    raise TypeError(f'Expected all Dizhi, got {[type(dz) for dz in dizhis]}')
   return DizhiRelationDiscovery({
     rel : result
     for rel in DizhiRelation
@@ -564,8 +584,10 @@ def discover_mutual(dizhis1: Sequence[Dizhi], dizhis2: Sequence[Dizhi]) -> Dizhi
     - return: {} // Empty returned frozendict!
   '''
 
-  assert all(isinstance(dz, Dizhi) for dz in dizhis1)
-  assert all(isinstance(dz, Dizhi) for dz in dizhis2)
+  if not all(isinstance(dz, Dizhi) for dz in dizhis1):
+    raise TypeError(f'Expected all Dizhi, got {[type(dz) for dz in dizhis1]}')
+  if not all(isinstance(dz, Dizhi) for dz in dizhis2):
+    raise TypeError(f'Expected all Dizhi, got {[type(dz) for dz in dizhis2]}')
 
   # 自刑 depends on multiplicity (the same Dizhi appearing once on each side forms 自刑),
   # so the two sides CONCATENATE -- a set union would silently break it. Deliberately

--- a/src/utils/relation_discovery.py
+++ b/src/utils/relation_discovery.py
@@ -33,7 +33,7 @@ class RelationDiscovery(
     '''Merge two discoveries together (set-union of combos per relation).
     合并两个发现结果（每个关系下的组合做集合并）。'''
     if not isinstance(other, type(self)):
-      raise TypeError(f'Expected {type(self)}, got {type(other)}')
+      raise TypeError(f'Expected {type(self).__name__}, got {type(other)}')
     d: dict[RelationType, set[frozenset[RelationItemType]]] = {}
 
     for rel, combos in self.items():

--- a/src/utils/relation_discovery.py
+++ b/src/utils/relation_discovery.py
@@ -21,7 +21,8 @@ class RelationDiscovery(
   def filter(self, f: Callable[[RelationType, frozenset[RelationItemType]], bool]) -> Self:
     '''Keep only the combos accepted by `f`; relations left with no combo are dropped.
     只保留 `f` 接受的组合；不再有组合的关系整键丢弃。'''
-    assert callable(f)
+    if not callable(f):
+      raise TypeError(f'Expected a callable, got {type(f)}')
     return type(self)({
       rel : filtered
       for rel, combos in self.items()
@@ -31,7 +32,8 @@ class RelationDiscovery(
   def merge(self, other: Self) -> Self:
     '''Merge two discoveries together (set-union of combos per relation).
     合并两个发现结果（每个关系下的组合做集合并）。'''
-    assert isinstance(other, type(self))
+    if not isinstance(other, type(self)):
+      raise TypeError(f'Expected {type(self)}, got {type(other)}')
     d: dict[RelationType, set[frozenset[RelationItemType]]] = {}
 
     for rel, combos in self.items():
@@ -44,6 +46,8 @@ class RelationDiscovery(
   def mutual_only(self, items1: AbstractSet[RelationItemType], items2: AbstractSet[RelationItemType]) -> Self:
     '''Keep only the combos that draw from both sides (a combo disjoint from either side
     comes from one side only). 只保留同时取材于两侧的组合（与任一侧不相交即单侧组合）。'''
-    assert isinstance(items1, AbstractSet)
-    assert isinstance(items2, AbstractSet)
+    if not isinstance(items1, AbstractSet):
+      raise TypeError(f'Expected AbstractSet, got {type(items1)}')
+    if not isinstance(items2, AbstractSet):
+      raise TypeError(f'Expected AbstractSet, got {type(items2)}')
     return self.filter(lambda rel, combo: not combo.isdisjoint(items1) and not combo.isdisjoint(items2))

--- a/src/utils/shensha_utils.py
+++ b/src/utils/shensha_utils.py
@@ -28,8 +28,10 @@ def taohua(year_or_day_dizhi: Dizhi, other_dizhi: Dizhi) -> bool:
     - return: False
   '''
 
-  assert isinstance(year_or_day_dizhi, Dizhi)
-  assert isinstance(other_dizhi, Dizhi)
+  if not isinstance(year_or_day_dizhi, Dizhi):
+    raise TypeError(f'Expected Dizhi, got {type(year_or_day_dizhi)}')
+  if not isinstance(other_dizhi, Dizhi):
+    raise TypeError(f'Expected Dizhi, got {type(other_dizhi)}')
   return ShenshaRules.TAOHUA[year_or_day_dizhi] is other_dizhi
 
 
@@ -51,8 +53,10 @@ def hongyan(day_master: Tiangan, dizhi: Dizhi) -> bool:
     - return: False
   '''
 
-  assert isinstance(day_master, Tiangan)
-  assert isinstance(dizhi, Dizhi)
+  if not isinstance(day_master, Tiangan):
+    raise TypeError(f'Expected Tiangan, got {type(day_master)}')
+  if not isinstance(dizhi, Dizhi):
+    raise TypeError(f'Expected Dizhi, got {type(dizhi)}')
   return ShenshaRules.HONGYAN[day_master] is dizhi
 
 
@@ -74,8 +78,10 @@ def hongluan(year_dizhi: Dizhi, other_dizhi: Dizhi) -> bool:
     - return: False
   '''
 
-  assert isinstance(year_dizhi, Dizhi)
-  assert isinstance(other_dizhi, Dizhi)
+  if not isinstance(year_dizhi, Dizhi):
+    raise TypeError(f'Expected Dizhi, got {type(year_dizhi)}')
+  if not isinstance(other_dizhi, Dizhi):
+    raise TypeError(f'Expected Dizhi, got {type(other_dizhi)}')
   return ShenshaRules.HONGLUAN[year_dizhi] is other_dizhi
 
 
@@ -97,8 +103,10 @@ def tianxi(year_dizhi: Dizhi, other_dizhi: Dizhi) -> bool:
     - return: False
   '''
 
-  assert isinstance(year_dizhi, Dizhi)
-  assert isinstance(other_dizhi, Dizhi)
+  if not isinstance(year_dizhi, Dizhi):
+    raise TypeError(f'Expected Dizhi, got {type(year_dizhi)}')
+  if not isinstance(other_dizhi, Dizhi):
+    raise TypeError(f'Expected Dizhi, got {type(other_dizhi)}')
   return ShenshaRules.TIANXI[year_dizhi] is other_dizhi
 
 
@@ -120,6 +128,8 @@ def yima(year_or_day_dizhi: Dizhi, other_dizhi: Dizhi) -> bool:
     - return: False
   '''
 
-  assert isinstance(year_or_day_dizhi, Dizhi)
-  assert isinstance(other_dizhi, Dizhi)
+  if not isinstance(year_or_day_dizhi, Dizhi):
+    raise TypeError(f'Expected Dizhi, got {type(year_or_day_dizhi)}')
+  if not isinstance(other_dizhi, Dizhi):
+    raise TypeError(f'Expected Dizhi, got {type(other_dizhi)}')
   return ShenshaRules.YIMA[year_or_day_dizhi] is other_dizhi

--- a/src/utils/tiangan_utils.py
+++ b/src/utils/tiangan_utils.py
@@ -50,8 +50,10 @@ def he(tg1: Tiangan, tg2: Tiangan) -> Wuxing | None:
     - return: Wuxing("土")
   '''
 
-  assert isinstance(tg1, Tiangan)
-  assert isinstance(tg2, Tiangan)
+  if not isinstance(tg1, Tiangan):
+    raise TypeError(f'Expected Tiangan, got {type(tg1)}')
+  if not isinstance(tg2, Tiangan):
+    raise TypeError(f'Expected Tiangan, got {type(tg2)}')
 
   fs: TianganCombo = TianganCombo((tg1, tg2))
   if fs in TianganRules.TIANGAN_HE:
@@ -81,8 +83,10 @@ def chong(tg1: Tiangan, tg2: Tiangan) -> bool:
     - return: True
   '''
 
-  assert isinstance(tg1, Tiangan)
-  assert isinstance(tg2, Tiangan)
+  if not isinstance(tg1, Tiangan):
+    raise TypeError(f'Expected Tiangan, got {type(tg1)}')
+  if not isinstance(tg2, Tiangan):
+    raise TypeError(f'Expected Tiangan, got {type(tg2)}')
   return TianganCombo((tg1, tg2)) in TianganRules.TIANGAN_CHONG
 
 
@@ -108,8 +112,10 @@ def sheng(tg1: Tiangan, tg2: Tiangan) -> bool:
     - return: False
   '''
 
-  assert isinstance(tg1, Tiangan)
-  assert isinstance(tg2, Tiangan)
+  if not isinstance(tg1, Tiangan):
+    raise TypeError(f'Expected Tiangan, got {type(tg1)}')
+  if not isinstance(tg2, Tiangan):
+    raise TypeError(f'Expected Tiangan, got {type(tg2)}')
   return (tg1, tg2) in TianganRules.TIANGAN_SHENG
 
 
@@ -135,8 +141,10 @@ def ke(tg1: Tiangan, tg2: Tiangan) -> bool:
     - return: True
   '''
 
-  assert isinstance(tg1, Tiangan)
-  assert isinstance(tg2, Tiangan)
+  if not isinstance(tg1, Tiangan):
+    raise TypeError(f'Expected Tiangan, got {type(tg1)}')
+  if not isinstance(tg2, Tiangan):
+    raise TypeError(f'Expected Tiangan, got {type(tg2)}')
   return (tg1, tg2) in TianganRules.TIANGAN_KE
 
 
@@ -175,8 +183,10 @@ def search(tiangans: Sequence[Tiangan], relation: TianganRelation) -> TianganRel
     - Note that the returned combos don't contain the direction.
   '''
 
-  assert isinstance(relation, TianganRelation)
-  assert all(isinstance(tg, Tiangan) for tg in tiangans)
+  if not isinstance(relation, TianganRelation):
+    raise TypeError(f'Expected TianganRelation, got {type(relation)}')
+  if not all(isinstance(tg, Tiangan) for tg in tiangans):
+    raise TypeError(f'Expected all Tiangan, got {[type(tg) for tg in tiangans]}')
 
   if relation is TianganRelation.合:
     return TianganRelationCombos(combo for combo in TianganRules.TIANGAN_HE if combo.issubset(tiangans))
@@ -211,7 +221,8 @@ def discover(tiangans: Sequence[Tiangan]) -> TianganRelationDiscovery:
   Return: (TianganRelationDiscovery) The result containing all matching Tiangan combos. Note that returned combos don't reveal the directions.
   '''
 
-  assert all(isinstance(tg, Tiangan) for tg in tiangans)
+  if not all(isinstance(tg, Tiangan) for tg in tiangans):
+    raise TypeError(f'Expected all Tiangan, got {[type(tg) for tg in tiangans]}')
   return TianganRelationDiscovery({
     rel : result
     for rel in TianganRelation
@@ -248,8 +259,10 @@ def discover_mutual(tiangans1: Sequence[Tiangan], tiangans2: Sequence[Tiangan]) 
     - return: {} // Empty returned frozendict!
   '''
 
-  assert all(isinstance(tg, Tiangan) for tg in tiangans1)
-  assert all(isinstance(tg, Tiangan) for tg in tiangans2)
+  if not all(isinstance(tg, Tiangan) for tg in tiangans1):
+    raise TypeError(f'Expected all Tiangan, got {[type(tg) for tg in tiangans1]}')
+  if not all(isinstance(tg, Tiangan) for tg in tiangans2):
+    raise TypeError(f'Expected all Tiangan, got {[type(tg) for tg in tiangans2]}')
 
   tg1_set: Final[set[Tiangan]] = set(tiangans1)
   tg2_set: Final[set[Tiangan]] = set(tiangans2)

--- a/tests/analyzer/test_relationship_analyzer.py
+++ b/tests/analyzer/test_relationship_analyzer.py
@@ -417,22 +417,20 @@ def test_transit_analysis_negative() -> None:
   bad_year = chart.bazi.ganzhi_year - 1
   assert not transits_analysis.support(bad_year, TransitOptions.LIUNIAN)
 
-  with pytest.raises(ValueError):
-    transits_analysis.shensha(bad_year, TransitOptions.LIUNIAN)
-  with pytest.raises(ValueError):
-    transits_analysis.day_master_relations(bad_year, TransitOptions.LIUNIAN)
-  with pytest.raises(ValueError):
-    transits_analysis.house_relations(bad_year, TransitOptions.LIUNIAN)
-  with pytest.raises(ValueError):
-    transits_analysis.star_relations(bad_year, TransitOptions.LIUNIAN)
-  with pytest.raises(ValueError):
-    transits_analysis.zhengyin(bad_year, TransitOptions.LIUNIAN)
-  with pytest.raises(ValueError):
-    transits_analysis.star(bad_year, TransitOptions.LIUNIAN)
+  for analysis in (transits_analysis.shensha, transits_analysis.day_master_relations,
+                   transits_analysis.house_relations, transits_analysis.star_relations,
+                   transits_analysis.zhengyin, transits_analysis.star):
+    with pytest.raises(ValueError):
+      analysis(bad_year, TransitOptions.LIUNIAN)
 
-  # A plain int with an unknown bit is not a `Level` member (the year is supported; the level gate fires first anyway).
-  with pytest.raises(ValueError):
+  # The level gate fires before the support check, so a supported year still raises.
+  with pytest.raises(TypeError):
     transits_analysis.star_relations(chart.bazi.ganzhi_year, TransitOptions.LIUNIAN, level=0x8) # type: ignore
+  # IntFlag happily constructs pseudo-members (undefined bit / empty flag); the gate rejects them by value.
+  with pytest.raises(ValueError):
+    transits_analysis.star_relations(chart.bazi.ganzhi_year, TransitOptions.LIUNIAN, level=TransitAnalysis.Level(0x8))
+  with pytest.raises(ValueError):
+    transits_analysis.star_relations(chart.bazi.ganzhi_year, TransitOptions.LIUNIAN, level=TransitAnalysis.Level(0))
 
 
 def test_registry_matches_shensha_analysis_keys() -> None:

--- a/tests/analyzer/test_relationship_analyzer.py
+++ b/tests/analyzer/test_relationship_analyzer.py
@@ -408,6 +408,33 @@ def test_star() -> None:
       assert expected_dz == actual.dizhi
 
 
+def test_transit_analysis_negative() -> None:
+  chart = BaziChart.random()
+  transits_analysis = RelationshipAnalyzer(chart).transits
+
+  # The year before the chart's own Ganzhi year precedes every transit -- never supported.
+  # 原局干支年之前的年份先于一切流运——必然不受支持。
+  bad_year = chart.bazi.ganzhi_year - 1
+  assert not transits_analysis.support(bad_year, TransitOptions.LIUNIAN)
+
+  with pytest.raises(ValueError):
+    transits_analysis.shensha(bad_year, TransitOptions.LIUNIAN)
+  with pytest.raises(ValueError):
+    transits_analysis.day_master_relations(bad_year, TransitOptions.LIUNIAN)
+  with pytest.raises(ValueError):
+    transits_analysis.house_relations(bad_year, TransitOptions.LIUNIAN)
+  with pytest.raises(ValueError):
+    transits_analysis.star_relations(bad_year, TransitOptions.LIUNIAN)
+  with pytest.raises(ValueError):
+    transits_analysis.zhengyin(bad_year, TransitOptions.LIUNIAN)
+  with pytest.raises(ValueError):
+    transits_analysis.star(bad_year, TransitOptions.LIUNIAN)
+
+  # A plain int with an unknown bit is not a `Level` member (the year is supported; the level gate fires first anyway).
+  with pytest.raises(ValueError):
+    transits_analysis.star_relations(chart.bazi.ganzhi_year, TransitOptions.LIUNIAN, level=0x8) # type: ignore
+
+
 def test_registry_matches_shensha_analysis_keys() -> None:
   '''The Shensha registry and `ShenshaAnalysis` must stay in sync / 神煞注册表和 ShenshaAnalysis 的键必须保持同步。'''
   assert set(_REGISTRY.keys()) == set(ShenshaAnalysis.__required_keys__ | ShenshaAnalysis.__optional_keys__)

--- a/tests/calendar/test_backend.py
+++ b/tests/calendar/test_backend.py
@@ -70,7 +70,7 @@ def test_create_with_backend() -> None:
   with pytest.raises(ValueError):
     Bazi.create('1984-04-02 04:02', 'male', 'day', backend='lunar')
 
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     Bazi.create('1984-04-02 04:02', 'male', 'day', backend=42) # type: ignore[arg-type]
 
 
@@ -85,7 +85,7 @@ def test_consistent_with_hko_utils() -> None:
 def test_init_rejects_str_backend() -> None:
   # `__init__` only takes the enum; strings go through `Bazi.create` (same
   # contract split as `gender` / `precision`).
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     Bazi(datetime(1984, 4, 2, 4, 2), BaziGender.MALE, BaziPrecision.DAY,
          backend='hko') # type: ignore[arg-type]
 

--- a/tests/calendar/test_backend.py
+++ b/tests/calendar/test_backend.py
@@ -35,7 +35,7 @@ def test_from_str() -> None:
   with pytest.raises(ValueError):
     CalendarBackend.from_str('lunar') # Not a supported backend.
 
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     CalendarBackend.from_str(42) # type: ignore[arg-type]
 
 
@@ -57,7 +57,7 @@ def test_calendar_utils_of() -> None:
   with pytest.raises(ValueError):
     calendar_utils_of('lunar')
 
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     calendar_utils_of(42) # type: ignore[arg-type]
 
 

--- a/tests/calendar/test_celestial_utils.py
+++ b/tests/calendar/test_celestial_utils.py
@@ -58,6 +58,13 @@ def test_the_three_bounds_are_one_physical_day() -> None:
     assert ALGO1.to_date(bound(CalendarType.GANZHI)) == day
 
 
+def test_get_min_max_supported_dates_negative() -> None:
+  with pytest.raises(ValueError):
+    ALGO1.get_min_supported_date(42) # Not a CalendarType.
+  with pytest.raises(ValueError):
+    ALGO1.get_max_supported_date(42) # Not a CalendarType.
+
+
 def test_solar() -> None:
   assert ALGO1.is_valid_solar_date(solar(2024, 2, 4))
   assert not ALGO1.is_valid_solar_date(lunar(2024, 2, 4)) # Wrong date type.
@@ -119,6 +126,13 @@ def test_ganzhi_month_lengths_cannot_poison_the_cache() -> None:
   assert ALGO1.is_valid_ganzhi_date(ganzhi(2000, 1, 29))
 
 
+def test_days_counts_in_ganzhi_year_negative() -> None:
+  with pytest.raises(ValueError):
+    ALGO1.days_counts_in_ganzhi_year(1900) # Before the first jieqi-table year.
+  with pytest.raises(ValueError):
+    ALGO1.days_counts_in_ganzhi_year(2100) # The last jieqi-table year: no 立春 of 2101 to close it.
+
+
 def test_round_trips() -> None:
   # Every day of a leap lunar year and of a plain one, both ways round.
   for year in (2023, 2024):
@@ -140,6 +154,38 @@ def test_dates_before_the_year_boundaries() -> None:
   assert ALGO1.solar_to_ganzhi(solar(2024, 2, 5)).year == 2024
 
 
+def test_date_conversions_negative() -> None:
+  with pytest.raises(ValueError):
+    ALGO1.ganzhi_to_lunar(ganzhi(1, 1, 1)) # Out of the supported range.
+  with pytest.raises(ValueError):
+    ALGO1.ganzhi_to_lunar(solar(2024, 1, 1)) # Wrong date type.
+
+  with pytest.raises(ValueError):
+    ALGO1.lunar_to_ganzhi(lunar(1, 1, 1)) # Out of the supported range.
+  with pytest.raises(ValueError):
+    ALGO1.lunar_to_ganzhi(solar(2024, 1, 1)) # Wrong date type.
+
+  with pytest.raises(ValueError):
+    ALGO1.solar_to_lunar(solar(1, 1, 1)) # Out of the supported range.
+  with pytest.raises(ValueError):
+    ALGO1.solar_to_lunar(ganzhi(2024, 1, 1)) # Wrong date type.
+
+  with pytest.raises(ValueError):
+    ALGO1.lunar_to_solar(lunar(1, 1, 1)) # Out of the supported range.
+  with pytest.raises(ValueError):
+    ALGO1.lunar_to_solar(ganzhi(2024, 1, 1)) # Wrong date type.
+
+  with pytest.raises(ValueError):
+    ALGO1.solar_to_ganzhi(solar(1, 1, 1)) # Out of the supported range.
+  with pytest.raises(ValueError):
+    ALGO1.solar_to_ganzhi(ganzhi(2024, 1, 1)) # Wrong date type.
+
+  with pytest.raises(ValueError):
+    ALGO1.ganzhi_to_solar(ganzhi(1, 1, 1)) # Out of the supported range.
+  with pytest.raises(ValueError):
+    ALGO1.ganzhi_to_solar(solar(2024, 1, 1)) # Wrong date type.
+
+
 def test_to_family() -> None:
   day: date = date(2024, 2, 4)
   assert ALGO1.to_solar(day) == solar(2024, 2, 4)
@@ -153,6 +199,22 @@ def test_to_family() -> None:
     assert ALGO1.to_lunar(d).date_type == CalendarType.LUNAR
     assert ALGO1.to_ganzhi(d).date_type == CalendarType.GANZHI
     assert ALGO1.to_date(d) == date(2024, 2, 4)
+
+
+def test_to_family_negative() -> None:
+  # Both checks live in the shared funnel, so every `to_*` carries the same contract.
+  with pytest.raises(ValueError):
+    ALGO1.to_solar(date(1901, 1, 1)) # An in-window year, yet before the first supported day (#63).
+  with pytest.raises(ValueError):
+    ALGO1.to_lunar(lunar(9999, 1, 1)) # Out of the supported range.
+  with pytest.raises(ValueError):
+    ALGO1.to_ganzhi(solar(1901, 1, 1)) # Before the first supported day.
+  with pytest.raises(TypeError):
+    ALGO1.to_solar('2024-01-01') # Not a date or CalendarDate.
+  with pytest.raises(TypeError):
+    ALGO1.to_lunar('2024-01-01') # Not a date or CalendarDate.
+  with pytest.raises(TypeError):
+    ALGO1.to_ganzhi('2024-01-01') # Not a date or CalendarDate.
 
 
 def test_real_moments_not_placeholders() -> None:
@@ -169,13 +231,13 @@ def test_date_is_the_moment_truncated() -> None:
 
 
 def test_out_of_range_year() -> None:
-  with pytest.raises(AssertionError):
+  with pytest.raises(ValueError):
     ALGO1.jieqi_moment(2101, Jieqi.立春)
-  with pytest.raises(AssertionError):
+  with pytest.raises(ValueError):
     ALGO1.jieqi_moment(1900, Jieqi.立春)
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     ALGO1.jieqi_moment('2024', Jieqi.立春)
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     ALGO1.jieqi_moment(2024, '立春')
 
 
@@ -192,7 +254,7 @@ def test_jie_range_is_enforced() -> None:
       fn(first - timedelta(seconds=1))
     with pytest.raises(ValueError):
       fn(last) # The upper bound is exclusive.
-    with pytest.raises(AssertionError):
+    with pytest.raises(TypeError):
       fn(date(2024, 2, 4)) # A date is not a datetime.
 
 

--- a/tests/calendar/test_celestial_utils.py
+++ b/tests/calendar/test_celestial_utils.py
@@ -209,7 +209,7 @@ def test_to_family_negative() -> None:
   with pytest.raises(ValueError):
     ALGO1.to_solar(date(1901, 1, 1)) # An in-window year, yet before the first supported day.
   with pytest.raises(ValueError):
-    ALGO1.to_lunar(lunar(9999, 1, 1)) # Out of the supported range.
+    ALGO1.to_lunar(lunar(9999, 1, 1))
   with pytest.raises(ValueError):
     ALGO1.to_ganzhi(solar(1901, 1, 1)) # Before the first supported day.
   with pytest.raises(TypeError):

--- a/tests/calendar/test_celestial_utils.py
+++ b/tests/calendar/test_celestial_utils.py
@@ -58,11 +58,14 @@ def test_the_three_bounds_are_one_physical_day() -> None:
     assert ALGO1.to_date(bound(CalendarType.GANZHI)) == day
 
 
-def test_get_min_max_supported_dates_negative() -> None:
+def test_get_min_supported_date_negative() -> None:
   with pytest.raises(ValueError):
-    ALGO1.get_min_supported_date(42) # Not a CalendarType.
+    ALGO1.get_min_supported_date(42)
+
+
+def test_get_max_supported_date_negative() -> None:
   with pytest.raises(ValueError):
-    ALGO1.get_max_supported_date(42) # Not a CalendarType.
+    ALGO1.get_max_supported_date(42)
 
 
 def test_solar() -> None:
@@ -156,34 +159,34 @@ def test_dates_before_the_year_boundaries() -> None:
 
 def test_date_conversions_negative() -> None:
   with pytest.raises(ValueError):
-    ALGO1.ganzhi_to_lunar(ganzhi(1, 1, 1)) # Out of the supported range.
+    ALGO1.ganzhi_to_lunar(ganzhi(1, 1, 1))
   with pytest.raises(ValueError):
-    ALGO1.ganzhi_to_lunar(solar(2024, 1, 1)) # Wrong date type.
+    ALGO1.ganzhi_to_lunar(solar(2024, 1, 1))
 
   with pytest.raises(ValueError):
-    ALGO1.lunar_to_ganzhi(lunar(1, 1, 1)) # Out of the supported range.
+    ALGO1.lunar_to_ganzhi(lunar(1, 1, 1))
   with pytest.raises(ValueError):
-    ALGO1.lunar_to_ganzhi(solar(2024, 1, 1)) # Wrong date type.
+    ALGO1.lunar_to_ganzhi(solar(2024, 1, 1))
 
   with pytest.raises(ValueError):
-    ALGO1.solar_to_lunar(solar(1, 1, 1)) # Out of the supported range.
+    ALGO1.solar_to_lunar(solar(1, 1, 1))
   with pytest.raises(ValueError):
-    ALGO1.solar_to_lunar(ganzhi(2024, 1, 1)) # Wrong date type.
+    ALGO1.solar_to_lunar(ganzhi(2024, 1, 1))
 
   with pytest.raises(ValueError):
-    ALGO1.lunar_to_solar(lunar(1, 1, 1)) # Out of the supported range.
+    ALGO1.lunar_to_solar(lunar(1, 1, 1))
   with pytest.raises(ValueError):
-    ALGO1.lunar_to_solar(ganzhi(2024, 1, 1)) # Wrong date type.
+    ALGO1.lunar_to_solar(ganzhi(2024, 1, 1))
 
   with pytest.raises(ValueError):
-    ALGO1.solar_to_ganzhi(solar(1, 1, 1)) # Out of the supported range.
+    ALGO1.solar_to_ganzhi(solar(1, 1, 1))
   with pytest.raises(ValueError):
-    ALGO1.solar_to_ganzhi(ganzhi(2024, 1, 1)) # Wrong date type.
+    ALGO1.solar_to_ganzhi(ganzhi(2024, 1, 1))
 
   with pytest.raises(ValueError):
-    ALGO1.ganzhi_to_solar(ganzhi(1, 1, 1)) # Out of the supported range.
+    ALGO1.ganzhi_to_solar(ganzhi(1, 1, 1))
   with pytest.raises(ValueError):
-    ALGO1.ganzhi_to_solar(solar(2024, 1, 1)) # Wrong date type.
+    ALGO1.ganzhi_to_solar(solar(2024, 1, 1))
 
 
 def test_to_family() -> None:
@@ -204,7 +207,7 @@ def test_to_family() -> None:
 def test_to_family_negative() -> None:
   # Both checks live in the shared funnel, so every `to_*` carries the same contract.
   with pytest.raises(ValueError):
-    ALGO1.to_solar(date(1901, 1, 1)) # An in-window year, yet before the first supported day (#63).
+    ALGO1.to_solar(date(1901, 1, 1)) # An in-window year, yet before the first supported day.
   with pytest.raises(ValueError):
     ALGO1.to_lunar(lunar(9999, 1, 1)) # Out of the supported range.
   with pytest.raises(ValueError):

--- a/tests/calendar/test_dates.py
+++ b/tests/calendar/test_dates.py
@@ -39,13 +39,13 @@ def test_solar_date() -> None:
   assert sd != date(2024, 1, 1)
   assert sd != '2024-01-01'
 
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     CalendarDate('2024', 1, 1, CalendarType.SOLAR) # type: ignore
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     CalendarDate(2024, '1', 1, CalendarType.SOLAR) # type: ignore
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     CalendarDate(2024, 1, '1', CalendarType.SOLAR) # type: ignore
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     CalendarDate(2024, 1, 1, 'SOLAR') # type: ignore
   with pytest.raises(TypeError):
     CalendarDate(2024, 1, 1) # type: ignore # Missing argument.
@@ -77,13 +77,13 @@ def test_lunar_date() -> None:
   assert ld != date(2024, 1, 1)
   assert ld != '2024-01-01'
 
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     CalendarDate('2024', 1, 1, CalendarType.LUNAR) # type: ignore
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     CalendarDate(2024, '1', 1, CalendarType.LUNAR) # type: ignore
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     CalendarDate(2024, 1, '1', CalendarType.LUNAR) # type: ignore
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     CalendarDate(2024, 1, 1, 'LUNAR') # type: ignore
   with pytest.raises(TypeError):
     CalendarDate(2024, 1, 1) # type: ignore # Missing argument.
@@ -114,13 +114,13 @@ def test_ganzhi_date() -> None:
   assert gzd != date(2024, 1, 1)
   assert gzd != '2024-01-01'
 
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     CalendarDate('2024', 1, 1, CalendarType.GANZHI) # type: ignore
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     CalendarDate(2024, '1', 1, CalendarType.GANZHI) # type: ignore
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     CalendarDate(2024, 1, '1', CalendarType.GANZHI) # type: ignore
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     CalendarDate(2024, 1, 1, 'GANZHI') # type: ignore
   with pytest.raises(TypeError):
     CalendarDate(2024, 1, 1) # type: ignore # Missing argument.

--- a/tests/calendar/test_hko_data.py
+++ b/tests/calendar/test_hko_data.py
@@ -111,19 +111,19 @@ def test_decode_jieqi() -> None:
 
 def test_decode_jieqi_getitem_negative() -> None:
   decoded_jieqi: hko_data.DecodedJieqiDates = hko_data.DecodedJieqiDates()
-  with pytest.raises(AssertionError):
+  with pytest.raises(ValueError):
     decoded_jieqi[1000]
-  with pytest.raises(AssertionError):
+  with pytest.raises(ValueError):
     decoded_jieqi[min(decoded_jieqi.supported_year_range()) - 1]
-  with pytest.raises(AssertionError):
+  with pytest.raises(ValueError):
     decoded_jieqi[max(decoded_jieqi.supported_year_range()) + 1]
-  with pytest.raises(AssertionError):
+  with pytest.raises(ValueError):
     decoded_jieqi['2024'] # type: ignore
-  with pytest.raises(AssertionError):
+  with pytest.raises(ValueError):
     decoded_jieqi[Jieqi.芒种] # type: ignore
-  with pytest.raises(AssertionError):
+  with pytest.raises(ValueError):
     decoded_jieqi[:] # type: ignore
-  with pytest.raises(AssertionError):
+  with pytest.raises(ValueError):
     decoded_jieqi[date(2024, 1, 1)] # type: ignore
 
   data1 = decoded_jieqi[2024]
@@ -144,13 +144,13 @@ def test_decode_jieqi_get_negative() -> None:
     decoded_jieqi.get(2024)
   with pytest.raises(TypeError):
     decoded_jieqi.get(Jieqi.春分)
-  with pytest.raises(AssertionError):
+  with pytest.raises(ValueError):
     decoded_jieqi.get('1000', Jieqi.寒露)
-  with pytest.raises(AssertionError):
+  with pytest.raises(ValueError):
     decoded_jieqi.get(1000, Jieqi.寒露)
-  with pytest.raises(AssertionError):
+  with pytest.raises(ValueError):
     decoded_jieqi.get(min(decoded_jieqi.supported_year_range()) - 1, Jieqi.寒露)
-  with pytest.raises(AssertionError):
+  with pytest.raises(ValueError):
     decoded_jieqi.get(max(decoded_jieqi.supported_year_range()) + 1, Jieqi.寒露)
 
   assert decoded_jieqi.get(2024, Jieqi.立春) == decoded_jieqi.get(2024, Jieqi.立春)
@@ -245,19 +245,21 @@ def test_decode_lunar_year_get_returns_a_copy() -> None:
 
 def test_decode_lunar_year_negative() -> None:
   decoded_lunardate: hko_data.DecodedLunarYears = hko_data.DecodedLunarYears()
-  with pytest.raises(AssertionError):
+  with pytest.raises(ValueError):
     decoded_lunardate.get(min(decoded_lunardate.supported_year_range()) - 1)
-  with pytest.raises(AssertionError):
+  with pytest.raises(ValueError):
     decoded_lunardate[min(decoded_lunardate.supported_year_range()) - 1]
-  with pytest.raises(AssertionError):
+  with pytest.raises(ValueError):
     decoded_lunardate.get(max(decoded_lunardate.supported_year_range()) + 1)
-  with pytest.raises(AssertionError):
+  with pytest.raises(ValueError):
     decoded_lunardate[max(decoded_lunardate.supported_year_range()) + 1]
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     decoded_lunardate.get('a') # type: ignore
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
+    decoded_lunardate['a'] # type: ignore
+  with pytest.raises(TypeError):
     decoded_lunardate.get('1984') # type: ignore
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     decoded_lunardate.get(date(year=1984, month=1, day=1)) # type: ignore
 
   temp = decoded_lunardate[2024]

--- a/tests/calendar/test_hko_data.py
+++ b/tests/calendar/test_hko_data.py
@@ -117,13 +117,13 @@ def test_decode_jieqi_getitem_negative() -> None:
     decoded_jieqi[min(decoded_jieqi.supported_year_range()) - 1]
   with pytest.raises(ValueError):
     decoded_jieqi[max(decoded_jieqi.supported_year_range()) + 1]
-  with pytest.raises(ValueError):
+  with pytest.raises(TypeError):
     decoded_jieqi['2024'] # type: ignore
-  with pytest.raises(ValueError):
+  with pytest.raises(TypeError):
     decoded_jieqi[Jieqi.芒种] # type: ignore
-  with pytest.raises(ValueError):
+  with pytest.raises(TypeError):
     decoded_jieqi[:] # type: ignore
-  with pytest.raises(ValueError):
+  with pytest.raises(TypeError):
     decoded_jieqi[date(2024, 1, 1)] # type: ignore
 
   data1 = decoded_jieqi[2024]
@@ -144,7 +144,7 @@ def test_decode_jieqi_get_negative() -> None:
     decoded_jieqi.get(2024)
   with pytest.raises(TypeError):
     decoded_jieqi.get(Jieqi.春分)
-  with pytest.raises(ValueError):
+  with pytest.raises(TypeError):
     decoded_jieqi.get('1000', Jieqi.寒露)
   with pytest.raises(ValueError):
     decoded_jieqi.get(1000, Jieqi.寒露)

--- a/tests/calendar/test_hko_data_utils.py
+++ b/tests/calendar/test_hko_data_utils.py
@@ -13,6 +13,16 @@ from src.calendar.hko_data import DecodedLunarYears, DecodedJieqiDates
 from src.defines import Jieqi
 
 
+def test_get_min_supported_date_negative() -> None:
+  with pytest.raises(ValueError):
+    hko_data_utils.get_min_supported_date(42)
+
+
+def test_get_max_supported_date_negative() -> None:
+  with pytest.raises(ValueError):
+    hko_data_utils.get_max_supported_date(42)
+
+
 @pytest.mark.slow
 def test_is_valid_solar_date() -> None:
   d: date = date(1902, 1, 1)
@@ -92,11 +102,11 @@ def test_days_counts_in_ganzhi_year() -> None:
   max_year: int = hko_data_utils.get_max_supported_date(CalendarType.GANZHI).year
 
   # Test negative cases first.
-  with pytest.raises(AssertionError):
+  with pytest.raises(ValueError):
     hko_data_utils.days_counts_in_ganzhi_year(-1)
-  with pytest.raises(AssertionError):
+  with pytest.raises(ValueError):
     hko_data_utils.days_counts_in_ganzhi_year(min_year - 1)
-  with pytest.raises(AssertionError):
+  with pytest.raises(ValueError):
     hko_data_utils.days_counts_in_ganzhi_year(max_year + 1)
 
   # Test edge cases.
@@ -368,34 +378,34 @@ def test_complex_date_conversions() -> None:
 
 
 def test_date_conversions_negative() -> None:
-  with pytest.raises(AssertionError):
+  with pytest.raises(ValueError):
     hko_data_utils.ganzhi_to_lunar(CalendarDate(1, 1, 1, CalendarType.GANZHI))
-  with pytest.raises(AssertionError):
+  with pytest.raises(ValueError):
     hko_data_utils.ganzhi_to_lunar(CalendarDate(2024, 1, 1, CalendarType.SOLAR))
 
-  with pytest.raises(AssertionError):
+  with pytest.raises(ValueError):
     hko_data_utils.lunar_to_ganzhi(CalendarDate(1, 1, 1, CalendarType.LUNAR))
-  with pytest.raises(AssertionError):
+  with pytest.raises(ValueError):
     hko_data_utils.lunar_to_ganzhi(CalendarDate(2024, 1, 1, CalendarType.SOLAR))
 
-  with pytest.raises(AssertionError):
+  with pytest.raises(ValueError):
     hko_data_utils.solar_to_lunar(CalendarDate(1, 1, 1, CalendarType.SOLAR))
-  with pytest.raises(AssertionError):
+  with pytest.raises(ValueError):
     hko_data_utils.solar_to_lunar(CalendarDate(2024, 1, 1, CalendarType.GANZHI))
 
-  with pytest.raises(AssertionError):
+  with pytest.raises(ValueError):
     hko_data_utils.lunar_to_solar(CalendarDate(1, 1, 1, CalendarType.LUNAR))
-  with pytest.raises(AssertionError):
+  with pytest.raises(ValueError):
     hko_data_utils.lunar_to_solar(CalendarDate(2024, 1, 1, CalendarType.GANZHI))
 
-  with pytest.raises(AssertionError):
+  with pytest.raises(ValueError):
     hko_data_utils.solar_to_ganzhi(CalendarDate(1, 1, 1, CalendarType.SOLAR))
-  with pytest.raises(AssertionError):
+  with pytest.raises(ValueError):
     hko_data_utils.solar_to_ganzhi(CalendarDate(2024, 1, 1, CalendarType.GANZHI))
 
-  with pytest.raises(AssertionError):
+  with pytest.raises(ValueError):
     hko_data_utils.ganzhi_to_solar(CalendarDate(1, 1, 1, CalendarType.GANZHI))
-  with pytest.raises(AssertionError):
+  with pytest.raises(ValueError):
     hko_data_utils.ganzhi_to_solar(CalendarDate(2024, 1, 1, CalendarType.SOLAR))
 
 
@@ -410,9 +420,11 @@ def test_to_solar() -> None:
   assert solar_date == hko_data_utils.to_solar(hko_data_utils.solar_to_ganzhi(solar_date))
 
   # Negative cases.
-  with pytest.raises(AssertionError):
+  with pytest.raises(ValueError):
     hko_data_utils.to_solar(CalendarDate(9999, 1, 1, CalendarType.SOLAR)) # Invalid date
-  with pytest.raises(AssertionError):
+  with pytest.raises(ValueError):
+    hko_data_utils.to_solar(CalendarDate(1901, 1, 1, CalendarType.SOLAR)) # Below the supported range
+  with pytest.raises(TypeError):
     hko_data_utils.to_solar('2024-01-01') # Invalid type
 
 
@@ -427,9 +439,11 @@ def test_to_lunar() -> None:
   assert lunar_date == hko_data_utils.to_lunar(hko_data_utils.lunar_to_ganzhi(lunar_date))
 
   # Negative cases.
-  with pytest.raises(AssertionError):
+  with pytest.raises(ValueError):
     hko_data_utils.to_lunar(CalendarDate(9999, 1, 1, CalendarType.LUNAR)) # Invalid date
-  with pytest.raises(AssertionError):
+  with pytest.raises(ValueError):
+    hko_data_utils.to_lunar(date(1901, 1, 1)) # Below the supported range
+  with pytest.raises(TypeError):
     hko_data_utils.to_lunar('2024-01-01') # Invalid type
 
 
@@ -444,9 +458,11 @@ def test_to_ganzhi() -> None:
   assert ganzhi_date == hko_data_utils.to_ganzhi(hko_data_utils.ganzhi_to_lunar(ganzhi_date))
 
   # Negative cases.
-  with pytest.raises(AssertionError):
+  with pytest.raises(ValueError):
     hko_data_utils.to_ganzhi(CalendarDate(9999, 1, 1, CalendarType.GANZHI)) # Invalid date
-  with pytest.raises(AssertionError):
+  with pytest.raises(ValueError):
+    hko_data_utils.to_ganzhi(CalendarDate(1901, 1, 1, CalendarType.SOLAR)) # Below the supported range
+  with pytest.raises(TypeError):
     hko_data_utils.to_ganzhi('2024-01-01') # Invalid type
 
 
@@ -464,24 +480,24 @@ def test_to_date() -> None:
   assert hko_data_utils.to_date(cd) == date(1901, 2, 19)
 
   # Negative cases.
-  with pytest.raises(AssertionError):
+  with pytest.raises(ValueError):
     hko_data_utils.to_date(CalendarDate(9999, 1, 1, CalendarType.GANZHI)) # Invalid date
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     hko_data_utils.to_date('2024-01-01') # Invalid type
 
 
 def test_get_jieqi_date() -> None:
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     hko_data_utils.jieqi_date('2024', Jieqi.大寒)
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     hko_data_utils.jieqi_date(2024, '大寒')
-  with pytest.raises(AssertionError):
+  with pytest.raises(ValueError):
     hko_data_utils.jieqi_date(9999, Jieqi.大寒) # Out of supported solar year range.
-  with pytest.raises(AssertionError):
+  with pytest.raises(ValueError):
     hko_data_utils.jieqi_date(2101, Jieqi.小寒) # Out of supported solar year range.
-  with pytest.raises(AssertionError):
+  with pytest.raises(ValueError):
     hko_data_utils.jieqi_date(0, Jieqi.大寒) # Out of supported solar year range.
-  with pytest.raises(AssertionError):
+  with pytest.raises(ValueError):
     hko_data_utils.jieqi_date(1900, Jieqi.冬至) # Out of supported solar year range.
 
   assert hko_data_utils.jieqi_date(1901, Jieqi.小寒) == date(1901, 1, 6)
@@ -501,16 +517,18 @@ def test_get_jieqi_date() -> None:
 
 
 def test_get_jieqi_moment() -> None:
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     hko_data_utils.jieqi_moment('2024', Jieqi.大寒)
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     hko_data_utils.jieqi_moment(2024, '大寒')
-  with pytest.raises(AssertionError):
+  with pytest.raises(ValueError):
     hko_data_utils.jieqi_moment(9999, Jieqi.大寒) # Out of supported solar year range.
-  with pytest.raises(AssertionError):
+  with pytest.raises(ValueError):
     hko_data_utils.jieqi_moment(2101, Jieqi.小寒) # Out of supported solar year range.
-  with pytest.raises(AssertionError):
+  with pytest.raises(ValueError):
     hko_data_utils.jieqi_moment(0, Jieqi.大寒) # Out of supported solar year range.
+  with pytest.raises(ValueError):
+    hko_data_utils.jieqi_moment(1900, Jieqi.冬至) # Out of supported solar year range.
 
   # HKO data only supported day-level precision.
   # So all returned moments are always at the beginning of the day.
@@ -533,7 +551,7 @@ def test_get_jieqi_moment() -> None:
 def test_prev_jie() -> None:
   supported_range: tuple[datetime, datetime] = hko_data_utils.supported_jie_boundaries()
 
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     hko_data_utils.prev_jie('2024-06-15')
   with pytest.raises(ValueError):
     hko_data_utils.prev_jie(datetime(1899, 12, 31))
@@ -593,7 +611,7 @@ def test_prev_jie() -> None:
 def test_next_jie() -> None:
   supported_range: tuple[datetime, datetime] = hko_data_utils.supported_jie_boundaries()
 
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     hko_data_utils.next_jie('2024-06-15')
   with pytest.raises(ValueError):
     hko_data_utils.next_jie(datetime(1899, 12, 31))

--- a/tests/defines/test_dizhi.py
+++ b/tests/defines/test_dizhi.py
@@ -60,11 +60,11 @@ def test_from_str() -> None:
     Dizhi.from_str('Zi')
   with pytest.raises(ValueError):
     Dizhi.from_str('甲')
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     Dizhi.from_str(Dizhi.子) # type: ignore
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     Dizhi.from_str(0) # type: ignore
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     Dizhi.from_str(Tiangan.丁) # type: ignore
 
   assert Dizhi.from_str('寅') == Dizhi.寅

--- a/tests/defines/test_ganzhi.py
+++ b/tests/defines/test_ganzhi.py
@@ -60,11 +60,11 @@ def test_from_strs() -> None:
     Ganzhi.from_strs('子', '子')
   with pytest.raises(ValueError):
     Ganzhi.from_strs('甲', '甲')
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     Ganzhi.from_strs('甲', Dizhi.子) # type: ignore
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     Ganzhi.from_strs(Tiangan.甲, '子') # type: ignore
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     Ganzhi.from_strs(0, 0) # type: ignore
 
 
@@ -75,11 +75,11 @@ def test_from_str() -> None:
 
   with pytest.raises(ValueError):
     Ganzhi.from_str('假子')
-  with pytest.raises(AssertionError):
+  with pytest.raises(ValueError):
     Ganzhi.from_str('JIA子')
-  with pytest.raises(AssertionError):
+  with pytest.raises(ValueError):
     Ganzhi.from_str('Jia子')
-  with pytest.raises(AssertionError):
+  with pytest.raises(ValueError):
     Ganzhi.from_str('甲子子')
   with pytest.raises(ValueError):
     Ganzhi.from_str('子甲')
@@ -128,13 +128,13 @@ def test_list_sexagenary_cycle_strs() -> None:
 
 def test_ganzhi_next_prev() -> None:
   # Negative.
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     Ganzhi(Tiangan.甲, Dizhi.子).next('1')
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     Ganzhi(Tiangan.甲, Dizhi.子).prev('1')
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     Ganzhi(Tiangan.甲, Dizhi.子).next(3.5)
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     Ganzhi(Tiangan.甲, Dizhi.子).prev(3.5)
 
   def __random_gz() -> Ganzhi:

--- a/tests/defines/test_jieqi.py
+++ b/tests/defines/test_jieqi.py
@@ -60,17 +60,17 @@ def test_from_str() -> None:
     Jieqi.from_str('甲甲')
   with pytest.raises(ValueError):
     Jieqi.from_str('處暑') # Not supporting traditional Chinese.
-  with pytest.raises(AssertionError):
+  with pytest.raises(ValueError):
     Jieqi.from_str('立秋 ')
-  with pytest.raises(AssertionError):
+  with pytest.raises(ValueError):
     Jieqi.from_str('SHUNFEN')
-  with pytest.raises(AssertionError):
+  with pytest.raises(ValueError):
     Jieqi.from_str('Xiazhi')
-  with pytest.raises(AssertionError):
+  with pytest.raises(ValueError):
     Jieqi.from_str('春')
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     Jieqi.from_str(Tiangan.甲) # type: ignore
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     Jieqi.from_str(0) # type: ignore
 
   for jq in Jieqi:

--- a/tests/defines/test_shishen.py
+++ b/tests/defines/test_shishen.py
@@ -65,8 +65,5 @@ def test_str() -> None:
     Shishen.from_str('比间')
   with pytest.raises(ValueError):
     Shishen.from_str('枭神')
-
-
-def test_from_str_negative() -> None:
   with pytest.raises(TypeError):
     Shishen.from_str(0) # type: ignore

--- a/tests/defines/test_shishen.py
+++ b/tests/defines/test_shishen.py
@@ -53,11 +53,11 @@ def test_str() -> None:
 
   assert ''.join([s.abbr for s in Shishen]) == '比劫食伤财才官杀印枭'
 
-  with pytest.raises(AssertionError):
+  with pytest.raises(ValueError):
     Shishen.from_str('甲')
-  with pytest.raises(AssertionError):
+  with pytest.raises(ValueError):
     Shishen.from_str('辰')
-  with pytest.raises(AssertionError):
+  with pytest.raises(ValueError):
     Shishen.from_str('')
   with pytest.raises(ValueError):
     Shishen.from_str('甲子')
@@ -65,3 +65,8 @@ def test_str() -> None:
     Shishen.from_str('比间')
   with pytest.raises(ValueError):
     Shishen.from_str('枭神')
+
+
+def test_from_str_negative() -> None:
+  with pytest.raises(TypeError):
+    Shishen.from_str(0) # type: ignore

--- a/tests/defines/test_tiangan.py
+++ b/tests/defines/test_tiangan.py
@@ -63,9 +63,9 @@ def test_from_str() -> None:
     Tiangan.from_str('Jia')
   with pytest.raises(ValueError):
     Tiangan.from_str('子')
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     Tiangan.from_str(Tiangan.甲) # type: ignore
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     Tiangan.from_str(0) # type: ignore
 
   assert Tiangan.from_str('甲') == Tiangan.甲

--- a/tests/defines/test_wuxing.py
+++ b/tests/defines/test_wuxing.py
@@ -43,9 +43,9 @@ def test_from_str() -> None:
   assert Wuxing.from_str('金') is Wuxing.金
   assert Wuxing.from_str('水') is Wuxing.水
 
-  with pytest.raises(AssertionError):
+  with pytest.raises(ValueError):
     Wuxing.from_str('')
-  with pytest.raises(AssertionError):
+  with pytest.raises(ValueError):
     Wuxing.from_str('木木')
   with pytest.raises(ValueError):
     Wuxing.from_str('甲')

--- a/tests/o_smoke.py
+++ b/tests/o_smoke.py
@@ -4,8 +4,8 @@
 '''
 Smoke-checks the public fail-fast contract under `python -O`: every face below must
 raise its documented TypeError/ValueError even with asserts stripped (issue #102).
-Before #102 these faces degraded under `-O` into silent wrong answers (e.g. a tz-aware
-birth time quietly accepted) or deep internal KeyErrors.
+Without these gates, `-O` turns each face into a silent wrong answer (e.g. a tz-aware
+birth time quietly accepted) or a deep internal KeyError.
 
 Standalone by design -- no `test_` prefix, so pytest does not collect it; the gates
 run it via `run_tests.py -osmoke` as `python -O tests/o_smoke.py`. Runnable from any
@@ -25,6 +25,7 @@ def main() -> int:
     print('o_smoke.py must run under `python -O`: it checks the contract that outlives stripped asserts.')
     return 2
 
+  # Imports live here: at module level they would sit below the sys.path bootstrap and trip E402.
   from datetime import date, datetime
   from collections.abc import Callable
   from zoneinfo import ZoneInfo
@@ -52,7 +53,7 @@ def main() -> int:
      lambda: hko_data_utils.jieqi_moment(1900, Jieqi.冬至)),
     ('TransitMoment mutually exclusive fields', ValueError,
      lambda: TransitMoment(2024, Dizhi.子, date(2024, 6, 1))),
-    ('dayun past supported window (#63.1)', ValueError,
+    ('dayun past supported window', ValueError,
      lambda: next(BaziChart(Bazi.create(datetime(2091, 6, 1, 12), 'male', 'day')).dayun)),
     ('hko get_min_supported_date garbage date_type', ValueError,
      lambda: hko_data_utils.get_min_supported_date(42)),
@@ -69,7 +70,7 @@ def main() -> int:
       failures.append(f'{label}: no exception, expected {expected.__name__}')
     except expected:
       pass
-    except Exception as e: # noqa: BLE001 -- a smoke harness reports whatever actually leaked
+    except Exception as e: # noqa: BLE001 # a smoke harness reports whatever actually leaked
       failures.append(f'{label}: {type(e).__name__} ({e}), expected {expected.__name__}')
 
   for line in failures:

--- a/tests/o_smoke.py
+++ b/tests/o_smoke.py
@@ -1,0 +1,82 @@
+# Copyright (C) 2026 Ningqi Wang (0xf3cd) <https://github.com/0xf3cd>
+# o_smoke.py
+
+'''
+Smoke-checks the public fail-fast contract under `python -O`: every face below must
+raise its documented TypeError/ValueError even with asserts stripped (issue #102).
+Before #102 these faces degraded under `-O` into silent wrong answers (e.g. a tz-aware
+birth time quietly accepted) or deep internal KeyErrors.
+
+Standalone by design -- no `test_` prefix, so pytest does not collect it; the gates
+run it via `run_tests.py -osmoke` as `python -O tests/o_smoke.py`. Runnable from any
+cwd: the script puts the repo root on sys.path itself (`-m tests.o_smoke` is not an
+option -- a stray `tests` package in site-packages shadows the repo's `tests/`, see
+the import note in `tests/calendar/test_celestial_tables.py`).
+'''
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+def main() -> int:
+  if __debug__:
+    print('o_smoke.py must run under `python -O`: it checks the contract that outlives stripped asserts.')
+    return 2
+
+  from datetime import date, datetime
+  from collections.abc import Callable
+  from zoneinfo import ZoneInfo
+
+  from src.defines import Dizhi, Jieqi
+  from src.bazi import Bazi
+  from src.bazi_chart import BaziChart
+  from src.transits import TransitMoment
+  from src.utils import tiangan_utils
+  from src.calendar import hko_data, hko_data_utils
+  from src.calendar.backend import CalendarBackend, calendar_utils_of
+
+  checks: list[tuple[str, type[Exception], Callable[[], object]]] = [
+    ('Bazi.create below window (1901-01-01)', ValueError,
+     lambda: Bazi.create(datetime(1901, 1, 1, 12), 'male', 'day')),
+    ('Bazi.create above window (2100-06-01)', ValueError,
+     lambda: Bazi.create(datetime(2100, 6, 1, 12), 'male', 'day')),
+    ('Bazi.create tz-aware birth time', ValueError,
+     lambda: Bazi.create(datetime(2000, 1, 1, 7, tzinfo=ZoneInfo('Asia/Shanghai')), 'male', 'day')),
+    ('tiangan_utils.he on raw strings', TypeError,
+     lambda: tiangan_utils.he('甲', '己')), # type: ignore
+    ('DecodedLunarYears.get out of range', ValueError,
+     lambda: hko_data.DecodedLunarYears().get(1800)),
+    ('jieqi_moment out of range', ValueError,
+     lambda: hko_data_utils.jieqi_moment(1900, Jieqi.冬至)),
+    ('TransitMoment mutually exclusive fields', ValueError,
+     lambda: TransitMoment(2024, Dizhi.子, date(2024, 6, 1))),
+    ('dayun past supported window (#63.1)', ValueError,
+     lambda: next(BaziChart(Bazi.create(datetime(2091, 6, 1, 12), 'male', 'day')).dayun)),
+    ('hko get_min_supported_date garbage date_type', ValueError,
+     lambda: hko_data_utils.get_min_supported_date(42)),
+    ('celestial get_max_supported_date garbage date_type', ValueError,
+     lambda: calendar_utils_of(CalendarBackend.CELESTIAL).get_max_supported_date(42)), # type: ignore
+    ('calendar_utils_of garbage backend', TypeError,
+     lambda: calendar_utils_of(42)), # type: ignore
+  ]
+
+  failures: list[str] = []
+  for label, expected, thunk in checks:
+    try:
+      thunk()
+      failures.append(f'{label}: no exception, expected {expected.__name__}')
+    except expected:
+      pass
+    except Exception as e: # noqa: BLE001 -- a smoke harness reports whatever actually leaked
+      failures.append(f'{label}: {type(e).__name__} ({e}), expected {expected.__name__}')
+
+  for line in failures:
+    print(f'FAIL {line}')
+  print(f'o_smoke: {len(checks) - len(failures)}/{len(checks)} public faces hold under -O.')
+  return 1 if failures else 0
+
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/tests/test_bazi.py
+++ b/tests/test_bazi.py
@@ -368,10 +368,14 @@ def test_invalid_arguments() -> None:
     Bazi(birth_time=random_dt, gender=BaziGender.男) # type: ignore # Missing `precision`
   with pytest.raises(TypeError):
     Bazi(birth_time=random_dt, precision=BaziPrecision.DAY) # type: ignore # Missing `gender`
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     Bazi(birth_time='2024-03-03', gender=BaziGender.男, precision=BaziPrecision.DAY) # type: ignore # Currently doesn't take string as input
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     Bazi(birth_time=date(9999, 1, 1), gender=BaziGender.男, precision=BaziPrecision.DAY) # type: ignore
+  with pytest.raises(TypeError):
+    Bazi(birth_time=random_dt, gender='男', precision=BaziPrecision.DAY) # type: ignore # `__init__` only takes the enum.
+  with pytest.raises(TypeError):
+    Bazi(birth_time=random_dt, gender=BaziGender.男, precision='day') # type: ignore # `__init__` only takes the enum.
   with pytest.raises(ValueError):
     dt: datetime = datetime(
       year=9999, # Out of supported range.
@@ -382,7 +386,7 @@ def test_invalid_arguments() -> None:
       second=random.randint(0, 59)
     )
     Bazi(birth_time=dt, gender=BaziGender.男, precision=BaziPrecision.DAY)
-  with pytest.raises(AssertionError):
+  with pytest.raises(ValueError):
     Bazi(
       birth_time=datetime(
         year=2000,
@@ -555,12 +559,19 @@ def test_create() -> None:
   with pytest.raises(ValueError):
     Bazi.create(datetime.now(), BaziGender.FEMALE, 'dya')
 
+  with pytest.raises(TypeError):
+    Bazi.create(19840402, BaziGender.FEMALE, BaziPrecision.DAY) # type: ignore
+  with pytest.raises(TypeError):
+    Bazi.create(datetime.now(), 1984, BaziPrecision.DAY) # type: ignore
+  with pytest.raises(TypeError):
+    Bazi.create(datetime.now(), BaziGender.FEMALE, 1984) # type: ignore
+
   # Create a datetime and set its timezone to Asia/Shanghai.
   _dt: datetime = datetime.now()
   _dt = _dt.replace(tzinfo=ZoneInfo('Asia/Shanghai'))
-  with pytest.raises(AssertionError):
+  with pytest.raises(ValueError):
     Bazi.create(_dt, BaziGender.FEMALE, BaziPrecision.DAY)
-  with pytest.raises(AssertionError):
+  with pytest.raises(ValueError):
     Bazi.create(_dt.isoformat(), BaziGender.FEMALE, BaziPrecision.DAY)
 
   now: datetime = datetime.now()
@@ -595,6 +606,20 @@ def test_create() -> None:
     assert bazi.precision in (BaziPrecision.HOUR, BaziPrecision.MINUTE)
     with pytest.raises(ValueError):
       Bazi.create(dt, g, p, backend='hko') # HKO has no real jieqi moments.
+
+
+def test_supported_date_window_edges() -> None:
+  '''
+  The supported date window, pinned as a `Bazi`-level contract: one day outside either
+  edge raises (the calendar funnel validates the converted date), the edges themselves
+  construct. The window itself is the celestial backend's, pinned in its own tests.
+  '''
+  with pytest.raises(ValueError):
+    Bazi.create(datetime(1901, 2, 18, 12), 'male', 'day')
+  with pytest.raises(ValueError):
+    Bazi.create(datetime(2100, 1, 1, 12), 'male', 'day')
+  assert Bazi.create(datetime(1901, 2, 19, 12), 'male', 'day').solar_date == date(1901, 2, 19)
+  assert Bazi.create(datetime(2099, 12, 31, 12), 'male', 'day').solar_date == date(2099, 12, 31)
 
 
 def test_eq_ne() -> None:

--- a/tests/test_bazi.py
+++ b/tests/test_bazi.py
@@ -372,7 +372,7 @@ def test_invalid_arguments() -> None:
     Bazi(birth_time='2024-03-03', gender=BaziGender.男, precision=BaziPrecision.DAY) # type: ignore # Currently doesn't take string as input
   with pytest.raises(AssertionError):
     Bazi(birth_time=date(9999, 1, 1), gender=BaziGender.男, precision=BaziPrecision.DAY) # type: ignore
-  with pytest.raises(AssertionError):
+  with pytest.raises(ValueError):
     dt: datetime = datetime(
       year=9999, # Out of supported range.
       month=random.randint(1, 12),

--- a/tests/test_bazi_chart.py
+++ b/tests/test_bazi_chart.py
@@ -37,7 +37,7 @@ def test_basic() -> None:
     if tg is not bazi.day_master:
       assert chart.bazi.day_master != tg
 
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     BaziChart(date(2024, 1, 1))  # type: ignore
 
 
@@ -58,7 +58,7 @@ def test_malicious() -> None:
     BaziChart(Bazi.random()).bazi = Bazi.random()  # type: ignore
 
   # Invalid __init__ parameters
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     BaziChart('1984-04-02 04:02:00') # type: ignore
   with pytest.raises(TypeError):
     BaziChart(datetime(1984, 4, 2, 4, 2), BaziGender.男, BaziPrecision.DAY) # type: ignore

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -47,6 +47,16 @@ def test_interpret_tiangan() -> None:
     assert result == Interpreter.interpret_tiangan(tg)
 
 
+def test_interpret_shishen_negative() -> None:
+  with pytest.raises(TypeError):
+    Interpreter.interpret_shishen('比肩') # type: ignore
+
+
+def test_interpret_tiangan_negative() -> None:
+  with pytest.raises(TypeError):
+    Interpreter.interpret_tiangan('甲') # type: ignore
+
+
 def test_corpus_is_frozen() -> None:
   # The corpus tables are frozen: reassigning an entry must fail, and mutating a
   # returned description must not corrupt the corpus.

--- a/tests/test_transit_chart.py
+++ b/tests/test_transit_chart.py
@@ -22,9 +22,9 @@ def test_basic() -> None:
 
 
 def test_basic_negative() -> None:
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     TransitChart(BaziChart.random().bazi) # type: ignore
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     TransitChart(datetime(2024, 1, 1)) # type: ignore
 
   with pytest.raises(AttributeError):
@@ -49,12 +49,20 @@ def test_delegation_negative() -> None:
   bazi: Bazi = Bazi.create(datetime(2000, 2, 4, 22, 1), BaziGender.MALE, BaziPrecision.DAY)
   transits: TransitChart = TransitChart(BaziChart(bazi))
 
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     transits.support('1999', TransitOptions.XIAOYUN) # type: ignore
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     transits.support(1999, TransitOptions.XIAOYUN) # type: ignore # int no longer accepted; `TransitMoment` required.
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
+    transits.support(TransitMoment(1999), 'XIAOYUN') # type: ignore
+  with pytest.raises(ValueError):
+    transits.support(TransitMoment(1999), TransitOptions(0))
+  with pytest.raises(TypeError):
+    transits.ganzhis('1999', TransitOptions.XIAOYUN) # type: ignore
+  with pytest.raises(TypeError):
     transits.ganzhis(TransitMoment(1999), 'XIAOYUN') # type: ignore
+  with pytest.raises(ValueError):
+    transits.ganzhis(TransitMoment(1999), TransitOptions(0))
   # Month/day-granularity moments are rejected until #48 / #48 落地前，月/日粒度的 moment 显式拒绝。
   with pytest.raises(NotImplementedError):
     transits.support(TransitMoment(2000, gz_month=Dizhi.寅), TransitOptions.LIUNIAN)

--- a/tests/test_transits.py
+++ b/tests/test_transits.py
@@ -40,7 +40,9 @@ def test_dayun_database() -> None:
       expected[year] = DayunTuple(start_year, dayun_ganzhi)
 
   db: DayunDatabase = DayunDatabase(chart)
-  with pytest.raises(AssertionError): # Test the year before the start of the dayun.
+  with pytest.raises(TypeError):
+    db['2000'] # type: ignore
+  with pytest.raises(ValueError): # Test the year before the start of the dayun.
     db[next(chart.dayun).ganzhi_year - 1]
 
   years: list[int] = list(expected.keys())
@@ -61,18 +63,18 @@ def test_support() -> None:
     chart: BaziChart = BaziChart.random()
     db: TransitDatabase = TransitDatabase(chart)
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(TypeError):
       db.support('1999', TransitOptions.XIAOYUN) # type: ignore
-    with pytest.raises(AssertionError):
+    with pytest.raises(TypeError):
       db.support(1999, TransitOptions.XIAOYUN) # type: ignore # int no longer accepted; `TransitMoment` required.
-    with pytest.raises(AssertionError):
+    with pytest.raises(TypeError):
       db.support(TransitMoment(1999), 'XIAOYUN') # type: ignore
-    with pytest.raises(AssertionError):
+    with pytest.raises(TypeError):
       db.support(TransitMoment(1999), 0x1 | 0x4) # type: ignore
     # Zero-value and unknown-bit flags are rejected on all Python versions (3.12+'s `in` used to let them through).
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
       db.support(TransitMoment(1999), TransitOptions(0))
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
       db.support(TransitMoment(1999), TransitOptions(0x8))
 
     # Ganzhi years before the birth year are not supported.
@@ -105,6 +107,13 @@ def test_ganzhis() -> None:
   for _ in range(4):
     chart = BaziChart.random()
     db: TransitDatabase = TransitDatabase(chart)
+
+    with pytest.raises(TypeError):
+      db.ganzhis('1999', TransitOptions.XIAOYUN) # type: ignore
+    with pytest.raises(TypeError):
+      db.ganzhis(TransitMoment(1999), 'XIAOYUN') # type: ignore
+    with pytest.raises(ValueError):
+      db.ganzhis(TransitMoment(1999), TransitOptions(0))
 
     xiaoyun_ganzhis: dict[int, Ganzhi] = {
       chart.bazi.ganzhi_date.year + age - 1 : xy
@@ -170,17 +179,17 @@ def test_value_semantics() -> None:
 
 
 def test_invalid() -> None:
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     TransitMoment('1990') # type: ignore
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     TransitMoment(1990, gz_month=3) # type: ignore
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     TransitMoment(1990, solar_date='1990-05-20') # type: ignore
   # `datetime` is a `date` subclass but breaks the value semantics / datetime 是 date 子类，但破坏值语义（与 date 不相等、hash 不同）。
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     TransitMoment(1990, solar_date=datetime(1990, 5, 20, 12, 0))
   # The month and day granularities are mutually exclusive / 月粒度与日粒度互斥。
-  with pytest.raises(AssertionError):
+  with pytest.raises(ValueError):
     TransitMoment(1990, gz_month=Dizhi.寅, solar_date=date(1990, 5, 20))
 
 

--- a/tests/utils/test_bazi_utils.py
+++ b/tests/utils/test_bazi_utils.py
@@ -39,10 +39,15 @@ def test_ganzhi_of_day_basic() -> None:
     assert bazi_utils.ganzhi_of_day(d) == Ganzhi.list_sexagenary_cycle()[offset % 60]
 
 
+def test_ganzhi_of_day_negative() -> None:
+  with pytest.raises(TypeError):
+    bazi_utils.ganzhi_of_day('2024-03-01') # type: ignore
+
+
 def test_ganzhi_of_year() -> None:
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     bazi_utils.ganzhi_of_year('2024') # type: ignore
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     bazi_utils.ganzhi_of_year((2024,)) # type: ignore
 
   assert bazi_utils.ganzhi_of_year(1836) == Ganzhi.from_str('丙申')
@@ -67,6 +72,13 @@ def test_month_tiangan() -> None:
   assert bazi_utils.month_tiangan(Tiangan.戊, Dizhi.巳) == Tiangan.丁
 
 
+def test_month_tiangan_negative() -> None:
+  with pytest.raises(TypeError):
+    bazi_utils.month_tiangan('甲', Dizhi.寅) # type: ignore
+  with pytest.raises(TypeError):
+    bazi_utils.month_tiangan(Tiangan.甲, '寅') # type: ignore
+
+
 def test_hour_tiangan() -> None:
   assert bazi_utils.hour_tiangan(Tiangan.甲, Dizhi.寅) == Tiangan.丙
   assert bazi_utils.hour_tiangan(Tiangan.壬, Dizhi.子) == Tiangan.庚
@@ -75,12 +87,24 @@ def test_hour_tiangan() -> None:
   assert bazi_utils.hour_tiangan(Tiangan.丙, Dizhi.卯) == Tiangan.辛
 
 
+def test_hour_tiangan_negative() -> None:
+  with pytest.raises(TypeError):
+    bazi_utils.hour_tiangan('甲', Dizhi.寅) # type: ignore
+  with pytest.raises(TypeError):
+    bazi_utils.hour_tiangan(Tiangan.甲, '寅') # type: ignore
+
+
 def test_tiangan_traits() -> None:
   for idx, tg in enumerate(Tiangan):
     expected_wuxing: Wuxing = Wuxing.as_list()[idx // 2]
     expected_yinyang: Yinyang = Yinyang.as_list()[idx % 2]
     assert bazi_utils.tiangan_traits(tg) == TraitTuple(expected_wuxing, expected_yinyang)
     assert str(bazi_utils.tiangan_traits(tg)) == str(expected_yinyang) + str(expected_wuxing)
+
+
+def test_tiangan_traits_negative() -> None:
+  with pytest.raises(TypeError):
+    bazi_utils.tiangan_traits('甲') # type: ignore
 
 
 def test_dizhi_traits() -> None:
@@ -107,6 +131,16 @@ def test_dizhi_traits() -> None:
     assert bazi_utils.dizhi_traits(dz) == TraitTuple(expected_wuxing, expected_yinyang)
 
 
+def test_dizhi_traits_negative() -> None:
+  with pytest.raises(TypeError):
+    bazi_utils.dizhi_traits('子') # type: ignore
+
+
+def test_traits_negative() -> None:
+  with pytest.raises(TypeError):
+    bazi_utils.traits('甲') # type: ignore
+
+
 def test_hidden_tiangans() -> None:
   for dz in Dizhi:
     percentages: HiddenTianganDict = bazi_utils.hidden_tiangans(dz)
@@ -115,6 +149,11 @@ def test_hidden_tiangans() -> None:
     assert sum(percentages.values()) == 100
     for tg in percentages:
       assert tg in Tiangan
+
+
+def test_hidden_tiangans_negative() -> None:
+  with pytest.raises(TypeError):
+    bazi_utils.hidden_tiangans('子') # type: ignore
 
 
 def test_shishen() -> None:
@@ -134,6 +173,13 @@ def test_shishen() -> None:
 
   assert bazi_utils.shishen(Tiangan.甲, Tiangan.壬) == Shishen.偏印
   assert bazi_utils.shishen(Tiangan.甲, Dizhi.子) == Shishen.正印
+
+
+def test_shishen_negative() -> None:
+  with pytest.raises(TypeError):
+    bazi_utils.shishen('甲', Tiangan.甲) # type: ignore
+  with pytest.raises(TypeError):
+    bazi_utils.shishen(Tiangan.甲, '寅') # type: ignore
 
 
 def test_nayin_str() -> None:
@@ -159,6 +205,11 @@ def test_nayin_str() -> None:
       else:
         with pytest.raises(AssertionError):
           bazi_utils.nayin_str(gz) # Ganzhis not in the sexagenary cycle don't have nayin.
+
+
+def test_nayin_str_negative() -> None:
+  with pytest.raises(TypeError):
+    bazi_utils.nayin_str('甲子') # type: ignore
 
 
 def test_shier_zhangsheng() -> None:
@@ -191,6 +242,13 @@ def test_shier_zhangsheng() -> None:
             bazi_utils.shier_zhangsheng(*Ganzhi.from_strs('己', str(dz))))
 
 
+def test_shier_zhangsheng_negative() -> None:
+  with pytest.raises(TypeError):
+    bazi_utils.shier_zhangsheng('甲', Dizhi.子) # type: ignore
+  with pytest.raises(TypeError):
+    bazi_utils.shier_zhangsheng(Tiangan.甲, '子') # type: ignore
+
+
 def test_from_shier_zhangsheng() -> None:
   assert bazi_utils.from_shier_zhangsheng(Tiangan('甲'), ShierZhangsheng.沐浴) == Dizhi('子')
   assert bazi_utils.from_shier_zhangsheng(Tiangan('甲'), ShierZhangsheng.长生) == Dizhi('亥')
@@ -221,6 +279,13 @@ def test_from_shier_zhangsheng() -> None:
             bazi_utils.from_shier_zhangsheng(Tiangan('己'), place))
 
 
+def test_from_shier_zhangsheng_negative() -> None:
+  with pytest.raises(TypeError):
+    bazi_utils.from_shier_zhangsheng('甲', ShierZhangsheng.沐浴) # type: ignore
+  with pytest.raises(TypeError):
+    bazi_utils.from_shier_zhangsheng(Tiangan.甲, '沐浴') # type: ignore
+
+
 def test_shier_zhangsheng_consistency() -> None:
   for tg, dz in itertools.product(Tiangan, Dizhi):
     zs: ShierZhangsheng = bazi_utils.shier_zhangsheng(tg, dz)
@@ -233,3 +298,8 @@ def test_shier_zhangsheng_consistency() -> None:
 def test_lu() -> None:
   for tg in Tiangan:
     assert bazi_utils.lu(tg) == bazi_utils.from_shier_zhangsheng(tg, ShierZhangsheng('临官'))
+
+
+def test_lu_negative() -> None:
+  with pytest.raises(TypeError):
+    bazi_utils.lu('甲') # type: ignore

--- a/tests/utils/test_dizhi_utils.py
+++ b/tests/utils/test_dizhi_utils.py
@@ -69,7 +69,7 @@ def test_sanhui() -> None:
     dizhi_utils.sanhui({Dizhi.亥, Dizhi.子, Dizhi.丑}) # type: ignore
   with pytest.raises(TypeError):
     dizhi_utils.sanhui([Dizhi.亥, Dizhi.子, Dizhi.丑]) # type: ignore
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     dizhi_utils.sanhui('亥', '子', '丑') # type: ignore
 
   dizhi_tuples: list[tuple[Dizhi, Dizhi, Dizhi]] = [
@@ -89,7 +89,7 @@ def test_sanhui() -> None:
         assert dizhi_utils.sanhui(*combo) == expected[fs]
     else:
       for combo in itertools.permutations(dizhis):
-        assert dizhi_utils.sanhui(*dizhis) is None
+        assert dizhi_utils.sanhui(*combo) is None
 
 
 def test_search_liuhe() -> None:
@@ -124,7 +124,7 @@ def test_liuhe() -> None:
     dizhi_utils.liuhe({Dizhi.子, Dizhi.丑}) # type: ignore
   with pytest.raises(TypeError):
     dizhi_utils.liuhe([Dizhi.子, Dizhi.丑]) # type: ignore
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     dizhi_utils.liuhe('亥', '子') # type: ignore
 
   liuhe_combos: list[DizhiCombo] = [
@@ -190,11 +190,11 @@ def test_anhe() -> None:
     dizhi_utils.anhe({Dizhi.子, Dizhi.丑}) # type: ignore
   with pytest.raises(TypeError):
     dizhi_utils.anhe([Dizhi.子, Dizhi.丑]) # type: ignore
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     dizhi_utils.anhe('亥', '子') # type: ignore
   with pytest.raises(TypeError):
     dizhi_utils.anhe(Dizhi.子, Dizhi.辰, DizhiRules.AnheDef.NORMAL + 100) # type: ignore
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     dizhi_utils.anhe(Dizhi.子, Dizhi.辰, definition='DizhiRules.AnheDef.NORMAL') # type: ignore
 
   normal_combos: list[DizhiCombo] = [
@@ -266,7 +266,7 @@ def test_tonghe() -> None:
     dizhi_utils.tonghe({Dizhi.子, Dizhi.丑}) # type: ignore
   with pytest.raises(TypeError):
     dizhi_utils.tonghe([Dizhi.子, Dizhi.丑]) # type: ignore
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     dizhi_utils.tonghe('亥', '子') # type: ignore
 
   tonghe_combos: set[DizhiCombo] = set()
@@ -316,7 +316,7 @@ def test_tongluhe() -> None:
     dizhi_utils.tongluhe({Dizhi.子, Dizhi.丑}) # type: ignore
   with pytest.raises(TypeError):
     dizhi_utils.tongluhe([Dizhi.子, Dizhi.丑]) # type: ignore
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     dizhi_utils.tongluhe('亥', '子') # type: ignore
 
   tongluhe_combos: list[DizhiCombo] = [ # 天干五合对应的地支禄身。
@@ -372,7 +372,7 @@ def test_sanhe() -> None:
     dizhi_utils.sanhe({Dizhi.亥, Dizhi.子, Dizhi.丑}) # type: ignore
   with pytest.raises(TypeError):
     dizhi_utils.sanhe([Dizhi.亥, Dizhi.子, Dizhi.丑]) # type: ignore
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     dizhi_utils.sanhe('亥', '子', '丑') # type: ignore
 
   sanhe_table: dict[DizhiCombo, Wuxing] = _gen_sanhe_table()
@@ -384,7 +384,7 @@ def test_sanhe() -> None:
         assert dizhi_utils.sanhe(*combo) == sanhe_table[fs]
     else:
       for combo in itertools.permutations(dizhis):
-        assert dizhi_utils.sanhe(*dizhis) is None
+        assert dizhi_utils.sanhe(*combo) is None
 
 
 def _gen_banhe_table() -> dict[DizhiCombo, Wuxing]:
@@ -429,7 +429,7 @@ def test_banhe() -> None:
     dizhi_utils.banhe({Dizhi.子, Dizhi.丑}) # type: ignore
   with pytest.raises(TypeError):
     dizhi_utils.banhe([Dizhi.子, Dizhi.丑]) # type: ignore
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     dizhi_utils.banhe('亥', '子') # type: ignore
 
   banhe_table: dict[DizhiCombo, Wuxing] = _gen_banhe_table()
@@ -500,19 +500,19 @@ def test_search_xing() -> None:
 
 
 def test_xing_negative() -> None:
-  with pytest.raises(AssertionError):
+  with pytest.raises(ValueError):
     dizhi_utils.xing(Dizhi.子, Dizhi.辰, Dizhi.子, Dizhi.辰)
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     dizhi_utils.xing((Dizhi.子, Dizhi.丑)) # type: ignore
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     dizhi_utils.xing({Dizhi.子, Dizhi.丑}) # type: ignore
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     dizhi_utils.xing([Dizhi.子, Dizhi.丑]) # type: ignore
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     dizhi_utils.xing('亥', '子') # type: ignore
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     dizhi_utils.xing(Dizhi.子, Dizhi.辰, DizhiRules.XingDef.LOOSE) # type: ignore
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     dizhi_utils.xing(Dizhi.子, Dizhi.辰, definition='DizhiRules.X.NORMAL') # type: ignore
 
   for dz in Dizhi:
@@ -522,12 +522,12 @@ def test_xing_negative() -> None:
 
   for _ in range(500):
     random_dizhis: list[Dizhi] = random.sample(list(Dizhi), random.randint(4, len(Dizhi)))
-    with pytest.raises(AssertionError):
-      assert dizhi_utils.xing(*random_dizhis) is None
-    with pytest.raises(AssertionError):
-      assert dizhi_utils.xing(*random_dizhis, definition=DizhiRules.XingDef.STRICT) is None
-    with pytest.raises(AssertionError):
-      assert dizhi_utils.xing(*random_dizhis, definition=DizhiRules.XingDef.LOOSE) is None
+    with pytest.raises(ValueError):
+      dizhi_utils.xing(*random_dizhis)
+    with pytest.raises(ValueError):
+      dizhi_utils.xing(*random_dizhis, definition=DizhiRules.XingDef.STRICT)
+    with pytest.raises(ValueError):
+      dizhi_utils.xing(*random_dizhis, definition=DizhiRules.XingDef.LOOSE)
 
 
 @pytest.mark.slow
@@ -668,9 +668,9 @@ def test_chong() -> None:
     dizhi_utils.chong({Dizhi.亥, Dizhi.子, Dizhi.丑}) # type: ignore
   with pytest.raises(TypeError):
     dizhi_utils.chong([Dizhi.亥, Dizhi.子, Dizhi.丑]) # type: ignore
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     dizhi_utils.chong('亥', '子') # type: ignore
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     dizhi_utils.chong(Tiangan.甲, '子') # type: ignore
 
   chong_table: list[set[Dizhi]] = [set(dz_tuple) for dz_tuple in zip(Dizhi.as_list()[:6], Dizhi.as_list()[6:])]
@@ -718,9 +718,9 @@ def test_po() -> None:
     dizhi_utils.po({Dizhi.亥, Dizhi.子, Dizhi.丑}) # type: ignore
   with pytest.raises(TypeError):
     dizhi_utils.po([Dizhi.亥, Dizhi.子, Dizhi.丑]) # type: ignore
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     dizhi_utils.po([Dizhi.亥, Dizhi.子], [Dizhi.丑]) # type: ignore
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     dizhi_utils.po('亥', '子') # type: ignore
 
   po_table: list[set[Dizhi]] = _gen_po_table()
@@ -773,9 +773,9 @@ def test_hai() -> None:
     dizhi_utils.hai((Dizhi.亥, Dizhi.子, Dizhi.丑)) # type: ignore
   with pytest.raises(TypeError):
     dizhi_utils.hai({Dizhi.亥, Dizhi.子, Dizhi.丑}) # type: ignore
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     dizhi_utils.hai([Dizhi.亥], [Dizhi.丑]) # type: ignore
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     dizhi_utils.hai('亥', '丑') # type: ignore
 
   hai_set: set[DizhiCombo] = _gen_hai_table()
@@ -815,9 +815,9 @@ def test_sheng() -> None:
     dizhi_utils.sheng((Dizhi.亥, Dizhi.子, Dizhi.丑)) # type: ignore
   with pytest.raises(TypeError):
     dizhi_utils.sheng({Dizhi.亥, Dizhi.子, Dizhi.丑}) # type: ignore
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     dizhi_utils.sheng([Dizhi.亥], [Dizhi.丑]) # type: ignore
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     dizhi_utils.sheng('亥', '丑') # type: ignore
 
   for dz1, dz2 in itertools.product(Dizhi, repeat=2):
@@ -838,9 +838,9 @@ def test_ke() -> None:
     dizhi_utils.ke((Dizhi.亥, Dizhi.子, Dizhi.丑)) # type: ignore
   with pytest.raises(TypeError):
     dizhi_utils.ke({Dizhi.亥, Dizhi.子, Dizhi.丑}) # type: ignore
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     dizhi_utils.ke([Dizhi.亥], [Dizhi.丑]) # type: ignore
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     dizhi_utils.ke('亥', '丑') # type: ignore
 
   for dz1, dz2 in itertools.product(Dizhi, repeat=2):
@@ -857,17 +857,17 @@ def test_search_negative() -> None:
     dizhi_utils.search([Dizhi.子, Dizhi.午]) # type: ignore
 
   for tg_relation in TianganRelation:
-    with pytest.raises(AssertionError):
+    with pytest.raises(TypeError):
       dizhi_utils.search([Dizhi.子, Dizhi.午], tg_relation) # type: ignore
 
   for relation in DizhiRelation:
-    with pytest.raises(AssertionError):
+    with pytest.raises(TypeError):
       dizhi_utils.search(Dizhi.子, relation) # type: ignore
-    with pytest.raises(AssertionError):
+    with pytest.raises(TypeError):
       dizhi_utils.search(['甲', '己'], relation) # type: ignore
-    with pytest.raises(AssertionError):
+    with pytest.raises(TypeError):
       dizhi_utils.search([Dizhi.子, Dizhi.午], str(relation)) # type: ignore
-    with pytest.raises(AssertionError):
+    with pytest.raises(TypeError):
       dizhi_utils.search({Dizhi.子, Dizhi.午}, relation) # type: ignore
 
 
@@ -964,6 +964,11 @@ def test_discover() -> None:
     assert discovery == discovery2
 
 
+def test_discover_negative() -> None:
+  with pytest.raises(TypeError):
+    dizhi_utils.discover([Dizhi.子, '午']) # type: ignore
+
+
 @pytest.mark.slow
 def test_discover_mutual() -> None:
   def __random_dz_lists() -> tuple[list[Dizhi], list[Dizhi]]:
@@ -1024,6 +1029,13 @@ def test_discover_mutual() -> None:
           assert combo in expected_combos
       else:
         assert len(expected_combos) == 0
+
+
+def test_discover_mutual_negative() -> None:
+  with pytest.raises(TypeError):
+    dizhi_utils.discover_mutual([Dizhi.亥, '子'], [Dizhi.丑]) # type: ignore
+  with pytest.raises(TypeError):
+    dizhi_utils.discover_mutual([Dizhi.亥], [Dizhi.子, '丑']) # type: ignore
 
 
 def test_edge_cases() -> None:

--- a/tests/utils/test_relation_discovery.py
+++ b/tests/utils/test_relation_discovery.py
@@ -1,0 +1,33 @@
+# Copyright (C) 2026 Ningqi Wang (0xf3cd) <https://github.com/0xf3cd>
+# test_relation_discovery.py
+
+'''
+Contract negatives for `RelationDiscovery`. Positive behaviors are covered by the
+`discover`-family tests in `test_tiangan_utils.py` / `test_dizhi_utils.py`.
+'''
+
+import pytest
+
+from src.defines import Tiangan, Dizhi
+from src.utils import tiangan_utils, dizhi_utils
+from src.utils.tiangan_utils import TianganRelationDiscovery
+
+
+def test_filter_negative() -> None:
+  discovery: TianganRelationDiscovery = tiangan_utils.discover([Tiangan.甲, Tiangan.己])
+  with pytest.raises(TypeError):
+    discovery.filter('not a callable') # type: ignore
+
+
+def test_merge_negative() -> None:
+  discovery: TianganRelationDiscovery = tiangan_utils.discover([Tiangan.甲, Tiangan.己])
+  with pytest.raises(TypeError):
+    discovery.merge(dizhi_utils.discover([Dizhi.子, Dizhi.丑])) # type: ignore
+
+
+def test_mutual_only_negative() -> None:
+  discovery: TianganRelationDiscovery = tiangan_utils.discover([Tiangan.甲, Tiangan.己])
+  with pytest.raises(TypeError):
+    discovery.mutual_only([Tiangan.甲], {Tiangan.己}) # type: ignore
+  with pytest.raises(TypeError):
+    discovery.mutual_only({Tiangan.甲}, [Tiangan.己]) # type: ignore

--- a/tests/utils/test_shensha_utils.py
+++ b/tests/utils/test_shensha_utils.py
@@ -3,6 +3,8 @@
 
 import random
 
+import pytest
+
 from src.defines import Tiangan, Dizhi
 from src.utils import shensha_utils
 
@@ -18,6 +20,13 @@ def test_taohua() -> None:
     dz1, dz2 = random.choices(Dizhi.as_list(), k=2)
     assert shensha_utils.taohua(dz1, dz2) == (expected_table[dz1] is dz2)
     assert shensha_utils.taohua(dz1, dz2) == (expected_table[dz1] is dz2) # Second call must answer the same (determinism across calls).
+
+
+def test_taohua_negative() -> None:
+  with pytest.raises(TypeError):
+    shensha_utils.taohua('申', Dizhi.酉) # type: ignore
+  with pytest.raises(TypeError):
+    shensha_utils.taohua(Dizhi.申, '酉') # type: ignore
 
 
 def test_hongyan() -> None:
@@ -39,6 +48,13 @@ def test_hongyan() -> None:
     assert shensha_utils.hongyan(tg, dz) == expected_result # Second call must answer the same (determinism across calls).
 
 
+def test_hongyan_negative() -> None:
+  with pytest.raises(TypeError):
+    shensha_utils.hongyan('癸', Dizhi.申) # type: ignore
+  with pytest.raises(TypeError):
+    shensha_utils.hongyan(Tiangan.癸, '申') # type: ignore
+
+
 def test_hongluan() -> None:
   expected_table: dict[Dizhi, Dizhi] = {}
   for dz1, dz2 in [
@@ -56,6 +72,13 @@ def test_hongluan() -> None:
     dz1, dz2 = random.choices(Dizhi.as_list(), k=2)
     assert shensha_utils.hongluan(dz1, dz2) == (expected_table[dz1] is dz2)
     assert shensha_utils.hongluan(dz1, dz2) == (expected_table[dz1] is dz2) # Second call must answer the same (determinism across calls).
+
+
+def test_hongluan_negative() -> None:
+  with pytest.raises(TypeError):
+    shensha_utils.hongluan('申', Dizhi.未) # type: ignore
+  with pytest.raises(TypeError):
+    shensha_utils.hongluan(Dizhi.申, '未') # type: ignore
 
 
 def test_tianxi() -> None:
@@ -77,6 +100,13 @@ def test_tianxi() -> None:
     assert shensha_utils.tianxi(dz1, dz2) == (expected_table[dz1] is dz2) # Second call must answer the same (determinism across calls).
 
 
+def test_tianxi_negative() -> None:
+  with pytest.raises(TypeError):
+    shensha_utils.tianxi('寅', Dizhi.未) # type: ignore
+  with pytest.raises(TypeError):
+    shensha_utils.tianxi(Dizhi.寅, '未') # type: ignore
+
+
 def test_yima() -> None:
   expected_table: dict[Dizhi, Dizhi] = {
     Dizhi(k_str) : Dizhi(v_str)
@@ -88,3 +118,10 @@ def test_yima() -> None:
     dz1, dz2 = random.choices(Dizhi.as_list(), k=2)
     assert shensha_utils.yima(dz1, dz2) == (expected_table[dz1] is dz2)
     assert shensha_utils.yima(dz1, dz2) == (expected_table[dz1] is dz2) # Second call must answer the same (determinism across calls).
+
+
+def test_yima_negative() -> None:
+  with pytest.raises(TypeError):
+    shensha_utils.yima('申', Dizhi.寅) # type: ignore
+  with pytest.raises(TypeError):
+    shensha_utils.yima(Dizhi.申, '寅') # type: ignore

--- a/tests/utils/test_tiangan_utils.py
+++ b/tests/utils/test_tiangan_utils.py
@@ -102,23 +102,23 @@ def test_search_negative() -> None:
     tiangan_utils.search(Tiangan.辛, TianganRelation.合) # type: ignore
   with pytest.raises(TypeError):
     tiangan_utils.search((Tiangan.甲, Dizhi.子)) # type: ignore
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     tiangan_utils.search((Tiangan.甲, Dizhi.子), TianganRelation.合) # type: ignore
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     tiangan_utils.search(('甲', '丙', '辛'), TianganRelation.合) # type: ignore
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     tiangan_utils.search((Tiangan.甲, Tiangan.丙, Tiangan.丁, Tiangan.庚, '辛'), TianganRelation.合) # type: ignore
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     tiangan_utils.search((Tiangan.甲, Tiangan.丙, Tiangan.丁, Tiangan.庚), '合') # type: ignore
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     tiangan_utils.search((Tiangan.甲, Tiangan.丙, Tiangan.丁, Tiangan.庚), 'HE') # type: ignore
 
   for dz_relation in DizhiRelation:
-    with pytest.raises(AssertionError):
+    with pytest.raises(TypeError):
       tiangan_utils.search((Tiangan.甲, Tiangan.丙, Tiangan.丁, Tiangan.庚), dz_relation) # type: ignore
 
   for relation in TianganRelation:
-    with pytest.raises(AssertionError):
+    with pytest.raises(TypeError):
       tiangan_utils.search((Tiangan.甲, Tiangan.丙, Tiangan.丁, Tiangan.庚), str(relation)) # type: ignore
 
   # No need to mutate the result: the returned tuple is immutable.
@@ -240,11 +240,11 @@ def test_search_correctness() -> None:
 
 
 def test_he() -> None:
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     tiangan_utils.he(Tiangan.甲, Dizhi.子) # type: ignore
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     tiangan_utils.he(Dizhi.子, Tiangan.甲) # type: ignore
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     tiangan_utils.he('甲', '己') # type: ignore
 
   expected: dict[TianganCombo, Wuxing] = {
@@ -266,11 +266,11 @@ def test_he() -> None:
 
 
 def test_chong() -> None:
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     tiangan_utils.chong(Tiangan.甲, Dizhi.子) # type: ignore
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     tiangan_utils.chong(Dizhi.子, Tiangan.甲) # type: ignore
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     tiangan_utils.chong('甲', '庚') # type: ignore
 
   for tg1, tg2 in itertools.product(Tiangan, Tiangan):
@@ -285,11 +285,11 @@ def test_chong() -> None:
 
 
 def test_sheng() -> None:
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     tiangan_utils.sheng(Tiangan.甲, Dizhi.子) # type: ignore
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     tiangan_utils.sheng(Dizhi.子, Tiangan.甲) # type: ignore
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     tiangan_utils.sheng('甲', '庚') # type: ignore
 
   for tg1, tg2 in itertools.product(Tiangan, Tiangan):
@@ -302,11 +302,11 @@ def test_sheng() -> None:
 
 
 def test_ke() -> None:
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     tiangan_utils.ke(Tiangan.甲, Dizhi.子) # type: ignore
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     tiangan_utils.ke(Dizhi.子, Tiangan.甲) # type: ignore
-  with pytest.raises(AssertionError):
+  with pytest.raises(TypeError):
     tiangan_utils.ke('甲', '庚') # type: ignore
 
   for tg1, tg2 in itertools.product(Tiangan, Tiangan):
@@ -335,6 +335,11 @@ def test_discover() -> None:
     # consistency
     discovery2: TianganRelationDiscovery = tiangan_utils.discover(tiangans)
     assert discovery == discovery2
+
+
+def test_discover_negative() -> None:
+  with pytest.raises(TypeError):
+    tiangan_utils.discover((Tiangan.甲, Dizhi.子)) # type: ignore
 
 
 @pytest.mark.slow
@@ -389,6 +394,13 @@ def test_discover_mutual() -> None:
           assert combo in expected_combos
       else:
         assert len(expected_combos) == 0
+
+
+def test_discover_mutual_negative() -> None:
+  with pytest.raises(TypeError):
+    tiangan_utils.discover_mutual((Tiangan.甲, Dizhi.子), (Tiangan.己,)) # type: ignore
+  with pytest.raises(TypeError):
+    tiangan_utils.discover_mutual((Tiangan.甲,), (Tiangan.己, Dizhi.子)) # type: ignore
 
 
 @pytest.mark.slow


### PR DESCRIPTION
## 内容

#102 本体:src 公开边界 assert → 显式 raise,4 提交分面推进,每提交门禁独立全绿:

1. **defines + utils 面**(`0e2c808`):src 75 处(tiangan 13/dizhi 22/bazi_utils 18/shensha 10/relation_discovery 4/enum_base 2/ganzhi 3/shishen 3)
2. **calendar 面**(`107442a`):src 60 处 = (a)49 + 灰区 11(`__to_calendardate` 漏斗双后端、`get_min/max_supported_date` else 穷尽 ×4、`__days_counts_in_ganzhi_year` 范围;dates/decoder/backend)
3. **顶层面**(`c3cc8d7`):src 39 处(bazi 10/bazi_chart 1/transits 12/transit_chart 7/interpreter 2/relationship 7)+ `bazi.py:199` 死闸删除
4. **`-O` 契约冒烟**(`5d66f7b`):`tests/o_smoke.py` 11 面 + `run_tests.py -osmoke`(接入 `-a`)+ CI 三 workflow 7 处调用串 + 修宪两处(§Idioms 公开边界例外、门禁清单第四道)+ README

总账:转换 174 处 + 删除 1 处(死闸)+ 重分类 1 处(见范围说明);src 残余 assert 259 → **84**,全部为内部不变量/cast 收窄((b)+(c) 面)。

## 测试

- **180 处钉改型**:`pytest.raises(AssertionError)` 按「首爆检查」逐条判定改 TypeError/ValueError;**4 处保留**(bytes_to_date ×3 = 数据层内部编解码件已拍板;test_bazi_utils:206 实钉 nayin_str 输出自检,属保留面)。
- **新增 35 个负例测试函数**(收集 361 → 396):覆盖率 100% 门禁要求每条新 raise 行有钉——shensha/relation_discovery/interpreter/relationship 等零钉面全部补齐;新建镜像测试 `tests/utils/test_relation_discovery.py`;缝隙直写(#102 范围注记):celestial 转换系/days_counts/to_* 负例、jieqi_date 与 jieqi_moment 同表、Bazi 窗沿(1901-02-18/2100-01-01 红,1901-02-19/2099-12-31 绿)。
- 顺修 test_dizhi_utils sanhui/sanhe 负例分支 `*dizhis`→`*combo` 笔误;xing 负例删除迁移遗留内层死断言。

## 验证

- 每提交:`run_tests.py -v -s -hko -c -cr 100 -ruff -mypy -d -i` 全绿(提交 4 起含 `-osmoke`,冒烟 11/11)。
- **检出率纪律**(文件快照法,非 `git checkout --`):19 个 src 文件逐一还原基线 → 定向测试全部红(c1 8 文件、c2 5、c3 6);o_smoke 自身:bazi.py 还原基线 → tz-aware 面即红。
- mypy 五 flag(含 `--warn-unreachable`)对 `if not isinstance` 转换形零误报(施工前探针实证)。

## 行为变更明示(公开契约变化)

| 面 | 之前(普通模式) | 之前(`-O`) | 现在(两种模式一致) |
|---|---|---|---|
| 全公开面类型错入参 | 空消息 AssertionError | 静默错答案(如 `he('甲','己')` 返 None)或深层 TypeError | **TypeError** 带 `type()` 回显 |
| 范围/成员/值违例(转换系、jieqi、decoder、DayunDatabase、options) | 空消息 AssertionError | 深层 KeyError(loader.py:138)或静默 | **ValueError** 带边界/支持窗回显 |
| tz-aware 出生时间 | AssertionError(带消息) | **静默接受出盘** | **ValueError**(原消息保留) |
| #63.1/.2(越界构造、2091 男命大运) | 空消息 AssertionError @ 漏斗 | KeyError @ loader | **ValueError** 带支持窗回显 |
| `get_min/max_supported_date` 垃圾 date_type | AssertionError | **静默走 GANZHI 分支错答案** | **ValueError** |
| decoder `DecodedJieqiDates` 非 int 年份 | 空消息 AssertionError | 深层 TypeError | **TypeError**(与孪生 `DecodedLunarYears` 对齐,R1 修复批) |
| `star_relations` level 裸 int / 伪成员 `Level(0x8)`/`Level(0)` | AssertionError / **伪成员静默空结果** | 版本相关(3.11 TypeError/3.12 静默/3.14 静默) | **TypeError / ValueError**(弃用枚举 `in`,版本无关,R1 修复批) |

## 范围说明

- 不做(已拍板):(b) 内部不变量 79 处与 (c) cast 收窄 3 处保留;encoder/generator 离线工具不动;不引入自定义异常层级;`bytes_to_date` 保持 assert。
- 顺手修(超出 assert→raise 改型面,明示):test_dizhi_utils sanhui/sanhe 负例分支 `*dizhis`→`*combo` 笔误(改前内层循环变量未用,每轮断言同一元组;修后测试强度恢复意图);dates.py `CalenderType` 拼写。
- R1 审阅修复批(`bd980c2`):kimi 盲审 P1(IntFlag `in` 语义 3.11/3.12/3.14 三代三样,CI 实红同因)→ level 闸版本无关化;四家收敛 → decoder 孪生 isinstance 对齐;修宪补映射规则;其余风格收敛见提交信息。
- 施工中两处驾驶者裁决(audit 修正):`bazi.py:199` 按计划删除(死闸,kimi 全路径验证 + 运行时亲验);原 `bazi.py:274`(`__parse_bazi_args` 入口)**降级保留 assert**——create :342 已先拦同一检查,公开 API 不可达,与同函数保留的 else 收窄同族((a)→(b) 重分类)。
- #90 item2(布局/打包,含 `_utils` 命名叠字注记)、#79、#110 均另批。
- PR 合并后 #102 关闭(留逐面清单)、#63 随之关账。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
