### PR TITLE
test: #79 HKO 再生成 subprocess 回归 + #90 测试 import 解耦

### DIFF
--- a/tests/integration/test_hko_data_regeneration.py
+++ b/tests/integration/test_hko_data_regeneration.py
@@ -1,0 +1,64 @@
+# Copyright (C) 2026 Ningqi Wang (0xf3cd) <https://github.com/0xf3cd>
+# test_hko_data_regeneration.py
+
+import pytest
+
+import shutil
+import subprocess
+import sys
+
+from pathlib import Path
+
+
+pytestmark = pytest.mark.integration
+
+
+# The repo root is the level holding `src/`; this file lives at tests/integration/.
+REPO_ROOT: Path = Path(__file__).resolve().parents[2]
+
+# Paths of the two encoded tables relative to an `src/` tree (see hko_data/common.py).
+JIEQI_BIN: Path = Path('src/calendar/hko_data/data/jieqi_encoded.bin')
+LUNARDATE_BIN: Path = Path('src/calendar/hko_data/data/lunardate_encoded.bin')
+
+
+def test_hko_data_regeneration_via_module_entry(tmp_path: Path) -> None:
+  '''Issue #79: the regeneration entry must survive missing encoded data.
+
+  When the two .bin tables (节气 jieqi / 农历 lunardate) are absent,
+  `python -m src.calendar.hko_data.encoder` must rebuild them. That entry imports the
+  parent packages first, and only the PEP 562 lazy imports in `src/__init__.py` /
+  `src/calendar/__init__.py` keep it from tripping over the decoder's fail-fast
+  (数据缺失即 RuntimeError) before it can regenerate anything. The in-process
+  `test_do_encode` (tests/calendar/test_hko_data.py) never exercises this subprocess
+  path — its import chain is already complete in the test process — so a regression
+  back to eager imports would pass the whole suite unnoticed.
+  '''
+
+  # Sandbox: a full copy of src/ (the raw HKO txt travels with it, so encoding stays
+  # offline). `__pycache__` is left out — stale bytecode must not shadow copied sources.
+  sandbox: Path = tmp_path / 'sandbox'
+  shutil.copytree(REPO_ROOT / 'src', sandbox / 'src', ignore=shutil.ignore_patterns('__pycache__'))
+
+  # Knock out both encoded tables inside the copy; the repo's own data/ stays untouched.
+  (sandbox / JIEQI_BIN).unlink()
+  (sandbox / LUNARDATE_BIN).unlink()
+
+  # The entry under test, exactly as users invoke it. cwd must be the sandbox root
+  # (the level containing src/), not the repo root.
+  result: subprocess.CompletedProcess[str] = subprocess.run(
+    [sys.executable, '-m', 'src.calendar.hko_data.encoder'],
+    cwd=sandbox,
+    capture_output=True,
+    text=True,
+    timeout=60,
+    check=False,
+  )
+  assert result.returncode == 0, f'encoder entry failed:\n{result.stdout}\n{result.stderr}'
+
+  # Both tables rebuilt...
+  assert (sandbox / JIEQI_BIN).is_file()
+  assert (sandbox / LUNARDATE_BIN).is_file()
+
+  # ...and the encoding is deterministic: byte-identical to the committed tables.
+  assert (sandbox / JIEQI_BIN).read_bytes() == (REPO_ROOT / JIEQI_BIN).read_bytes()
+  assert (sandbox / LUNARDATE_BIN).read_bytes() == (REPO_ROOT / LUNARDATE_BIN).read_bytes()

