### PR TITLE
test: #114 oracle 错源族三修——后端跟随 + 同源镜像独立重算 + 归属级通道

### DIFF
--- a/tests/test_bazi.py
+++ b/tests/test_bazi.py
@@ -14,7 +14,7 @@ from typing import Final
 from src.calendar import JieqiTime
 from src.defines import Tiangan, Dizhi, Ganzhi, Jieqi
 from src.bazi import BaziGender, BaziPrecision, Bazi, 八字
-from src.calendar import hko_data_utils, CalendarBackend, calendar_utils_of
+from src.calendar import CalendarBackend, calendar_utils_of
 
 
 def test_bazi_gender_basic() -> None:
@@ -487,12 +487,16 @@ def test_four_tiangans_correctness() -> None:
 
 
 def test_ganzhi_date() -> None:
+  # The oracle must follow the chart's own backend: `ganzhi_date` is the day-level label
+  # through `Bazi`'s resolved calendar utils. The two backends legitimately diverge inside
+  # the 1917/1927 jieqi-shift windows (pinned by the parity whitelist), so an oracle bound
+  # to the wrong backend false-reds there -- the #114 CI failure was exactly that.
   bazi: Bazi = _create_bazi(datetime(1984, 4, 2, 4, 2))
-  assert bazi.ganzhi_date == hko_data_utils.to_ganzhi(date(1984, 4, 2))
+  assert bazi.ganzhi_date == calendar_utils_of(bazi.backend).to_ganzhi(date(1984, 4, 2))
 
   for _ in range(10):
     bazi = Bazi.random()
-    assert bazi.ganzhi_date == hko_data_utils.to_ganzhi(bazi.solar_date)
+    assert bazi.ganzhi_date == calendar_utils_of(bazi.backend).to_ganzhi(bazi.solar_date)
 
 
 def test_date_time() -> None:

--- a/tests/test_bazi_chart.py
+++ b/tests/test_bazi_chart.py
@@ -438,8 +438,10 @@ def test_liunian() -> None:
       expected_ganzhi: Ganzhi = cycle[(year - 1924) % 60] # 1924 is a year of "甲子"
       assert ganzhi == expected_ganzhi
 
-    # The first liunian is also the birth ganzhi year.
-    assert next(chart.liunian).ganzhi_year == random_bazi.ganzhi_date.year
+    # The first liunian is also the birth ganzhi year. The liunian generator starts from the
+    # precision-attributed `ganzhi_year`, not the day-level `ganzhi_date.year` (the two agree
+    # at DAY but diverge on HOUR tie charts).
+    assert next(chart.liunian).ganzhi_year == random_bazi.ganzhi_year
 
 
 @pytest.mark.slow

--- a/tests/test_transits.py
+++ b/tests/test_transits.py
@@ -17,6 +17,16 @@ from src.calendar import calendar_utils_of
 from src.transits import DayunDatabase, TransitMoment, TransitOptions, TransitDatabase, _ALL_OPTIONS
 
 
+def _dayun_start_gz_year(chart: BaziChart) -> int:
+  # Independent recomputation, not a mirror of `next(chart.dayun).ganzhi_year` -- the very
+  # expression `TransitDatabase` consumes: the day-level label of `dayun_start_moment`
+  # through the chart's own backend, floored at `Bazi.ganzhi_year`.
+  return max(
+    calendar_utils_of(chart.bazi.backend).to_ganzhi(chart.dayun_start_moment).year,
+    chart.bazi.ganzhi_year,
+  )
+
+
 def test_simple() -> None:
   bazi: Bazi = Bazi.create(datetime(2000, 2, 4, 22, 1), BaziGender.MALE, BaziPrecision.DAY)
   chart: BaziChart = BaziChart(bazi)
@@ -85,13 +95,7 @@ def test_support() -> None:
         assert not db.support(TransitMoment(gz_year), option)
 
     # Xiaoyun / 小运.
-    # Independent recomputation, not a mirror of `next(chart.dayun).ganzhi_year` -- the very
-    # expression `TransitDatabase` consumes: the day-level label of `dayun_start_moment`
-    # through the chart's own backend, floored at `Bazi.ganzhi_year`.
-    first_dayun_gz_year: int = max(
-      calendar_utils_of(chart.bazi.backend).to_ganzhi(chart.dayun_start_moment).year,
-      chart.bazi.ganzhi_year,
-    )
+    first_dayun_gz_year: int = _dayun_start_gz_year(chart)
     for gz_year in range(chart.bazi.ganzhi_year, chart.bazi.ganzhi_year + len(chart.xiaoyun)):
       assert db.support(TransitMoment(gz_year), TransitOptions.XIAOYUN)
       assert db.support(TransitMoment(gz_year), TransitOptions.LIUNIAN)
@@ -129,13 +133,7 @@ def test_ganzhis() -> None:
       for age, xy in chart.xiaoyun
     }
 
-    # Independent recomputation, not a mirror of the source `TransitDatabase` consumes:
-    # the day-level label of `dayun_start_moment` through the chart's own backend,
-    # floored at `Bazi.ganzhi_year`.
-    dayun_start_gz_year: int = max(
-      calendar_utils_of(chart.bazi.backend).to_ganzhi(chart.dayun_start_moment).year,
-      chart.bazi.ganzhi_year,
-    )
+    dayun_start_gz_year: int = _dayun_start_gz_year(chart)
     dayun_ganzhis: list[Ganzhi] = [dy.ganzhi for dy in itertools.islice(chart.dayun, 50)]
 
     # Randomly select 20 ganzhi years to test...

