### PR TITLE
test: #110 测试缝隙八条全钉——dayun golden 组 + ganzhis 重做 + bracketing/闰月/口诀

### DIFF
--- a/tests/calendar/test_celestial_utils.py
+++ b/tests/calendar/test_celestial_utils.py
@@ -89,6 +89,13 @@ def test_lunar() -> None:
   assert not ALGO1.is_valid_lunar_date(lunar(2024, 1, 31))
 
 
+def test_lunar_leap_month_boundary() -> None:
+  # 2023's leap month is 闰二月, slot 3 in this numbering (it shifts the later months:
+  # slot 13 is 腊月, not the leap month).  It runs 29 days, 2023-03-22 to 2023-04-19.
+  assert ALGO1.is_valid_lunar_date(lunar(2023, 3, 29)) # Last day of the leap month.
+  assert not ALGO1.is_valid_lunar_date(lunar(2023, 3, 30)) # One past the leap month's end.
+
+
 def test_ganzhi() -> None:
   assert ALGO1.is_valid_ganzhi_date(ganzhi(2024, 1, 1))
   assert not ALGO1.is_valid_ganzhi_date(solar(2024, 1, 1)) # Wrong date type.
@@ -147,6 +154,15 @@ def test_round_trips() -> None:
       assert ALGO1.ganzhi_to_lunar(ALGO1.solar_to_ganzhi(d)) == ALGO1.solar_to_lunar(d)
       assert ALGO1.lunar_to_ganzhi(ALGO1.solar_to_lunar(d)) == ALGO1.solar_to_ganzhi(d)
       day += timedelta(days=1)
+
+
+def test_lunar_leap_month_round_trips() -> None:
+  # Lunar-anchored: `test_round_trips` reaches the leap month only via solar dates, so
+  # pin the leap month from the lunar side.  The solar values agree with the HKO backend.
+  for d, expected in ((1, solar(2023, 3, 22)), (15, solar(2023, 4, 5)), (29, solar(2023, 4, 19))):
+    leap: CalendarDate = lunar(2023, 3, d)
+    assert ALGO1.lunar_to_solar(leap) == expected
+    assert ALGO1.solar_to_lunar(ALGO1.lunar_to_solar(leap)) == leap
 
 
 def test_dates_before_the_year_boundaries() -> None:

--- a/tests/calendar/test_celestial_utils.py
+++ b/tests/calendar/test_celestial_utils.py
@@ -90,8 +90,11 @@ def test_lunar() -> None:
 
 
 def test_lunar_leap_month_boundary() -> None:
-  # 2023's leap month is 闰二月, slot 3 in this numbering (it shifts the later months:
-  # slot 13 is 腊月, not the leap month).  It runs 29 days, 2023-03-22 to 2023-04-19.
+  # A readable sample of the slot-3 numbering convention, plus the boundary: 2023's leap
+  # month is 闰二月, slot 3 in this numbering (it shifts the later months -- slot 13 is
+  # 腊月, not the leap month), running 29 days from 2023-03-22 to 2023-04-19.  The data
+  # itself is regression-pinned by `test_data_sections_are_frozen` (table hash) and
+  # `test_algo1_matches_hko_strictly`; this test does not guard that class alone.
   assert ALGO1.is_valid_lunar_date(lunar(2023, 3, 29)) # Last day of the leap month.
   assert not ALGO1.is_valid_lunar_date(lunar(2023, 3, 30)) # One past the leap month's end.
 
@@ -158,7 +161,9 @@ def test_round_trips() -> None:
 
 def test_lunar_leap_month_round_trips() -> None:
   # Lunar-anchored: `test_round_trips` reaches the leap month only via solar dates, so
-  # pin the leap month from the lunar side.  The solar values agree with the HKO backend.
+  # walk the leap month from the lunar side.  Like the boundary test above, this is a
+  # readable sample of the slot-3 convention; the data-side regression belongs to
+  # `test_data_sections_are_frozen` (table hash) and `test_algo1_matches_hko_strictly`.
   for d, expected in ((1, solar(2023, 3, 22)), (15, solar(2023, 4, 5)), (29, solar(2023, 4, 19))):
     leap: CalendarDate = lunar(2023, 3, d)
     assert ALGO1.lunar_to_solar(leap) == expected