--- a/tests/integration/test_import_from_any_cwd.py
+++ b/tests/integration/test_import_from_any_cwd.py
@@ -1,0 +1,41 @@
+# Copyright (C) 2026 Ningqi Wang (0xf3cd) <https://github.com/0xf3cd>
+# test_import_from_any_cwd.py
+
+import pytest
+
+import subprocess
+import sys
+
+from pathlib import Path
+
+
+pytestmark = pytest.mark.integration
+
+
+# The repo root is the level holding `src/`; this file lives at tests/integration/.
+REPO_ROOT: Path = Path(__file__).resolve().parents[2]
+
+
+def test_pytest_runs_from_any_cwd(tmp_path: Path) -> None:
+  '''Issue #90 item 2: the suite must not depend on being launched from the repo root.
+
+  Tests import `from src...`, which used to resolve only via `sys.path[0]` — i.e. only
+  when pytest was launched with the repo root as cwd/script dir; from any other cwd
+  collection died with `ModuleNotFoundError: No module named 'src'`. The fix is
+  `pythonpath = ..` in tests/pytest.ini (rootdir is tests/, so `..` is the repo root).
+  This test is what keeps that one-liner falsifiable: delete it and this goes red.
+
+  Runs a small stable test file in a subprocess with a tmp cwd — pytest startup plus
+  collection takes seconds, so the timeout is generous.
+  '''
+  result: subprocess.CompletedProcess[str] = subprocess.run(
+    [sys.executable, '-m', 'pytest', str(REPO_ROOT / 'tests' / 'test_common.py'), '-x', '-q'],
+    cwd=tmp_path,
+    capture_output=True,
+    text=True,
+    timeout=120,
+    check=False,
+  )
+  output: str = result.stdout + result.stderr
+  assert 'ModuleNotFoundError' not in output
+  assert result.returncode == 0, f'pytest from a foreign cwd failed:\n{output}'

--- a/tests/integration/test_import_from_any_cwd.py
+++ b/tests/integration/test_import_from_any_cwd.py
@@ -37,5 +37,5 @@ def test_pytest_runs_from_any_cwd(tmp_path: Path) -> None:
     check=False,
   )
   output: str = result.stdout + result.stderr
-  assert 'ModuleNotFoundError' not in output
+  assert 'ModuleNotFoundError' not in output, f'`from src` unresolved from a foreign cwd:\n{output}'
   assert result.returncode == 0, f'pytest from a foreign cwd failed:\n{output}'

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,4 +1,8 @@
 [pytest]
+# rootdir is tests/ (this ini anchors it), so `..` puts the repo root on sys.path.
+# Without it, `from src...` imports only resolve when pytest is launched from the
+# repo root (issue #90 item 2; regression: tests/integration/test_import_from_any_cwd.py).
+pythonpath = ..
 markers =
   slow: time-consuming tests.
   hkodata: hko raw data related tests.


### PR DESCRIPTION
测试缝隙批 PR-B(#110 的姊妹批 PR #113 已合并),纯测试侧,零 src 改动。

## 内容

- **#79**(`1f3d65d`):HKO 再生成入口的 subprocess 回归测试。复制 src 树进 tmp 沙箱、删两个 .bin、以沙箱根为 cwd 跑 `python -m src.calendar.hko_data.encoder`,断言 exit 0 + 两表重建 + 与 committed 表 byte-identical。钉的是 PEP 562 惰性 import 层:in-process 的 `test_do_encode` 覆盖不到「`python -m` 入口在数据缺失时先 import 父包」这条路径,eager 回退会整套绿着溜走。检出率:沙箱副本注入 eager import → 必红。
- **#90 item2**(`672dfd3`):`tests/pytest.ini` 加 `pythonpath = ..`(rootdir=tests/ 故 `..` = 仓库根),测试 import 不再绑死「从仓库根启动 pytest」;附非根 cwd 回归测试(删 ini 行必红,修法可证伪)。验证矩阵:foreign cwd / tests 内 cwd / 裸 pytest 三格施工前炸、施工后绿,`run_tests.py` 各面未退。

## 审阅

grok 快扫 **NO FINDINGS**(四个点名攻击面:沙箱正确性 / 检出率声明复核 / ini 副作用面 / integration 标记一致性,全部实证未破;byte-identical 对拍钉的是编码确定性,合法表重烤不会假红——表重烤只需同提交内 raw/encoder/committed 自洽)。

收集 402 → 404,两新测试在默认面(integration 标记,亚秒级)。

Closes #79