--- a/tests/test_transits.py
+++ b/tests/test_transits.py
@@ -77,14 +77,22 @@ def test_support() -> None:
     with pytest.raises(ValueError):
       db.support(TransitMoment(1999), TransitOptions(0x8))
 
-    # Ganzhi years before the birth year are not supported.
-    for gz_year in range(chart.bazi.ganzhi_date.year - 10, chart.bazi.ganzhi_date.year):
+    # Ganzhi years before the birth year are not supported. The birth-side channel is the
+    # precision-attributed `ganzhi_year` -- the field `TransitDatabase` actually reads --
+    # not the day-level `ganzhi_date.year` (they agree at DAY but diverge on HOUR ties).
+    for gz_year in range(chart.bazi.ganzhi_year - 10, chart.bazi.ganzhi_year):
       for option in TransitOptions:
         assert not db.support(TransitMoment(gz_year), option)
 
     # Xiaoyun / 小运.
-    first_dayun_gz_year: int = next(chart.dayun).ganzhi_year
-    for gz_year in range(chart.bazi.ganzhi_date.year, chart.bazi.ganzhi_date.year + len(chart.xiaoyun)):
+    # Independent recomputation, not a mirror of `next(chart.dayun).ganzhi_year` -- the very
+    # expression `TransitDatabase` consumes: the day-level label of `dayun_start_moment`
+    # through the chart's own backend, floored at `Bazi.ganzhi_year`.
+    first_dayun_gz_year: int = max(
+      calendar_utils_of(chart.bazi.backend).to_ganzhi(chart.dayun_start_moment).year,
+      chart.bazi.ganzhi_year,
+    )
+    for gz_year in range(chart.bazi.ganzhi_year, chart.bazi.ganzhi_year + len(chart.xiaoyun)):
       assert db.support(TransitMoment(gz_year), TransitOptions.XIAOYUN)
       assert db.support(TransitMoment(gz_year), TransitOptions.LIUNIAN)
       assert db.support(TransitMoment(gz_year), TransitOptions.XIAOYUN_LIUNIAN)
@@ -95,8 +103,9 @@ def test_support() -> None:
       else:
         assert gz_year < first_dayun_gz_year
 
-    # Dayun / 大运.
-    for start_gz_year, _ in itertools.islice(chart.dayun, 10): # Expect the first 10 dayuns to be supported anyways...
+    # Dayun / 大运. Each dayun lasts 10 years, stepping from the independently recomputed
+    # first dayun year above -- not from `chart.dayun`, which is what the database reads.
+    for start_gz_year in range(first_dayun_gz_year, first_dayun_gz_year + 100, 10): # Expect the first 10 dayuns to be supported anyways...
       for gz_year in range(start_gz_year, start_gz_year + 10):
         assert db.support(TransitMoment(gz_year), TransitOptions.DAYUN)
         assert db.support(TransitMoment(gz_year), TransitOptions.LIUNIAN)


### PR DESCRIPTION
Closes #114

修复 PR #113 CI 抓到的那次 flake 的本体,并把同族 sweep 一次收完。纯 tests,零 src 改动。

## 内容(三修)

- **F1(族一主案)`test_ganzhi_date`**:oracle 从 HKO 后端的 `hko_data_utils.to_ganzhi` 改为后端跟随 `calendar_utils_of(bazi.backend)`。原写法在双后端合法分叉的 61 天 paradox 窗(1917 大雪 / 1927 白露,parity 白名单钉死)内对 celestial 随机盘假红——CI macOS leg 实测命中一次。修复后角色归位为 Bazi 层 plumbing 钉(backend 解析 → utils 绑定 → 日级委托);「backend 算错」的正确性面由 calendar 层 parity/golden 兜住,不在本测试职责内。
- **F2(族二主案)`test_support`**:大运起点 oracle 从 `next(chart.dayun).ganzhi_year`(与 `TransitDatabase` 消费表达式逐字同源,chart 层漂移时跟着漂)改为独立重算式(`max(后端跟随 to_ganzhi(dayun_start_moment).year, ganzhi_year)`,与 `test_ganzhis` 修复后同款);大运段 `islice(chart.dayun, 10)` 改 `range` 步进,与生成器契约严格等价(50 盘实测零差分)。修复后 chart 层 `+1` 突变必红(修复前 0 fail 失明);transits 局部字段支撑面未削弱。
- **F3(族二亚型,等价通道 ×3)**:`test_support` ×2 与 `test_liunian` ×1 的 oracle 从日级 `ganzhi_date.year` 对齐到实现实际读取的归属级 `ganzhi_year`。DAY 下两通道构造性相等(故无行为变化),防的是 `random()` 未来放开 HOUR/MINUTE 后的潜伏错配(HOUR tie 盘两通道分叉已实测)。

## 审阅

grok 快扫 **NO FINDINGS**(四攻击面:F1 降格边界 / F2 等价性与支撑面 / F3 逐处实现读点 / 检出率声明,全部实证复核;窗内 27 个可达日跟随 oracle 0 假红 vs 旧 HKO oracle 27/27 假红)。

每条修复过检出率:F1「窗内不假红 + 注入 +1 天真错仍抓」、F2「chart 层 +1 突变必红」、F3 如实记录「构造性等价,检出靠既有 HOUR 钉与代码审查」。全量门禁 ×2(随机盘 flake 确认)404 绿、coverage 100%。