--- a/tests/test_bazi.py
+++ b/tests/test_bazi.py
@@ -71,6 +71,27 @@ def test_day_precision_compares_dates_not_moments(backend: str, moment: str, yea
   assert bazi.month_commander == month_dizhi
 
 
+def test_day_precision_bracketing_jies_stay_moment_level() -> None:
+  '''
+  The bracketing half of the DAY trade-off (`Bazi.bracketing_jies` docstring): on a jieqi's
+  day the pillars compare dates -- the whole day falls on the new side -- while
+  `bracketing_jies` keeps the moment-level `prev_jie` / `next_jie`, so before the jie's true
+  moment the birth is still owned by the OLD jie. `BaziChart`'s dayun counting consumes
+  `bracketing_jies`, so the two readings legitimately disagree; this pin is what makes the
+  docstring's "pinned by `test_bazi`" true.
+  '''
+  # 立春 2000 = 02-04 20:40:23; midnight precedes the true moment by 20h40m...
+  bazi: Bazi = Bazi.create('2000-02-04 00:00', 'male', 'day')
+  # ...yet the pillars already read the new year and month (day-level attribution).
+  assert str(bazi.year_pillar) == '庚辰'
+  assert str(bazi.month_pillar) == '戊寅'
+  # The bracketing jies stay moment-level: the old 小寒 still owns the birth.
+  owning, following = bazi.bracketing_jies
+  assert owning == JieqiTime(Jieqi.小寒, datetime(2000, 1, 6, 9, 0, 41))
+  assert following == JieqiTime(Jieqi.立春, datetime(2000, 2, 4, 20, 40, 23))
+  assert following.moment > bazi.solar_datetime
+
+
 @pytest.mark.parametrize('moment, year, month, day', [
   # 1984-02-04 is the 立春 date, so the year/month pillars turn over between these rows while
   # the day pillar turns over an hour earlier, at 23:00.

--- a/tests/test_bazi.py
+++ b/tests/test_bazi.py
@@ -77,8 +77,8 @@ def test_day_precision_bracketing_jies_stay_moment_level() -> None:
   day the pillars compare dates -- the whole day falls on the new side -- while
   `bracketing_jies` keeps the moment-level `prev_jie` / `next_jie`, so before the jie's true
   moment the birth is still owned by the OLD jie. `BaziChart`'s dayun counting consumes
-  `bracketing_jies`, so the two readings legitimately disagree; this pin is what makes the
-  docstring's "pinned by `test_bazi`" true.
+  `bracketing_jies`, so the two readings legitimately disagree -- this is the pin
+  `Bazi.bracketing_jies`' docstring points at.
   '''
   # 立春 2000 = 02-04 20:40:23; midnight precedes the true moment by 20h40m...
   bazi: Bazi = Bazi.create('2000-02-04 00:00', 'male', 'day')

--- a/tests/test_bazi_chart.py
+++ b/tests/test_bazi_chart.py
@@ -9,7 +9,6 @@ import itertools
 import pytest
 
 from datetime import datetime, date, timedelta
-from typing import Final
 
 from src.defines import Tiangan, Dizhi, Ganzhi, Wuxing, Yinyang, Shishen, ShierZhangsheng
 from src.bazi import BaziGender, BaziPrecision, Bazi
@@ -312,27 +311,19 @@ def test_dayun_start_moment() -> None:
   )
 
 
-# The HKO backend's dayun start for the 2000-02-04 10:00 male DAY chart -- one value, shared
-# by the backend-divergence pin and the HKO golden below, so the two can never drift apart.
-HKO_DAYUN_START_2000_02_04_10AM: Final[datetime] = datetime(2009, 12, 12, 17, 20)
-
-
 def test_dayun_start_before_the_true_moment_on_a_jieqi_day() -> None:
   '''
-  立春 2000's true moment is 02-04 20:40:23. A DAY-precision birth at 00:00 on that civil day
-  already belongs to the NEW year and month at pillar level (day-level attribution), but the
-  dayun counting consumes `bracketing_jies`, which is moment-level: the birth still sits in
-  小寒, so the forward count walks the whole way to 立春 and the first dayun starts in 2000.
-  The 22:01 golden in `test_dayun_start_moment` is the same-day sibling past the true moment
-  -- same year/month/day pillars, yet its count starts from 立春 itself and lands in 2009.
-  This pins the shipped contract (day-level pillars vs. moment-level bracketing "legitimately
-  disagree", see `Bazi.bracketing_jies`), not a preferred 命理 semantics.
+  The dayun consequence of the DAY trade-off pinned in `test_bazi`: a 00:00 birth on the
+  jieqi's civil day still sits in 小寒 at moment level, so the forward count walks the
+  whole way to 立春 and the first dayun starts in 2000.  The 22:01 golden in
+  `test_dayun_start_moment` is the same-day sibling past the true moment -- same pillars,
+  but its bracketing starts at 立春 itself and the count walks on to 惊蛰, landing in 2009.
   '''
   delta: timedelta = timedelta(seconds=1)
 
   chart: BaziChart = BaziChart(Bazi.create(datetime(2000, 2, 4, 0, 0), BaziGender.MALE, BaziPrecision.DAY))
   assert chart.dayun_start_moment == pytest.approx(
-    datetime(2000, 5, 18, 19, 13, 18), # Float tail .333333 stays under the 1s tolerance.
+    datetime(2000, 5, 18, 19, 13, 18, 333333), # Float tail written out; the 1s tolerance is re-bake headroom.
     abs=delta,
   )
   assert next(chart.dayun).ganzhi_year == 2000
@@ -340,12 +331,13 @@ def test_dayun_start_before_the_true_moment_on_a_jieqi_day() -> None:
 
 def test_dayun_start_diverges_across_backends_on_the_same_pillars() -> None:
   '''
-  Same birth, same four pillars, different dayun start. celestial keeps moment-level jieqi:
-  the 10:00 birth precedes 立春's true moment (20:40:23), so it sits in 小寒 and the count
-  walks to 立春 -- the dayun starts in 2000. HKO places every jieqi at midnight, so the same
-  birth falls right after 立春@00:00 and the count walks to 惊蛰 -- the dayun starts in
-  2009, ~9.7 years later. The divergence is the HKO table's documented midnight-window
-  behavior, pinned as-is.
+  Same birth, same four pillars, different dayun start. celestial keeps moment-level jieqi
+  (the DAY trade-off pinned in `test_bazi`): the 10:00 birth still sits in 小寒, the count
+  walks to 立春, and the dayun starts in 2000. HKO places every jieqi at midnight, so the
+  same birth falls right after 立春@00:00 and the count walks to 惊蛰 -- the dayun starts
+  in 2009, ~9.7 years later. The divergence is the HKO table's documented midnight-window
+  behavior, pinned as-is; the HKO assertion doubles as the first absolute-moment golden
+  on the HKO side.
   '''
   delta: timedelta = timedelta(seconds=1)
 
@@ -359,25 +351,15 @@ def test_dayun_start_diverges_across_backends_on_the_same_pillars() -> None:
   assert list(hko.bazi.pillars) == list(cel.bazi.pillars)
 
   assert cel.dayun_start_moment == pytest.approx(
-    datetime(2000, 3, 29, 12, 33, 18), # Float tail .333333 stays under the 1s tolerance.
+    datetime(2000, 3, 29, 12, 33, 18, 333333), # Float tail written out; the 1s tolerance is re-bake headroom.
     abs=delta,
   )
-  assert hko.dayun_start_moment == pytest.approx(HKO_DAYUN_START_2000_02_04_10AM, abs=delta)
+  assert hko.dayun_start_moment == pytest.approx(
+    datetime(2009, 12, 12, 17, 20),
+    abs=delta,
+  )
   assert next(cel.dayun).ganzhi_year == 2000
   assert next(hko.dayun).ganzhi_year == 2009
-
-
-def test_dayun_start_moment_hko_golden() -> None:
-  '''
-  First absolute-moment golden on the HKO side -- `test_dayun_start_moment` and the pins
-  above only cover the celestial default. HKO's midnight jieqi moments make the arithmetic
-  exact (no float tail); the shared constant keeps this pin and the divergence pin on one
-  value.
-  '''
-  chart: BaziChart = BaziChart(Bazi.create(datetime(2000, 2, 4, 10, 0), BaziGender.MALE, BaziPrecision.DAY,
-                                           backend='hko'))
-  assert chart.dayun_start_moment == pytest.approx(HKO_DAYUN_START_2000_02_04_10AM,
-                                                   abs=timedelta(seconds=1))
 
 
 def test_dayun_ganzhi() -> None:

--- a/tests/test_bazi_chart.py
+++ b/tests/test_bazi_chart.py
@@ -9,6 +9,7 @@ import itertools
 import pytest
 
 from datetime import datetime, date, timedelta
+from typing import Final
 
 from src.defines import Tiangan, Dizhi, Ganzhi, Wuxing, Yinyang, Shishen, ShierZhangsheng
 from src.bazi import BaziGender, BaziPrecision, Bazi
@@ -309,6 +310,74 @@ def test_dayun_start_moment() -> None:
     datetime(1993, 5, 24, 0, 24, 13, 333333),
     abs=delta,
   )
+
+
+# The HKO backend's dayun start for the 2000-02-04 10:00 male DAY chart -- one value, shared
+# by the backend-divergence pin and the HKO golden below, so the two can never drift apart.
+HKO_DAYUN_START_2000_02_04_10AM: Final[datetime] = datetime(2009, 12, 12, 17, 20)
+
+
+def test_dayun_start_before_the_true_moment_on_a_jieqi_day() -> None:
+  '''
+  立春 2000's true moment is 02-04 20:40:23. A DAY-precision birth at 00:00 on that civil day
+  already belongs to the NEW year and month at pillar level (day-level attribution), but the
+  dayun counting consumes `bracketing_jies`, which is moment-level: the birth still sits in
+  小寒, so the forward count walks the whole way to 立春 and the first dayun starts in 2000.
+  The 22:01 golden in `test_dayun_start_moment` is the same-day sibling past the true moment
+  -- same year/month/day pillars, yet its count starts from 立春 itself and lands in 2009.
+  This pins the shipped contract (day-level pillars vs. moment-level bracketing "legitimately
+  disagree", see `Bazi.bracketing_jies`), not a preferred 命理 semantics.
+  '''
+  delta: timedelta = timedelta(seconds=1)
+
+  chart: BaziChart = BaziChart(Bazi.create(datetime(2000, 2, 4, 0, 0), BaziGender.MALE, BaziPrecision.DAY))
+  assert chart.dayun_start_moment == pytest.approx(
+    datetime(2000, 5, 18, 19, 13, 18), # Float tail .333333 stays under the 1s tolerance.
+    abs=delta,
+  )
+  assert next(chart.dayun).ganzhi_year == 2000
+
+
+def test_dayun_start_diverges_across_backends_on_the_same_pillars() -> None:
+  '''
+  Same birth, same four pillars, different dayun start. celestial keeps moment-level jieqi:
+  the 10:00 birth precedes 立春's true moment (20:40:23), so it sits in 小寒 and the count
+  walks to 立春 -- the dayun starts in 2000. HKO places every jieqi at midnight, so the same
+  birth falls right after 立春@00:00 and the count walks to 惊蛰 -- the dayun starts in
+  2009, ~9.7 years later. The divergence is the HKO table's documented midnight-window
+  behavior, pinned as-is.
+  '''
+  delta: timedelta = timedelta(seconds=1)
+
+  cel: BaziChart = BaziChart(Bazi.create(datetime(2000, 2, 4, 10, 0), BaziGender.MALE, BaziPrecision.DAY,
+                                         backend='celestial'))
+  hko: BaziChart = BaziChart(Bazi.create(datetime(2000, 2, 4, 10, 0), BaziGender.MALE, BaziPrecision.DAY,
+                                         backend='hko'))
+
+  # Same pillars on both backends; only the dayun start (and everything it feeds) diverges.
+  assert [str(p) for p in cel.bazi.pillars] == ['庚辰', '戊寅', '壬辰', '乙巳']
+  assert list(hko.bazi.pillars) == list(cel.bazi.pillars)
+
+  assert cel.dayun_start_moment == pytest.approx(
+    datetime(2000, 3, 29, 12, 33, 18), # Float tail .333333 stays under the 1s tolerance.
+    abs=delta,
+  )
+  assert hko.dayun_start_moment == pytest.approx(HKO_DAYUN_START_2000_02_04_10AM, abs=delta)
+  assert next(cel.dayun).ganzhi_year == 2000
+  assert next(hko.dayun).ganzhi_year == 2009
+
+
+def test_dayun_start_moment_hko_golden() -> None:
+  '''
+  First absolute-moment golden on the HKO side -- `test_dayun_start_moment` and the pins
+  above only cover the celestial default. HKO's midnight jieqi moments make the arithmetic
+  exact (no float tail); the shared constant keeps this pin and the divergence pin on one
+  value.
+  '''
+  chart: BaziChart = BaziChart(Bazi.create(datetime(2000, 2, 4, 10, 0), BaziGender.MALE, BaziPrecision.DAY,
+                                           backend='hko'))
+  assert chart.dayun_start_moment == pytest.approx(HKO_DAYUN_START_2000_02_04_10AM,
+                                                   abs=timedelta(seconds=1))
 
 
 def test_dayun_ganzhi() -> None:

--- a/tests/test_bazi_chart.py
+++ b/tests/test_bazi_chart.py
@@ -316,8 +316,9 @@ def test_dayun_start_before_the_true_moment_on_a_jieqi_day() -> None:
   The dayun consequence of the DAY trade-off pinned in `test_bazi`: a 00:00 birth on the
   jieqi's civil day still sits in 小寒 at moment level, so the forward count walks the
   whole way to 立春 and the first dayun starts in 2000.  The 22:01 golden in
-  `test_dayun_start_moment` is the same-day sibling past the true moment -- same pillars,
-  but its bracketing starts at 立春 itself and the count walks on to 惊蛰, landing in 2009.
+  `test_dayun_start_moment` is the same-day sibling past the true moment -- same
+  year/month/day pillars, but its bracketing starts at 立春 itself and the count walks on
+  to 惊蛰, landing in 2009.
   '''
   delta: timedelta = timedelta(seconds=1)
 

--- a/tests/test_transits.py
+++ b/tests/test_transits.py
@@ -11,7 +11,6 @@ from src.data_types import DayunTuple
 from src.defines import Ganzhi, Dizhi
 from src.utils import bazi_utils
 
-from src.calendar.hko_data_utils import to_ganzhi
 from src.bazi import Bazi, BaziGender, BaziPrecision
 from src.bazi_chart import BaziChart
 from src.transits import DayunDatabase, TransitMoment, TransitOptions, TransitDatabase, _ALL_OPTIONS
@@ -120,7 +119,8 @@ def test_ganzhis() -> None:
       for age, xy in chart.xiaoyun
     }
 
-    dayun_start_gz_year: int = to_ganzhi(chart.dayun_start_moment).year
+    # The same source `TransitDatabase` consumes (floor at `Bazi.ganzhi_year` included).
+    dayun_start_gz_year: int = next(chart.dayun).ganzhi_year
     dayun_ganzhis: list[Ganzhi] = [dy.ganzhi for dy in itertools.islice(chart.dayun, 50)]
 
     # Randomly select 20 ganzhi years to test...
@@ -131,7 +131,9 @@ def test_ganzhis() -> None:
       db.ganzhis(TransitMoment(dayun_start_gz_year - 1), TransitOptions.DAYUN)
 
     for gz_year, _ in random_liunians:
-      for option in TransitOptions:
+      # `_ALL_OPTIONS`, not `TransitOptions`: on Python 3.11+ the enum iterates single-bit
+      # members only, and single-bit queries can never observe the append order.
+      for option in _ALL_OPTIONS:
         if not db.support(TransitMoment(gz_year), option):
           with pytest.raises(ValueError):
             db.ganzhis(TransitMoment(gz_year), option)
@@ -146,10 +148,9 @@ def test_ganzhis() -> None:
         if option.value & TransitOptions.LIUNIAN.value:
           transit_ganzhis.append(bazi_utils.ganzhi_of_year(gz_year))
 
+        # Exact tuple equality pins the order too: 小运 -> 大运 -> 流年.
         actual = db.ganzhis(TransitMoment(gz_year), option)
-        assert len(actual) == len(transit_ganzhis)
-        for gz in actual:
-          assert gz in transit_ganzhis
+        assert actual == tuple(transit_ganzhis)
 
 
 def test_valid_shapes() -> None:
@@ -260,3 +261,38 @@ def test_day_precision_unchanged() -> None:
   db: TransitDatabase = TransitDatabase(chart)
   assert db.support(TransitMoment(2008), TransitOptions.LIUNIAN)  # 戊子 2008 IS this chart's first liunian.
   assert not db.support(TransitMoment(2007), TransitOptions.LIUNIAN)
+
+
+def test_dayun_year_floored_at_ganzhi_year() -> None:
+  '''
+  Cross-midnight tie chart (2009-02-03 23:30 male, HOUR): the backward-counted dayun
+  start clamps to the birth moment itself, whose day-level label is still the OLD year
+  2008 (戊子). The first dayun year must be floored up to the chart's own precision-
+  attributed `Bazi.ganzhi_year` 2009 (己丑) -- otherwise 2008 would wrongly support
+  dayun, and every later year would resolve one dayun step off (2018: 甲子 instead of
+  乙丑).
+  '''
+  chart: BaziChart = BaziChart(Bazi.create('2009-02-03 23:30', 'male', 'hour'))
+  assert chart.dayun_start_moment == chart.bazi.solar_datetime # The clamp: the start IS the birth.
+  assert chart.bazi.ganzhi_date.year == 2008 # The bare day-level label of the clamped start.
+  assert chart.bazi.ganzhi_year == 2009
+
+  # 逆排: the first dayun steps one ganzhi back from the month pillar 丙寅 -> 乙丑.
+  first_dayun: DayunTuple = next(chart.dayun)
+  assert first_dayun == DayunTuple(2009, Ganzhi.from_str('乙丑'))
+
+  db: TransitDatabase = TransitDatabase(chart)
+  with pytest.raises(ValueError):
+    db.ganzhis(TransitMoment(2008), TransitOptions.DAYUN) # 戊子 2008 is below the floored start.
+  assert db.ganzhis(TransitMoment(2009), TransitOptions.DAYUN) == (
+    Ganzhi.from_str('乙丑'),
+  )
+  # 2018 is the last year of the first dayun (2009-2018); the unfloored start 2008 would
+  # put it one step further back (甲子). 2019 opens the second dayun.
+  assert db.ganzhis(TransitMoment(2018), TransitOptions.DAYUN_LIUNIAN) == (
+    Ganzhi.from_str('乙丑'),
+    Ganzhi.from_str('戊戌'), # The 2018 liunian.
+  )
+  assert db.ganzhis(TransitMoment(2019), TransitOptions.DAYUN) == (
+    Ganzhi.from_str('甲子'),
+  )

--- a/tests/test_transits.py
+++ b/tests/test_transits.py
@@ -13,6 +13,7 @@ from src.utils import bazi_utils
 
 from src.bazi import Bazi, BaziGender, BaziPrecision
 from src.bazi_chart import BaziChart
+from src.calendar import calendar_utils_of
 from src.transits import DayunDatabase, TransitMoment, TransitOptions, TransitDatabase, _ALL_OPTIONS
 
 
@@ -115,12 +116,17 @@ def test_ganzhis() -> None:
       db.ganzhis(TransitMoment(1999), TransitOptions(0))
 
     xiaoyun_ganzhis: dict[int, Ganzhi] = {
-      chart.bazi.ganzhi_date.year + age - 1 : xy
+      chart.bazi.ganzhi_year + age - 1 : xy
       for age, xy in chart.xiaoyun
     }
 
-    # The same source `TransitDatabase` consumes (floor at `Bazi.ganzhi_year` included).
-    dayun_start_gz_year: int = next(chart.dayun).ganzhi_year
+    # Independent recomputation, not a mirror of the source `TransitDatabase` consumes:
+    # the day-level label of `dayun_start_moment` through the chart's own backend,
+    # floored at `Bazi.ganzhi_year`.
+    dayun_start_gz_year: int = max(
+      calendar_utils_of(chart.bazi.backend).to_ganzhi(chart.dayun_start_moment).year,
+      chart.bazi.ganzhi_year,
+    )
     dayun_ganzhis: list[Ganzhi] = [dy.ganzhi for dy in itertools.islice(chart.dayun, 50)]
 
     # Randomly select 20 ganzhi years to test...
@@ -286,6 +292,10 @@ def test_dayun_year_floored_at_ganzhi_year() -> None:
     db.ganzhis(TransitMoment(2008), TransitOptions.DAYUN) # 戊子 2008 is below the floored start.
   assert db.ganzhis(TransitMoment(2009), TransitOptions.DAYUN) == (
     Ganzhi.from_str('乙丑'),
+  )
+  # Xiaoyun, too, is keyed by the precision-attributed 2009, not the day-level 2008.
+  assert db.ganzhis(TransitMoment(2009), TransitOptions.XIAOYUN) == (
+    Ganzhi.from_str('乙亥'),
   )
   # 2018 is the last year of the first dayun (2009-2018); the unfloored start 2008 would
   # put it one step further back (甲子). 2019 opens the second dayun.

--- a/tests/utils/test_bazi_utils.py
+++ b/tests/utils/test_bazi_utils.py
@@ -67,7 +67,8 @@ def test_ganzhi_of_year() -> None:
 
 def test_month_tiangan() -> None:
   # 五虎遁口诀(年上起月):甲己之年丙作首,乙庚之年戊为头,丙辛之年寻庚起,丁壬壬位顺行流,戊癸之年甲寅求。
-  # 下表为口诀的手工转录(oracle 独立于此仓的任何表):每个年干一行,12 个字依次是寅月到丑月的月干。
+  # Hand transcription of the mnemonic (an oracle independent of any table in this repo):
+  # one row per year stem, 12 chars for the month stems from 寅 to 丑.
   wuhudun: dict[Tiangan, str] = {
     Tiangan.甲 : '丙丁戊己庚辛壬癸甲乙丙丁', # 甲己之年丙作首(丙寅起)
     Tiangan.己 : '丙丁戊己庚辛壬癸甲乙丙丁',
@@ -97,7 +98,8 @@ def test_month_tiangan_negative() -> None:
 
 def test_hour_tiangan() -> None:
   # 五鼠遁口诀(日上起时):甲己还加甲,乙庚丙作初,丙辛从戊起,丁壬庚子居,戊癸壬子求。
-  # 下表为口诀的手工转录(oracle 独立于此仓的任何表):每个日干一行,12 个字依次是子时到亥时的时干。
+  # Hand transcription of the mnemonic (an oracle independent of any table in this repo):
+  # one row per day stem, 12 chars for the hour stems from 子 to 亥.
   wushudun: dict[Tiangan, str] = {
     Tiangan.甲 : '甲乙丙丁戊己庚辛壬癸甲乙', # 甲己还加甲(甲子起)
     Tiangan.己 : '甲乙丙丁戊己庚辛壬癸甲乙',

--- a/tests/utils/test_bazi_utils.py
+++ b/tests/utils/test_bazi_utils.py
@@ -67,7 +67,7 @@ def test_ganzhi_of_year() -> None:
 
 def test_month_tiangan() -> None:
   # 五虎遁口诀(年上起月):甲己之年丙作首,乙庚之年戊为头,丙辛之年寻庚起,丁壬壬位顺行流,戊癸之年甲寅求。
-  # 下表为口诀的手工转录（oracle 独立于此仓的任何表）：每个年干一行，12 个字依次是寅月到丑月的月干。
+  # 下表为口诀的手工转录(oracle 独立于此仓的任何表):每个年干一行,12 个字依次是寅月到丑月的月干。
   wuhudun: dict[Tiangan, str] = {
     Tiangan.甲 : '丙丁戊己庚辛壬癸甲乙丙丁', # 甲己之年丙作首(丙寅起)
     Tiangan.己 : '丙丁戊己庚辛壬癸甲乙丙丁',
@@ -97,7 +97,7 @@ def test_month_tiangan_negative() -> None:
 
 def test_hour_tiangan() -> None:
   # 五鼠遁口诀(日上起时):甲己还加甲,乙庚丙作初,丙辛从戊起,丁壬庚子居,戊癸壬子求。
-  # 下表为口诀的手工转录（oracle 独立于此仓的任何表）：每个日干一行，12 个字依次是子时到亥时的时干。
+  # 下表为口诀的手工转录(oracle 独立于此仓的任何表):每个日干一行,12 个字依次是子时到亥时的时干。
   wushudun: dict[Tiangan, str] = {
     Tiangan.甲 : '甲乙丙丁戊己庚辛壬癸甲乙', # 甲己还加甲(甲子起)
     Tiangan.己 : '甲乙丙丁戊己庚辛壬癸甲乙',

--- a/tests/utils/test_bazi_utils.py
+++ b/tests/utils/test_bazi_utils.py
@@ -66,10 +66,26 @@ def test_ganzhi_of_year() -> None:
 
 
 def test_month_tiangan() -> None:
-  assert bazi_utils.month_tiangan(Tiangan.甲, Dizhi.寅) == Tiangan.丙
-  assert bazi_utils.month_tiangan(Tiangan.壬, Dizhi.子) == Tiangan.壬
-  assert bazi_utils.month_tiangan(Tiangan.丁, Dizhi.丑) == Tiangan.癸
-  assert bazi_utils.month_tiangan(Tiangan.戊, Dizhi.巳) == Tiangan.丁
+  # 五虎遁口诀(年上起月):甲己之年丙作首,乙庚之年戊为头,丙辛之年寻庚起,丁壬壬位顺行流,戊癸之年甲寅求。
+  # 下表为口诀的手工转录(oracle 独立于此仓的任何表):每个年干一行,12 个字依次是寅月到丑月的月干。
+  wuhudun: dict[Tiangan, str] = {
+    Tiangan.甲 : '丙丁戊己庚辛壬癸甲乙丙丁', # 甲己之年丙作首(丙寅起)
+    Tiangan.己 : '丙丁戊己庚辛壬癸甲乙丙丁',
+    Tiangan.乙 : '戊己庚辛壬癸甲乙丙丁戊己', # 乙庚之年戊为头(戊寅起)
+    Tiangan.庚 : '戊己庚辛壬癸甲乙丙丁戊己',
+    Tiangan.丙 : '庚辛壬癸甲乙丙丁戊己庚辛', # 丙辛之年寻庚起(庚寅起)
+    Tiangan.辛 : '庚辛壬癸甲乙丙丁戊己庚辛',
+    Tiangan.丁 : '壬癸甲乙丙丁戊己庚辛壬癸', # 丁壬壬位顺行流(壬寅起)
+    Tiangan.壬 : '壬癸甲乙丙丁戊己庚辛壬癸',
+    Tiangan.戊 : '甲乙丙丁戊己庚辛壬癸甲乙', # 戊癸之年甲寅求(甲寅起)
+    Tiangan.癸 : '甲乙丙丁戊己庚辛壬癸甲乙',
+  }
+
+  for year_tg, month_row in wuhudun.items():
+    assert len(month_row) == 12
+    for idx, expected_tg in enumerate(month_row):
+      month_dz: Dizhi = Dizhi.from_index((idx + 2) % 12) # First month is "寅".
+      assert bazi_utils.month_tiangan(year_tg, month_dz) == Tiangan(expected_tg)
 
 
 def test_month_tiangan_negative() -> None:
@@ -80,11 +96,26 @@ def test_month_tiangan_negative() -> None:
 
 
 def test_hour_tiangan() -> None:
-  assert bazi_utils.hour_tiangan(Tiangan.甲, Dizhi.寅) == Tiangan.丙
-  assert bazi_utils.hour_tiangan(Tiangan.壬, Dizhi.子) == Tiangan.庚
-  assert bazi_utils.hour_tiangan(Tiangan.丁, Dizhi.丑) == Tiangan.辛
-  assert bazi_utils.hour_tiangan(Tiangan.戊, Dizhi.巳) == Tiangan.丁
-  assert bazi_utils.hour_tiangan(Tiangan.丙, Dizhi.卯) == Tiangan.辛
+  # 五鼠遁口诀(日上起时):甲己还加甲,乙庚丙作初,丙辛从戊起,丁壬庚子居,戊癸壬子求。
+  # 下表为口诀的手工转录(oracle 独立于此仓的任何表):每个日干一行,12 个字依次是子时到亥时的时干。
+  wushudun: dict[Tiangan, str] = {
+    Tiangan.甲 : '甲乙丙丁戊己庚辛壬癸甲乙', # 甲己还加甲(甲子起)
+    Tiangan.己 : '甲乙丙丁戊己庚辛壬癸甲乙',
+    Tiangan.乙 : '丙丁戊己庚辛壬癸甲乙丙丁', # 乙庚丙作初(丙子起)
+    Tiangan.庚 : '丙丁戊己庚辛壬癸甲乙丙丁',
+    Tiangan.丙 : '戊己庚辛壬癸甲乙丙丁戊己', # 丙辛从戊起(戊子起)
+    Tiangan.辛 : '戊己庚辛壬癸甲乙丙丁戊己',
+    Tiangan.丁 : '庚辛壬癸甲乙丙丁戊己庚辛', # 丁壬庚子居(庚子起)
+    Tiangan.壬 : '庚辛壬癸甲乙丙丁戊己庚辛',
+    Tiangan.戊 : '壬癸甲乙丙丁戊己庚辛壬癸', # 戊癸壬子求(壬子起)
+    Tiangan.癸 : '壬癸甲乙丙丁戊己庚辛壬癸',
+  }
+
+  for day_tg, hour_row in wushudun.items():
+    assert len(hour_row) == 12
+    for idx, expected_tg in enumerate(hour_row):
+      hour_dz: Dizhi = Dizhi.from_index(idx) # First hour is "子".
+      assert bazi_utils.hour_tiangan(day_tg, hour_dz) == Tiangan(expected_tg)
 
 
 def test_hour_tiangan_negative() -> None:

--- a/tests/utils/test_bazi_utils.py
+++ b/tests/utils/test_bazi_utils.py
@@ -67,7 +67,7 @@ def test_ganzhi_of_year() -> None:
 
 def test_month_tiangan() -> None:
   # 五虎遁口诀(年上起月):甲己之年丙作首,乙庚之年戊为头,丙辛之年寻庚起,丁壬壬位顺行流,戊癸之年甲寅求。
-  # 下表为口诀的手工转录(oracle 独立于此仓的任何表):每个年干一行,12 个字依次是寅月到丑月的月干。
+  # 下表为口诀的手工转录（oracle 独立于此仓的任何表）：每个年干一行，12 个字依次是寅月到丑月的月干。
   wuhudun: dict[Tiangan, str] = {
     Tiangan.甲 : '丙丁戊己庚辛壬癸甲乙丙丁', # 甲己之年丙作首(丙寅起)
     Tiangan.己 : '丙丁戊己庚辛壬癸甲乙丙丁',
@@ -97,7 +97,7 @@ def test_month_tiangan_negative() -> None:
 
 def test_hour_tiangan() -> None:
   # 五鼠遁口诀(日上起时):甲己还加甲,乙庚丙作初,丙辛从戊起,丁壬庚子居,戊癸壬子求。
-  # 下表为口诀的手工转录(oracle 独立于此仓的任何表):每个日干一行,12 个字依次是子时到亥时的时干。
+  # 下表为口诀的手工转录（oracle 独立于此仓的任何表）：每个日干一行，12 个字依次是子时到亥时的时干。
   wushudun: dict[Tiangan, str] = {
     Tiangan.甲 : '甲乙丙丁戊己庚辛壬癸甲乙', # 甲己还加甲(甲子起)
     Tiangan.己 : '甲乙丙丁戊己庚辛壬癸甲乙',


### PR DESCRIPTION
Closes #110

缝隙轮首跑 8 条全收,纯 tests 改动(零 src 行为改动)。kickoff-brief 流程:三路现场审计 → brief v1 → grok 计划审(GO-WITH-CHANGES,拦下根空 conftest 假修复 P1)→ brief v2 → 用户拍板(D-1 钉现状语义)→ 施工。

## 八条落点(5 施工提交 + 2 审阅修复提交)

- **条目 1/2/6**(9e7ff7e):dayun golden 组——DAY 精度立春日真时刻前(00:00 → 交运 2000-05-18 19:13:18.333333,与已钉 22:01 同历法日对照)、双后端同盘分叉(2000-02-04 10:00:celestial 2000 vs HKO 2009,四柱全同)、HKO 侧首个绝对时刻 golden(由分叉钉承担)。期望值经 grok 计划审 + 驾驶者双重独立复算(三天折年 vs 节气时刻表)。
- **条目 3/4**(d520e1f):test_ganzhis 重做——顺序精确 tuple(小运→大运→流年)、oracle 去 HKO 错源、HOUR floor 夹逼(2009-02-03 23:30:bare 2008 vs floored 2009,旧 oracle 2018 取错大运)。施工期抓到计划外真问题:Python 3.11+ 枚举迭代只产单比特成员,`for option in TransitOptions` 下顺序断言是空钉,改 `_ALL_OPTIONS`。
- **条目 5**(7f3dfa8):DAY 精度 bracketing 时刻级直接钉(柱归新 vs 旧节拥有的刻意不一致)——`src/bazi.py` docstring 的 "pinned by test_bazi" 由此变真,docstring 本身未改(终态与 main 逐字节相同)。
- **条目 7**(e01aea7):celestial 闰月边界定点(2023 闰二月 = slot 3 编号约定,末日 valid/+1 invalid + lunar 锚定 round-trip,solar 值与 HKO 交叉)。
- **条目 8**(aa54fe0):五虎遁/五鼠遁口诀手工转录字面表全表化(120+120 格,oracle 独立于 BaziRules 表)。

## 审阅史

- **R1 三席**(正确性 grok 清单 + opus 盲审 / 风格 kimi):grok 1×P2(小运 oracle 年通道未同源)、opus 1×P2+5×P3(最重要:同源 oracle 让 test_ganzhis 对首运年漂移结构性失明——突变实证 `_dayun_start_ganzhi_year +1` 下不红;与 grok 计划审的建议正面冲突,突变证据定案)、kimi 1×P2+3×P3(trade-off 三处复述等)。
- **修复批**(0b512de,十项):oracle 改独立算式 `max(calendar_utils_of(backend).to_ganzhi(...).year, ganzhi_year)`(修复后同突变必红,A/B 实证)、小运年通道对齐 ganzhi_year + HOUR 钉补小运断言(乙亥)、删逐字重复的 standalone HKO golden、μs 字面对齐邻居约定、docstring 复述收敛为指针+增量。
- **R2 三席全 FIXES VERIFIED**:grok 明示接受同源改判并撤销辩护;opus 实证新算式检出力 + 闸门咬合;kimi 核保留反例无误伤。二轮修复(b852773):`same pillars` 断言强度回退(00:00 vs 22:01 时柱不同)、标点孤岛回退半角(tests/ 中文注释实测 544 半角 vs 16 全角,邻近质感为准)。
- **记账**(后续,不在本 PR):opus F3——`test_support` 里同形同源失明既存(PR-A 未碰该测试),建议单开 issue;`_first_dayun_start_gz_year` 局部突变对 test_ganzhis 盲属构造性分工(support 绝对性归 test_support),不立项。

每条新测试均过检出率(注入旧行为/置换顺序/改表一格 → 定向必红,记录在案)。