### PR TITLE
feat: #69 BaziConfig/BaziSchool 流派机制 + DayRollover 换日点 variant(PR-1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,7 +90,7 @@ those, don't restate them here. Two rules the README doesn't spell out:
   bazi = Bazi.create(
     birth_time,
     gender,
-    precision,
+    config,
   )
   ```
 

--- a/run_demo.py
+++ b/run_demo.py
@@ -86,7 +86,7 @@ def get_transit_info(chart: BaziChart) -> str:
   day_master: Tiangan = chart.bazi.day_master
   s: str = '\n' # The output string.
 
-  utils = calendar_utils_of(chart.bazi.backend)
+  utils = calendar_utils_of(chart.bazi.config.backend)
   jie_before = utils.prev_jie(chart.bazi.solar_datetime)
   jie_after = utils.next_jie(chart.bazi.solar_datetime)
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,6 +2,7 @@ from importlib import import_module
 from typing import Any, Final
 
 from . import calendar
+from . import school
 
 from . import common
 from . import defines
@@ -10,7 +11,7 @@ from . import utils
 from . import descriptions
 
 __all__ = [
-  'common', 'defines', 'calendar', 'bazi', 'bazi_chart', 'rules', 'utils',
+  'common', 'defines', 'calendar', 'school', 'bazi', 'bazi_chart', 'rules', 'utils',
   'analyzer', 'descriptions', 'interpreter', 'transits', 'transit_chart',
 ]
 

--- a/src/bazi.py
+++ b/src/bazi.py
@@ -10,7 +10,7 @@ from .defines import Tiangan, Dizhi, Ganzhi, Jieqi
 from .calendar import (
   CalendarDate, CalendarUtilsProtocol, CalendarBackend, calendar_utils_of, JieqiTime,
 )
-from .school import BaziPrecision, BaziConfig, DEFAULT_CONFIG
+from .school import BaziPrecision, DayRollover, BaziConfig, DEFAULT_CONFIG
 
 from .utils.bazi_utils import (
   month_tiangan, hour_tiangan, ganzhi_of_day, ganzhi_of_year,
@@ -190,13 +190,14 @@ class Bazi:
 
     # Figure out the ganzhi day, as well as the Day Ganzhi / Day Pillar (日柱).
     #
-    # 晚子时换日: the day pillar rolls at 23:00 (when 子时 begins), which the year and month
-    # pillars above deliberately do NOT do -- they follow `BaziPrecision`'s attribution
-    # (dates at DAY, truncated moments at HOUR/MINUTE). So a 23:30 birth takes the *next*
-    # day's day pillar while its year/month attribution stays put, except inside a tie
-    # window. Both halves of that are variants tracked in issue #69, and a 子正换日
-    # variant has to say which pillars it moves; `test_bazi` pins today's answer meanwhile.
-    day_offset: int = 0 if self._birth_time.hour < 23 else 1
+    # 换日点 is the `DayRollover` variant (issue #69), mounted on
+    # `BaziSchool.day_rollover`: WAN_ZISHI (晚子时) rolls the day pillar at 23:00 when
+    # 子时 begins, ZIZHENG (子正) keeps the civil day's pillar until 00:00. The default
+    # WAN_ZISHI is the behavior `test_bazi` has long pinned. The year and month pillars
+    # above deliberately do NOT follow this knob -- they follow `BaziPrecision`'s
+    # attribution (two independent mechanisms; see `DayRollover`'s docstring).
+    rolls_at_23: bool = self._config.school.day_rollover is DayRollover.WAN_ZISHI
+    day_offset: int = 0 if self._birth_time.hour < 23 or not rolls_at_23 else 1
     self._day_pillar: Final[Ganzhi] = ganzhi_of_day(timedelta(days=day_offset) + self._birth_time)
 
     # Finally, find out the Hour Dizhi (时柱地支).

--- a/src/bazi.py
+++ b/src/bazi.py
@@ -10,6 +10,7 @@ from .defines import Tiangan, Dizhi, Ganzhi, Jieqi
 from .calendar import (
   CalendarDate, CalendarUtilsProtocol, CalendarBackend, calendar_utils_of, JieqiTime,
 )
+from .school import BaziPrecision, BaziConfig, DEFAULT_CONFIG
 
 from .utils.bazi_utils import (
   month_tiangan, hour_tiangan, ganzhi_of_day, ganzhi_of_year,
@@ -43,69 +44,6 @@ class BaziGender(Enum):
       assert self is self.FEMALE
       return 'female'
 
-
-
-class BaziPrecision(Enum):
-  '''
-  BaziPrecision is used to specify the precision when generating the Bazi chart.
-
-  As per the rules of Bazi system, new years start on the days of Start of Spring (LICHUN / 立春), and new months start
-  on the days of 12 Jieqis (LICHUN, JINGZHE, QINGMING, LIXIA... / 立春, 惊蛰, 清明, 立夏...).
-
-  So, even born on the same day, two persons can have different Year Ganzhi (年柱) and Month Ganzhi (月柱).
-
-  The 3 levels -- DAY, HOUR, MINUTE -- are three granularities of ONE rule, not three
-  approximations of a single truth. A birth belongs to the new year / month when
-  `birth >= jieqi`, compared at the granularity the birth is known to; a tie resolves to the
-  NEW pillar. That tie-break is the same one the calendar layer freezes -- see
-  `calendar/celestial_data/SCHEMA.md`, "Boundary convention".
-  三档是同一条规则的三个粒度，不是对同一真值的三种逼近：出生按「已知的粒度」与节气时刻比较，
-  `birth >= jieqi` 归新年 / 新月，相等归新。
-
-  - DAY    -- the birth is known to the day, so dates are compared.    只知道日期，比到日。
-  - HOUR   -- known to the 时辰, so (date, 时辰) is compared.           知道时辰，比到时辰。
-  - MINUTE -- known to the minute, so (date, hour, minute) is compared. 知道到分，比到分。
-
-  `HOUR` means a 时辰 (a traditional double-hour, 子时 starting at 23:00), not a clock hour:
-  birth records come at day, 时辰, or minute granularity -- never "hour but not minute".
-
-  For example, LICHUN / 立春 of 2000 falls at 2000-02-04 20:40:23 (per the celestial backend;
-  the HKO backend publishes the date only). Then:
-  - DAY:    everyone born on 2000-02-04 gets "庚辰" and Month Dizhi "寅", including those born
-            before 20:40:23 -- at day granularity, 02-04 >= 02-04 is a tie, and ties go new.
-            Those born on 2000-02-03 get "己卯" and "丑".
-  - HOUR:   born in 戌时 [19:00, 21:00), the 时辰 holding the jieqi, gets "庚辰" and "寅" (a tie
-            again); born in 酉时 [17:00, 19:00) or earlier that day gets "己卯" and "丑".
-  - MINUTE: born at or after 20:40 gets "庚辰" and "寅"; before it, "己卯" and "丑".
-
-  This is a rule, not an estimate, and the difference is visible at the extremes: LICHUN of
-  2017 falls at 2017-02-03 23:34:03, so DAY assigns all of 02-03 to the new year even though
-  98% of that day precedes the jieqi. That is what the rule says, not a defect in it -- an
-  estimator would have to flip its answer based on a clock time the DAY caller is not claiming
-  to know, which would also make ganzhi month lengths depend on it.
-
-  Because 子时 spans midnight, the tie 时辰 can start on the previous civil day: LICHUN of
-  2009 falls at 2009-02-04 00:49:48, in the 子时 that began at 02-03 23:00, so a HOUR birth
-  at 2009-02-03 23:30 ties and belongs to the new year -- on a day that DAY assigns to the
-  old side. The granularities are three readings of one rule, not nested refinements.
-  子时跨午夜，tie 时辰可始于节气前一公历日——三档是同一规则的三种读法，不是嵌套细化。
-
-  HOUR and MINUTE need real jieqi moments, so they require the celestial backend --
-  `Bazi.__init__` rejects the HKO backend for them (its `jieqi_moment` is a midnight
-  placeholder, see `CalendarUtilsProtocol`).
-  '''
-  DAY    = 0
-  HOUR   = 1
-  MINUTE = 2
-
-  def __str__(self) -> str:
-    if self is self.DAY:
-      return 'day'
-    elif self is self.HOUR:
-      return 'hour'
-    else:
-      assert self is self.MINUTE
-      return 'minute'
 
 
 '''Maps each Jie (节) to the ganzhi month it opens: 立春 -> 1 (寅月), ..., 小寒 -> 12 (丑月). / 每个节到其所开干支月的映射：立春开寅月，……，小寒开丑月。'''
@@ -164,8 +102,7 @@ class Bazi:
   - 本库从立春派：年柱以立春换年，不以正月初一（春节）换年。
   '''
 
-  def __init__(self, birth_time: datetime, gender: BaziGender, precision: BaziPrecision,
-               backend: CalendarBackend = CalendarBackend.CELESTIAL) -> None:
+  def __init__(self, birth_time: datetime, gender: BaziGender, config: BaziConfig = DEFAULT_CONFIG) -> None:
     '''
     `Bazi` (i.e. 八字, which means eight characters in Chinese) takes the birth time and gender as input, 
     and figures out the pillars of year, month, day, and hour.
@@ -180,21 +117,19 @@ class Bazi:
     Args:
     - birth_time: (datetime) The birth date (in Gregorian calendar) and time. Note that no timezone should be set.
     - gender: (BaziGender) The gender of the person.
-    - precision: (BaziPrecision) The precision of the birth time.
-    - backend: (CalendarBackend) The calendar backend used for all calendar conversions.
+    - config: (BaziConfig) The chart-level configuration: the precision of the birth time, the calendar
+      backend used for all calendar conversions, and the school profile (流派档案).
     '''
 
     if not isinstance(birth_time, datetime):
       raise TypeError(f'Expected datetime, got {type(birth_time)}')
     if not isinstance(gender, BaziGender):
       raise TypeError(f'Expected BaziGender, got {type(gender)}')
-    if not isinstance(precision, BaziPrecision):
-      raise TypeError(f'Expected BaziPrecision, got {type(precision)}')
-    if not isinstance(backend, CalendarBackend):
-      raise TypeError(f'Expected CalendarBackend, got {type(backend)}')
+    if not isinstance(config, BaziConfig):
+      raise TypeError(f'Expected BaziConfig, got {type(config)}')
 
-    self._backend: Final[CalendarBackend] = backend
-    utils: Final[CalendarUtilsProtocol] = calendar_utils_of(backend)
+    self._config: Final[BaziConfig] = config
+    utils: Final[CalendarUtilsProtocol] = calendar_utils_of(config.backend)
 
     self._birth_time: Final[datetime] = birth_time
     if self._birth_time.tzinfo is not None:
@@ -204,23 +139,22 @@ class Bazi:
     self._solar_date: Final[CalendarDate] = utils.to_solar(self._birth_time)
 
     self._gender: Final[BaziGender] = gender
-    self._precision: Final[BaziPrecision] = precision
 
     # Which ganzhi year / month owns the birth, compared per `BaziPrecision`
     # (`birth >= jieqi` at the known granularity, ties go new).
     ganzhi_year: int
     ganzhi_month: int
     bracketing_jies: tuple[JieqiTime, JieqiTime] | None = None
-    if self._precision is BaziPrecision.DAY:
+    if self._config.precision is BaziPrecision.DAY:
       # DAY compares dates: the `to_ganzhi` channel drops the time, so a jieqi's whole day
       # falls on its new side. `bracketing_jies` stays moment-level for DAY (see the property).
       ganzhi_calendardate: CalendarDate = utils.to_ganzhi(self._solar_date)
       ganzhi_year = ganzhi_calendardate.year
       ganzhi_month = ganzhi_calendardate.month # `ganzhi_calendardate` is already at `DAY`-level precision.
     else:
-      if self._backend is CalendarBackend.HKO:
+      if self._config.backend is CalendarBackend.HKO:
         raise ValueError(
-          f'{self._precision} needs real jieqi moments, which the HKO backend cannot provide '
+          f'{self._config.precision} needs real jieqi moments, which the HKO backend cannot provide '
           '(its `jieqi_moment` is a midnight placeholder). Use `CalendarBackend.CELESTIAL`.'
         )
 
@@ -231,7 +165,7 @@ class Bazi:
       birth_moment: Final[datetime] = self.solar_datetime
       prev_j: Final[JieqiTime] = utils.prev_jie(birth_moment)
       next_j: Final[JieqiTime] = utils.next_jie(birth_moment)
-      if _truncated(birth_moment, self._precision) >= _truncated(next_j.moment, self._precision):
+      if _truncated(birth_moment, self._config.precision) >= _truncated(next_j.moment, self._config.precision):
         bracketing_jies = (next_j, utils.next_jie(next_j.moment))
       else:
         bracketing_jies = (prev_j, next_j)
@@ -271,11 +205,9 @@ class Bazi:
   @staticmethod
   def __parse_bazi_args(
     birth_time: datetime | str,
-    gender: BaziGender | str, 
-    precision: BaziPrecision | str,
-    backend: CalendarBackend | str
-  ) -> tuple[datetime, BaziGender, BaziPrecision, CalendarBackend]:
-    
+    gender: BaziGender | str,
+  ) -> tuple[datetime, BaziGender]:
+
     assert isinstance(birth_time, (datetime, str))
     _birth_time: datetime = birth_time if isinstance(birth_time, datetime) else datetime.fromisoformat(birth_time)
 
@@ -294,35 +226,13 @@ class Bazi:
       else:
         raise ValueError(f'Currently not support gender: {gender}')
 
-    _precision: BaziPrecision
-    if isinstance(precision, BaziPrecision):
-      _precision = precision
-    else:
-      assert isinstance(precision, str)
-      if precision.lower() in ['分', '分钟', 'm', 'min', 'minute']:
-        _precision = BaziPrecision.MINUTE
-      elif precision.lower() in ['时', '小时', 'h', 'hour']:
-        _precision = BaziPrecision.HOUR
-      elif precision.lower() in ['天', '日', 'd', 'day']:
-        _precision = BaziPrecision.DAY
-      else:
-        raise ValueError(f'Unsupported precision: {precision}')
-
-    _backend: CalendarBackend
-    if isinstance(backend, CalendarBackend):
-      _backend = backend
-    else:
-      assert isinstance(backend, str)
-      _backend = CalendarBackend.from_str(backend)
-
-    return _birth_time, _gender, _precision, _backend
+    return _birth_time, _gender
 
   @staticmethod
   def create(
     birth_time: datetime | str,
-    gender: BaziGender | str, 
-    precision: BaziPrecision | str,
-    backend: CalendarBackend | str = CalendarBackend.CELESTIAL
+    gender: BaziGender | str,
+    config: BaziConfig = DEFAULT_CONFIG
   ) -> 'Bazi':
     '''
     Staticmethod that creates a `Bazi` object from the inputs.
@@ -335,31 +245,23 @@ class Bazi:
       - if `BaziGender` type: it will be directly fed to `Bazi`.
       - if `str` type: it will be converted by `BaziGender`. 
         - Supported values: "男"/"女"/"male"/"female" (case insensitive).
-    - precision: (BaziPrecision | str) The precision of the birth time.
-      - if `BaziPrecision` type: it will be directly fed to `Bazi`.
-      - if `str` type: it will be converted by `BaziPrecision`. 
-        - Supported values: "分"/"分钟"/"时"/"小时"/"天"/"日"/"m"/"min"/"minute"/"h"/"hour"/"d"/"day" (case insensitive).
-    - backend: (CalendarBackend | str) The calendar backend used for all calendar conversions.
-      - if `CalendarBackend` type: it will be directly fed to `Bazi`.
-      - if `str` type: it will be converted by `CalendarBackend.from_str`.
-        - Supported values: the member names and values of `CalendarBackend` (e.g. "HKO"/"hko", case insensitive).
+    - config: (BaziConfig) The chart-level configuration (precision / backend / school).
+      Use `BaziConfig.from_values` to build one from string spellings -- it shares the
+      acceptance face this method historically parsed for `precision` / `backend`.
     '''
 
     if not isinstance(birth_time, (datetime, str)):
       raise TypeError(f'Expected datetime or str, got {type(birth_time)}')
     if not isinstance(gender, (BaziGender, str)):
       raise TypeError(f'Expected BaziGender or str, got {type(gender)}')
-    if not isinstance(precision, (BaziPrecision, str)):
-      raise TypeError(f'Expected BaziPrecision or str, got {type(precision)}')
-    if not isinstance(backend, (CalendarBackend, str)):
-      raise TypeError(f'Expected CalendarBackend or str, got {type(backend)}')
+    if not isinstance(config, BaziConfig):
+      raise TypeError(f'Expected BaziConfig, got {type(config)}')
 
-    _birth_time, _gender, _precision, _backend = Bazi.__parse_bazi_args(birth_time, gender, precision, backend)
+    _birth_time, _gender = Bazi.__parse_bazi_args(birth_time, gender)
     bazi: Bazi = Bazi(
       birth_time=_birth_time,
       gender=_gender,
-      precision=_precision,
-      backend=_backend,
+      config=config,
     )
     return bazi
   
@@ -368,7 +270,7 @@ class Bazi:
     '''
     Staticmethod that creates a random `Bazi` object. Mainly for testing purpose.
 
-    Note that the precision is currently set to `BaziPrecision.DAY`.
+    Note that the config is `DEFAULT_CONFIG` (DAY precision, the celestial backend, the default school).
     Note that the year is in [1902, 2080], and day is in [1, 28].
     '''
     return Bazi.create(
@@ -380,7 +282,7 @@ class Bazi:
         minute=random.randint(0, 59),
       ),
       gender=random.choice(list(BaziGender)),
-      precision=BaziPrecision.DAY,
+      config=DEFAULT_CONFIG,
     )
 
   @property
@@ -402,18 +304,18 @@ class Bazi:
   @property
   def ganzhi_year(self) -> int:
     '''
-    The ganzhi year the birth belongs to, attributed at `self.precision` -- the year pillar is
-    `ganzhi_of_year` of exactly this. 按 `self.precision` 粒度归属的出生干支年，年柱即由它推出。
+    The ganzhi year the birth belongs to, attributed at `self.config.precision` -- the year
+    pillar is `ganzhi_of_year` of exactly this. 按 `self.config.precision` 粒度归属的出生干支年，年柱即由它推出。
     '''
     return self._ganzhi_year
 
   @property
   def bracketing_jies(self) -> tuple[JieqiTime, JieqiTime]:
     '''
-    The two Jies (节) bracketing the birth, per `self.precision`. This is the single source
+    The two Jies (节) bracketing the birth, per `self.config.precision`. This is the single source
     that the year/month attribution and `BaziChart`'s dayun counting share, so a chart cannot
     contradict itself about which jie owns the birth month.
-    按 `self.precision` 归属的出生前后两节。年/月柱归属与大运数节共用此单一来源，保证盘面自洽。
+    按 `self.config.precision` 归属的出生前后两节。年/月柱归属与大运数节共用此单一来源，保证盘面自洽。
 
     Note:
     - HOUR / MINUTE: `[0]` is the jie owning the birth month (granularity-aware, ties go new --
@@ -450,18 +352,15 @@ class Bazi:
     return self._gender
   
   @property
-  def precision(self) -> BaziPrecision:
-    return self._precision
-
-  @property
-  def backend(self) -> CalendarBackend:
-    '''The calendar backend that this `Bazi` uses / 此命盘使用的历法后端'''
-    return self._backend
+  def config(self) -> BaziConfig:
+    '''The chart-level configuration of this `Bazi` (precision / backend / school).
+    此命盘的配置（出生时间精度 / 历法后端 / 流派档案）。'''
+    return self._config
 
   @property
   def _utils(self) -> CalendarUtilsProtocol:
     '''
-    The resolved calendar utils of `self.backend`. Resolved on each access, so the resolved
+    The resolved calendar utils of `self.config.backend`. Resolved on each access, so the resolved
     utils -- the HKO module or a celestial singleton -- is never stored on the instance.
     当前历法后端对应的实际工具。每次访问时现解析，实例上不存解析结果，保证 `Bazi` 可安全 deepcopy。
 
@@ -469,7 +368,7 @@ class Bazi:
     the instance dict, where the module breaks `deepcopy` loudly and a singleton would be
     silently duplicated, forking its caches.
     '''
-    return calendar_utils_of(self._backend)
+    return calendar_utils_of(self._config.backend)
   
   @property
   def four_dizhis(self) -> tuple[Dizhi, Dizhi, Dizhi, Dizhi]:
@@ -554,17 +453,16 @@ class Bazi:
     return (
       self.solar_datetime == other.solar_datetime
       and self.gender == other.gender
-      and self.precision == other.precision
-      and self.backend == other.backend
+      and self.config == other.config
     )
   
   def __ne__(self, other: object) -> bool:
     return not self.__eq__(other)
 
   def __hash__(self) -> int:
-    # Same four inputs as `__eq__`, all derived from `Final` state: stable under the
+    # Same three inputs as `__eq__`, all derived from `Final` state: stable under the
     # public API (private reassignment is not defended against, as everywhere else).
-    # 与 `__eq__` 同源四元组，皆派生自 `Final` 状态：公开 API 下稳定（私有改写不设防，全类同此）。
-    return hash((self.solar_datetime, self.gender, self.precision, self.backend))
+    # 与 `__eq__` 同源三元组，皆派生自 `Final` 状态：公开 API 下稳定（私有改写不设防，全类同此）。
+    return hash((self.solar_datetime, self.gender, self.config))
 
 八字 = Bazi

--- a/src/bazi.py
+++ b/src/bazi.py
@@ -196,8 +196,18 @@ class Bazi:
     # WAN_ZISHI is the behavior `test_bazi` has long pinned. The year and month pillars
     # above deliberately do NOT follow this knob -- they follow `BaziPrecision`'s
     # attribution (two independent mechanisms; see `DayRollover`'s docstring).
-    rolls_at_23: bool = self._config.school.day_rollover is DayRollover.WAN_ZISHI
-    day_offset: int = 0 if self._birth_time.hour < 23 or not rolls_at_23 else 1
+    day_offset: int
+    if self._config.school.day_rollover is DayRollover.WAN_ZISHI:
+      # 晚子时: a birth at/after 23:00 already carries the next day's day pillar.
+      day_offset = 1 if self._birth_time.hour >= 23 else 0
+    elif self._config.school.day_rollover is DayRollover.ZIZHENG:
+      # 子正: the whole 子时 keeps the civil day's day pillar.
+      day_offset = 0
+    else:
+      # Invariant: every enum member must be wired up above. Reaching here means we
+      # added a member but forgot to wire it -- not something users can trigger.
+      # `raise` instead of `assert` so the guard survives `python -O`.
+      raise AssertionError(f'DayRollover not wired up in `Bazi.__init__`: {self._config.school.day_rollover}') # pragma: no cover # Unreachable invariant guard.
     self._day_pillar: Final[Ganzhi] = ganzhi_of_day(timedelta(days=day_offset) + self._birth_time)
 
     # Finally, find out the Hour Dizhi (时柱地支).
@@ -211,9 +221,6 @@ class Bazi:
 
     assert isinstance(birth_time, (datetime, str))
     _birth_time: datetime = birth_time if isinstance(birth_time, datetime) else datetime.fromisoformat(birth_time)
-
-    if _birth_time.tzinfo is not None:
-      raise ValueError('Timezone should be well-processed outside of this class.')
 
     _gender: BaziGender
     if isinstance(gender, BaziGender):
@@ -247,8 +254,8 @@ class Bazi:
       - if `str` type: it will be converted by `BaziGender`. 
         - Supported values: "男"/"女"/"male"/"female" (case insensitive).
     - config: (BaziConfig) The chart-level configuration (precision / backend / school).
-      Use `BaziConfig.from_values` to build one from string spellings -- it shares the
-      acceptance face this method historically parsed for `precision` / `backend`.
+      Use `BaziConfig.from_values` to build one from string spellings -- the same
+      acceptance face this method parsed here before #69.
     '''
 
     if not isinstance(birth_time, (datetime, str)):

--- a/src/bazi_chart.py
+++ b/src/bazi_chart.py
@@ -66,11 +66,19 @@ class BaziJson:
     # value: dayun in str / 该步大运
     dayun: dict[str, str]
 
+  class School(TypedDict):
+    '''Not expected to be accessed directly. Used in `BaziChartJsonDict`. The school
+    profile (流派档案), serialized as the member names of the two variant enums.
+    流派档案：两个分歧枚举各存其成员名。'''
+    day_rollover: str
+    hongyan_key: str
+
   class BaziChartJsonDict(TypedDict):
     birth_time: str
     gender: str
     precision: str
     backend: str
+    school: 'BaziJson.School'
     pillars: 'BaziJson.FourPillars'
     nayin: 'BaziJson.FourPillars'
     shier_zhangsheng: 'BaziJson.FourPillars'
@@ -126,7 +134,7 @@ class BaziChart:
     the instance dict, where the module breaks `deepcopy` loudly and a singleton would be
     silently duplicated, forking its caches.
     '''
-    return calendar_utils_of(self._bazi.backend)
+    return calendar_utils_of(self._bazi.config.backend)
   
   @property
   def house_of_relationship(self) -> Dizhi:
@@ -438,8 +446,12 @@ class BaziChart:
     return {
       'birth_time': self._bazi.solar_datetime.isoformat(),
       'gender': str(self._bazi.gender),
-      'precision': str(self._bazi.precision),
-      'backend': str(self._bazi.backend),
+      'precision': str(self._bazi.config.precision),
+      'backend': str(self._bazi.config.backend),
+      'school': {
+        'day_rollover': self._bazi.config.school.day_rollover.name,
+        'hongyan_key': self._bazi.config.school.hongyan_key.name,
+      },
       'pillars': f([str(p) for p in self._bazi.pillars]),
       'nayin': f([str(ny) for ny in self.nayin]),
       'shier_zhangsheng': f([str(sz) for sz in self.shier_zhangsheng]),

--- a/src/bazi_chart.py
+++ b/src/bazi_chart.py
@@ -68,8 +68,8 @@ class BaziJson:
 
   class School(TypedDict):
     '''Not expected to be accessed directly. Used in `BaziChartJsonDict`. The school
-    profile (流派档案), serialized as the member names of the two variant enums.
-    流派档案：两个分歧枚举各存其成员名。'''
+    profile (流派档案), serialized as the member name of each variant knob.
+    流派档案：每个分歧旋钮各存其枚举成员名。'''
     day_rollover: str
     hongyan_key: str
 

--- a/src/school.py
+++ b/src/school.py
@@ -1,0 +1,236 @@
+# Copyright (C) 2026 Ningqi Wang (0xf3cd) <https://github.com/0xf3cd>
+
+from enum import Enum
+from dataclasses import dataclass
+from typing import Final
+
+from .calendar import CalendarBackend
+
+
+class BaziPrecision(Enum):
+  '''
+  BaziPrecision is used to specify the precision when generating the Bazi chart.
+
+  As per the rules of Bazi system, new years start on the days of Start of Spring (LICHUN / 立春), and new months start
+  on the days of 12 Jieqis (LICHUN, JINGZHE, QINGMING, LIXIA... / 立春, 惊蛰, 清明, 立夏...).
+
+  So, even born on the same day, two persons can have different Year Ganzhi (年柱) and Month Ganzhi (月柱).
+
+  The 3 levels -- DAY, HOUR, MINUTE -- are three granularities of ONE rule, not three
+  approximations of a single truth. A birth belongs to the new year / month when
+  `birth >= jieqi`, compared at the granularity the birth is known to; a tie resolves to the
+  NEW pillar. That tie-break is the same one the calendar layer freezes -- see
+  `calendar/celestial_data/SCHEMA.md`, "Boundary convention".
+  三档是同一条规则的三个粒度，不是对同一真值的三种逼近：出生按「已知的粒度」与节气时刻比较，
+  `birth >= jieqi` 归新年 / 新月，相等归新。
+
+  - DAY    -- the birth is known to the day, so dates are compared.    只知道日期，比到日。
+  - HOUR   -- known to the 时辰, so (date, 时辰) is compared.           知道时辰，比到时辰。
+  - MINUTE -- known to the minute, so (date, hour, minute) is compared. 知道到分，比到分。
+
+  `HOUR` means a 时辰 (a traditional double-hour, 子时 starting at 23:00), not a clock hour:
+  birth records come at day, 时辰, or minute granularity -- never "hour but not minute".
+
+  For example, LICHUN / 立春 of 2000 falls at 2000-02-04 20:40:23 (per the celestial backend;
+  the HKO backend publishes the date only). Then:
+  - DAY:    everyone born on 2000-02-04 gets "庚辰" and Month Dizhi "寅", including those born
+            before 20:40:23 -- at day granularity, 02-04 >= 02-04 is a tie, and ties go new.
+            Those born on 2000-02-03 get "己卯" and "丑".
+  - HOUR:   born in 戌时 [19:00, 21:00), the 时辰 holding the jieqi, gets "庚辰" and "寅" (a tie
+            again); born in 酉时 [17:00, 19:00) or earlier that day gets "己卯" and "丑".
+  - MINUTE: born at or after 20:40 gets "庚辰" and "寅"; before it, "己卯" and "丑".
+
+  This is a rule, not an estimate, and the difference is visible at the extremes: LICHUN of
+  2017 falls at 2017-02-03 23:34:03, so DAY assigns all of 02-03 to the new year even though
+  98% of that day precedes the jieqi. That is what the rule says, not a defect in it -- an
+  estimator would have to flip its answer based on a clock time the DAY caller is not claiming
+  to know, which would also make ganzhi month lengths depend on it.
+
+  Because 子时 spans midnight, the tie 时辰 can start on the previous civil day: LICHUN of
+  2009 falls at 2009-02-04 00:49:48, in the 子时 that began at 02-03 23:00, so a HOUR birth
+  at 2009-02-03 23:30 ties and belongs to the new year -- on a day that DAY assigns to the
+  old side. The granularities are three readings of one rule, not nested refinements.
+  子时跨午夜，tie 时辰可始于节气前一公历日——三档是同一规则的三种读法，不是嵌套细化。
+
+  HOUR and MINUTE need real jieqi moments, so they require the celestial backend --
+  `Bazi.__init__` rejects the HKO backend for them (its `jieqi_moment` is a midnight
+  placeholder, see `CalendarUtilsProtocol`).
+  '''
+  DAY    = 0
+  HOUR   = 1
+  MINUTE = 2
+
+  def __str__(self) -> str:
+    if self is self.DAY:
+      return 'day'
+    elif self is self.HOUR:
+      return 'hour'
+    else:
+      assert self is self.MINUTE
+      return 'minute'
+
+
+class DayRollover(Enum):
+  '''
+  The rule that decides when the Day Pillar (日柱) rolls over to the next day (换日点).
+  日柱换日点的流派分歧。
+
+  - WAN_ZISHI (晚子时): the day pillar rolls at 23:00, when 子时 begins -- a birth in
+    [23:00, 24:00) already carries the next day's day pillar. This is the default, matching
+    the majority school and the behaviour `test_bazi` has long pinned.
+    晚子时：23:00 子时一开始即换日柱。默认，多数派口径，即现状行为。
+  - ZIZHENG (子正): the day pillar rolls at 00:00 (子正, midnight) -- the whole 子时 keeps
+    the civil day's day pillar.
+    子正：0:00 才换日柱，整个子时不提前换。
+
+  Note:
+  - The year and month pillars do NOT follow this knob -- their attribution is
+    `BaziPrecision`'s rule (`birth >= jieqi` at the known granularity, ties go new). The two
+    mechanisms are independent: a 23:30 WAN_ZISHI birth takes the next day's day pillar while
+    its year/month attribution stays put.
+    年/月柱不随此旋钮——它们的归属是 `BaziPrecision` 的规则，两条机制相互独立。
+
+  No change should be made to the existing definitions. Only add new definitions.
+  '''
+  WAN_ZISHI = 0
+  ZIZHENG   = 1
+
+
+class KeyStem(Enum):
+  '''
+  The Tiangan a 神煞 lookup keys on, where schools disagree (查法锚干).
+  神煞查法所锚的天干（流派分歧处）。
+
+  - DAY_MASTER: key on the Day Master (日干 / 日主) -- the 《三命通会》 reading, and the
+    default this library has always used for 红艳.
+    以日干为锚——《三命通会》口径，本库红艳查法的既有默认。
+  - YEAR_MASTER: key on the Year Tiangan (年干).
+    以年干为锚。
+
+  No change should be made to the existing definitions. Only add new definitions.
+  '''
+  DAY_MASTER  = 0
+  YEAR_MASTER = 1
+
+
+@dataclass(frozen=True)
+class BaziSchool:
+  '''
+  The school (流派) profile of a chart: the variant knobs where schools disagree.
+  Immutable; a chart carries one profile end to end.
+  命盘的流派档案：各流派分歧旋钮的取值。不可变；一张盘从头到尾持有一份。
+
+  Fields must stay immutable types (enums / frozen value types) -- no `dict` / `list`
+  defaults, so a shared default instance can never be mutated through.
+  字段只许不可变类型（枚举 / frozen 值类型），共享默认实例不可能被改脏。
+
+  The field defaults below are the single definition of the default school (多数派口径);
+  `DEFAULT_SCHOOL` picks them up, and `BaziConfig.school` points at that same instance --
+  the defaults are written down exactly once.
+  默认流派只在字段默认值处定义一次；`DEFAULT_SCHOOL` 构造即默认，`BaziConfig.school` 指向同一实例。
+  '''
+  day_rollover: DayRollover = DayRollover.WAN_ZISHI
+  hongyan_key:  KeyStem     = KeyStem.DAY_MASTER
+
+  def __post_init__(self) -> None:
+    # Type check at runtime (same shape as `CalendarDate`).
+    if not isinstance(self.day_rollover, DayRollover):
+      raise TypeError(f'Expected DayRollover, got {type(self.day_rollover)}')
+    if not isinstance(self.hongyan_key, KeyStem):
+      raise TypeError(f'Expected KeyStem, got {type(self.hongyan_key)}')
+
+
+'''The default school profile: 晚子时换日 + 红艳以日干为锚 (《三命通会》). / 默认流派档案：晚子时换日、红艳查日干。'''
+DEFAULT_SCHOOL: Final[BaziSchool] = BaziSchool()
+
+
+@dataclass(frozen=True)
+class BaziConfig:
+  '''
+  The chart-level configuration of a `Bazi`: every knob that affects what the chart
+  computes, carried as one immutable value. A `Bazi` stores its `BaziConfig`, and the
+  config feeds `__eq__` / `__hash__` / JSON as a unit (same precedent as `backend`).
+  命盘级配置：凡影响盘面演算的旋钮聚合为一个不可变值。`Bazi` 持有它，
+  相等性 / 哈希 / JSON 都以它为单位进出（同 `backend` 先例）。
+
+  - precision: (BaziPrecision) The precision of the birth time / 出生时间精度。
+  - backend: (CalendarBackend) The calendar backend for all calendar conversions / 历法后端。
+  - school: (BaziSchool) The school profile (流派档案); defaults to `DEFAULT_SCHOOL`.
+
+  Gender is deliberately NOT here: it does not affect the four pillars' computation
+  channel this config aggregates, and stays a `Bazi.create` argument (its string coercion
+  lives there too, as before).
+  性别刻意不在此：它不进本配置聚合的排盘算路，仍是 `Bazi.create` 的参数（字符串解析也留在那里）。
+
+  The constructor takes the strict types only; string coercion lives in `from_values`,
+  which shares one alias table with `Bazi.create`'s historical parsing face.
+  构造只收严格枚举类型；字符串解析收在 `from_values`，与 `Bazi.create` 既有解析面同一张别名表。
+  '''
+  precision: BaziPrecision    = BaziPrecision.DAY
+  backend:   CalendarBackend  = CalendarBackend.CELESTIAL
+  school:    BaziSchool       = DEFAULT_SCHOOL
+
+  def __post_init__(self) -> None:
+    # Type check at runtime; no coercion here (same shape as `CalendarDate`).
+    if not isinstance(self.precision, BaziPrecision):
+      raise TypeError(f'Expected BaziPrecision, got {type(self.precision)}')
+    if not isinstance(self.backend, CalendarBackend):
+      raise TypeError(f'Expected CalendarBackend, got {type(self.backend)}')
+    if not isinstance(self.school, BaziSchool):
+      raise TypeError(f'Expected BaziSchool, got {type(self.school)}')
+
+  @classmethod
+  def from_values(cls, precision: BaziPrecision | str = BaziPrecision.DAY,
+                  backend: CalendarBackend | str = CalendarBackend.CELESTIAL,
+                  school: BaziSchool = DEFAULT_SCHOOL) -> 'BaziConfig':
+    '''
+    Build a `BaziConfig`, coercing string spellings to the enums -- the same acceptance
+    face `Bazi.create` historically parsed (one alias table, one rejection face).
+    从字符串/枚举构造 `BaziConfig`——与 `Bazi.create` 既有解析面同一张别名表、同一个拒绝面。
+
+    Args:
+    - precision: (BaziPrecision | str) The precision of the birth time.
+      - Supported string values: "分"/"分钟"/"时"/"小时"/"天"/"日"/"m"/"min"/"minute"/"h"/"hour"/"d"/"day"
+        (case insensitive). Anything else raises `ValueError`.
+    - backend: (CalendarBackend | str) The calendar backend.
+      - Supported string values: the member names and values of `CalendarBackend`
+        (e.g. "HKO"/"hko", case insensitive), resolved by `CalendarBackend.from_str`.
+        Anything else raises `ValueError`.
+    - school: (BaziSchool) The school profile; no string spelling. A wrong type raises
+      `TypeError` from the constructor's runtime gate.
+
+    Return: (BaziConfig) The coerced, frozen config.
+    '''
+
+    if not isinstance(precision, (BaziPrecision, str)):
+      raise TypeError(f'Expected BaziPrecision or str, got {type(precision)}')
+    if not isinstance(backend, (CalendarBackend, str)):
+      raise TypeError(f'Expected CalendarBackend or str, got {type(backend)}')
+
+    _precision: BaziPrecision
+    if isinstance(precision, BaziPrecision):
+      _precision = precision
+    else:
+      assert isinstance(precision, str)
+      if precision.lower() in ['分', '分钟', 'm', 'min', 'minute']:
+        _precision = BaziPrecision.MINUTE
+      elif precision.lower() in ['时', '小时', 'h', 'hour']:
+        _precision = BaziPrecision.HOUR
+      elif precision.lower() in ['天', '日', 'd', 'day']:
+        _precision = BaziPrecision.DAY
+      else:
+        raise ValueError(f'Unsupported precision: {precision}')
+
+    _backend: CalendarBackend
+    if isinstance(backend, CalendarBackend):
+      _backend = backend
+    else:
+      assert isinstance(backend, str)
+      _backend = CalendarBackend.from_str(backend)
+
+    return cls(precision=_precision, backend=_backend, school=school)
+
+
+'''The default config: DAY precision, the celestial backend, and `DEFAULT_SCHOOL` -- the
+constructor defaults are its single definition. / 默认配置：日级精度、celestial 后端、默认流派——构造即默认，无双写。'''
+DEFAULT_CONFIG: Final[BaziConfig] = BaziConfig()

--- a/src/school.py
+++ b/src/school.py
@@ -1,5 +1,8 @@
 # Copyright (C) 2026 Ningqi Wang (0xf3cd) <https://github.com/0xf3cd>
 
+'''The home of the chart-level configuration: `BaziConfig` (every knob steering chart
+computation), the school-divergence knobs (`BaziSchool` / `DayRollover` / `KeyStem`), and `BaziPrecision`.'''
+
 from enum import Enum
 from dataclasses import dataclass
 from typing import Final
@@ -79,7 +82,7 @@ class DayRollover(Enum):
     [23:00, 24:00) already carries the next day's day pillar. This is the default, matching
     the majority school and the behaviour `test_bazi` has long pinned.
     晚子时：23:00 子时一开始即换日柱。默认，多数派口径，即现状行为。
-  - ZIZHENG (子正): the day pillar rolls at 00:00 (子正, midnight) -- the whole 子时 keeps
+  - ZIZHENG (子正): the day pillar rolls at 00:00 (midnight) -- the whole 子时 keeps
     the civil day's day pillar.
     子正：0:00 才换日柱，整个子时不提前换。
 
@@ -107,6 +110,9 @@ class KeyStem(Enum):
   - YEAR_MASTER: key on the Year Tiangan (年干).
     以年干为锚。
 
+  Note: the 查法 consumption lands in #69 PR-2 -- until then this knob feeds eq / JSON
+  only, not the computed chart. 查法消费在 #69 PR-2 落地；此前本旋钮只影响相等性 / JSON，不影响盘面。
+
   No change should be made to the existing definitions. Only add new definitions.
   '''
   DAY_MASTER  = 0
@@ -128,6 +134,9 @@ class BaziSchool:
   `DEFAULT_SCHOOL` picks them up, and `BaziConfig.school` points at that same instance --
   the defaults are written down exactly once.
   默认流派只在字段默认值处定义一次；`DEFAULT_SCHOOL` 构造即默认，`BaziConfig.school` 指向同一实例。
+
+  `hongyan_key` does not steer the chart yet -- its 查法 consumption lands in #69 PR-2;
+  until then it feeds eq / JSON only. `hongyan_key` 的查法消费在 #69 PR-2 落地，此前不进盘面。
   '''
   day_rollover: DayRollover = DayRollover.WAN_ZISHI
   hongyan_key:  KeyStem     = KeyStem.DAY_MASTER
@@ -155,16 +164,15 @@ class BaziConfig:
 
   - precision: (BaziPrecision) The precision of the birth time / 出生时间精度。
   - backend: (CalendarBackend) The calendar backend for all calendar conversions / 历法后端。
-  - school: (BaziSchool) The school profile (流派档案); defaults to `DEFAULT_SCHOOL`.
+  - school: (BaziSchool) The school profile; defaults to `DEFAULT_SCHOOL`. / 流派档案，默认 `DEFAULT_SCHOOL`。
 
   Gender is deliberately NOT here: it does not affect the four pillars' computation
   channel this config aggregates, and stays a `Bazi.create` argument (its string coercion
   lives there too, as before).
   性别刻意不在此：它不进本配置聚合的排盘算路，仍是 `Bazi.create` 的参数（字符串解析也留在那里）。
 
-  The constructor takes the strict types only; string coercion lives in `from_values`,
-  which shares one alias table with `Bazi.create`'s historical parsing face.
-  构造只收严格枚举类型；字符串解析收在 `from_values`，与 `Bazi.create` 既有解析面同一张别名表。
+  The constructor takes the strict types only; string coercion lives in `from_values`.
+  构造只收严格枚举类型；字符串解析收在 `from_values`。
   '''
   precision: BaziPrecision    = BaziPrecision.DAY
   backend:   CalendarBackend  = CalendarBackend.CELESTIAL
@@ -232,5 +240,8 @@ class BaziConfig:
 
 
 '''The default config: DAY precision, the celestial backend, and `DEFAULT_SCHOOL` -- the
-constructor defaults are its single definition. / 默认配置：日级精度、celestial 后端、默认流派——构造即默认，无双写。'''
+constructor defaults are the canonical definition; `from_values`'s signature defaults are a
+second spelling of the same, pinned equivalent by `test_defaults_are_defined_once`.
+默认配置：日级精度、celestial 后端、默认流派——构造默认值是正典；`from_values` 的签名默认值是
+第二处拼写，由 `test_defaults_are_defined_once` 钉住等价。'''
 DEFAULT_CONFIG: Final[BaziConfig] = BaziConfig()

--- a/tests/calendar/test_backend.py
+++ b/tests/calendar/test_backend.py
@@ -12,7 +12,8 @@ from src.calendar import (
   CalendarBackend, CalendarUtilsProtocol, hko_data_utils, calendar_utils_of,
 )
 from src.calendar.celestial_utils import ALGO1, ALGO2
-from src.bazi import Bazi, BaziGender, BaziPrecision
+from src.bazi import Bazi, BaziGender
+from src.school import BaziConfig
 from src.bazi_chart import BaziChart
 
 
@@ -62,49 +63,48 @@ def test_calendar_utils_of() -> None:
 
 
 def test_create_with_backend() -> None:
-  bazi_enum: Bazi = Bazi.create('1984-04-02 04:02', 'male', 'day', backend=CalendarBackend.HKO)
-  bazi_str: Bazi = Bazi.create('1984-04-02 04:02', 'male', 'day', backend='hko')
+  bazi_enum: Bazi = Bazi.create('1984-04-02 04:02', 'male', BaziConfig(backend=CalendarBackend.HKO))
+  bazi_str: Bazi = Bazi.create('1984-04-02 04:02', 'male', BaziConfig.from_values(backend='hko'))
 
   assert bazi_enum == bazi_str # enum and string spellings resolve the same way
 
   with pytest.raises(ValueError):
-    Bazi.create('1984-04-02 04:02', 'male', 'day', backend='lunar')
+    Bazi.create('1984-04-02 04:02', 'male', BaziConfig.from_values(backend='lunar'))
 
   with pytest.raises(TypeError):
-    Bazi.create('1984-04-02 04:02', 'male', 'day', backend=42) # type: ignore[arg-type]
+    Bazi.create('1984-04-02 04:02', 'male', BaziConfig.from_values(backend=42)) # type: ignore[arg-type]
 
 
 def test_consistent_with_hko_utils() -> None:
   # The backend-resolved utils should produce results identical to direct HKO calls.
-  bazi: Bazi = Bazi(datetime(2000, 2, 4, 20, 35), BaziGender.FEMALE, BaziPrecision.DAY,
-                    backend=CalendarBackend.HKO)
+  bazi: Bazi = Bazi(datetime(2000, 2, 4, 20, 35), BaziGender.FEMALE,
+                    BaziConfig(backend=CalendarBackend.HKO))
   assert bazi.solar_date == hko_data_utils.to_date(datetime(2000, 2, 4))
   assert bazi.ganzhi_date == hko_data_utils.to_ganzhi(bazi.solar_date)
 
 
-def test_init_rejects_str_backend() -> None:
-  # `__init__` only takes the enum; strings go through `Bazi.create` (same
-  # contract split as `gender` / `precision`).
+def test_init_rejects_str_config() -> None:
+  # `__init__` only takes `BaziConfig`; strings go through `BaziConfig.from_values`
+  # (same contract split as `gender`, whose strings go through `Bazi.create`).
   with pytest.raises(TypeError):
-    Bazi(datetime(1984, 4, 2, 4, 2), BaziGender.MALE, BaziPrecision.DAY,
-         backend='hko') # type: ignore[arg-type]
+    Bazi(datetime(1984, 4, 2, 4, 2), BaziGender.MALE, 'hko') # type: ignore[arg-type]
 
 
 def test_default_backend_is_celestial() -> None:
   '''
-  #93 flipped the default from HKO to CELESTIAL.  The switch is two quiet keyword
-  defaults, so pin every construction path that can pick it up implicitly.
+  #93 flipped the default from HKO to CELESTIAL.  The default now lives in
+  `DEFAULT_CONFIG`, so pin every construction path that can pick it up implicitly.
   '''
-  assert Bazi(datetime(2000, 2, 4, 22, 1), BaziGender.MALE, BaziPrecision.DAY).backend is CalendarBackend.CELESTIAL
-  assert Bazi.create('2000-02-04 22:01', 'male', 'day').backend is CalendarBackend.CELESTIAL
-  assert Bazi.random().backend is CalendarBackend.CELESTIAL
+  assert Bazi(datetime(2000, 2, 4, 22, 1), BaziGender.MALE).config.backend is CalendarBackend.CELESTIAL
+  assert Bazi.create('2000-02-04 22:01', 'male').config.backend is CalendarBackend.CELESTIAL
+  assert Bazi.random().config.backend is CalendarBackend.CELESTIAL
 
 
 def test_json_contains_backend() -> None:
-  chart: BaziChart = BaziChart(Bazi(datetime(1984, 4, 2, 4, 2), BaziGender.MALE, BaziPrecision.DAY))
+  chart: BaziChart = BaziChart(Bazi(datetime(1984, 4, 2, 4, 2), BaziGender.MALE))
   assert chart.json['backend'] == 'celestial' # the default
-  hko_chart: BaziChart = BaziChart(Bazi(datetime(1984, 4, 2, 4, 2), BaziGender.MALE, BaziPrecision.DAY,
-                                        backend=CalendarBackend.HKO))
+  hko_chart: BaziChart = BaziChart(Bazi(datetime(1984, 4, 2, 4, 2), BaziGender.MALE,
+                                        BaziConfig(backend=CalendarBackend.HKO)))
   assert hko_chart.json['backend'] == 'hko'
 
 
@@ -118,9 +118,9 @@ def test_celestial_backend_end_to_end() -> None:
   '''
   for spelling, backend in (('celestial', CalendarBackend.CELESTIAL),
                             ('celestial-algo2', CalendarBackend.CELESTIAL_ALGO2)):
-    bazi: Bazi = Bazi.create('1984-04-02 04:02', 'male', 'day', backend=spelling)
-    assert bazi.backend is backend
-    assert bazi == Bazi.create('1984-04-02 04:02', 'male', 'day', backend=backend)
+    bazi: Bazi = Bazi.create('1984-04-02 04:02', 'male', BaziConfig.from_values(backend=spelling))
+    assert bazi.config.backend is backend
+    assert bazi == Bazi.create('1984-04-02 04:02', 'male', BaziConfig(backend=backend))
     # The bare-`datetime` call shape, which is what `Bazi.__init__` actually uses.
     assert bazi.solar_date == calendar_utils_of(backend).to_date(datetime(1984, 4, 2))
     assert BaziChart(bazi).json['backend'] == spelling
@@ -134,8 +134,8 @@ def test_celestial_differs_from_hko_exactly_where_the_whitelist_says() -> None:
   layer-c derivation predicts from that whitelist row -- so this pins the propagation
   end to end, not just inside the calendar layer.
   '''
-  hko: Bazi = Bazi.create('1917-12-07 12:00', 'male', 'day', backend='hko')
-  cel: Bazi = Bazi.create('1917-12-07 12:00', 'male', 'day', backend='celestial')
+  hko: Bazi = Bazi.create('1917-12-07 12:00', 'male', BaziConfig.from_values(backend='hko'))
+  cel: Bazi = Bazi.create('1917-12-07 12:00', 'male', BaziConfig.from_values(backend='celestial'))
 
   assert str(hko.month_pillar) == '壬子'
   assert str(cel.month_pillar) == '辛亥'
@@ -154,17 +154,16 @@ def test_deepcopy() -> None:
   forbidden: tuple[object, ...] = tuple(calendar_utils_of(b) for b in CalendarBackend)
 
   for backend in CalendarBackend:
-    bazi: Bazi = Bazi(datetime(1984, 4, 2, 4, 2), BaziGender.MALE, BaziPrecision.DAY,
-                      backend=backend)
+    bazi: Bazi = Bazi(datetime(1984, 4, 2, 4, 2), BaziGender.MALE, BaziConfig(backend=backend))
     chart: BaziChart = BaziChart(bazi) # `BaziChart` deepcopies the bazi internally.
 
     # Trigger the utils-resolving paths before copying.
     _ = bazi.solar_date, bazi.ganzhi_date
     _ = chart.dayun_start_moment
 
-    # Only the `CalendarBackend` enum may be stored on the instances (deepcopy-safe).
-    # `_utils` must stay a plain property: no resolved utils object may ever land in
-    # the instance dicts.
+    # Only the config (frozen, holding the `CalendarBackend` enum) may be stored on the
+    # instances (deepcopy-safe). `_utils` must stay a plain property: no resolved utils
+    # object may ever land in the instance dicts.
     for obj in (bazi, chart):
       for value in vars(obj).values():
         assert not isinstance(value, types.ModuleType)
@@ -173,10 +172,10 @@ def test_deepcopy() -> None:
 
     bazi2: Bazi = copy.deepcopy(bazi)
     assert bazi == bazi2
-    assert bazi2.backend is backend
+    assert bazi2.config.backend is backend
     # The copy still resolves the calendar utils on demand.
     assert bazi2.ganzhi_date == bazi.ganzhi_date
 
     chart2: BaziChart = copy.deepcopy(chart)
-    assert chart2.bazi.backend is backend
+    assert chart2.bazi.config.backend is backend
     assert chart2.dayun_start_moment == chart.dayun_start_moment

--- a/tests/integration/test_ganzhi_relations.py
+++ b/tests/integration/test_ganzhi_relations.py
@@ -5,7 +5,7 @@ import pytest
 
 from datetime import datetime
 
-from src.bazi import Bazi, BaziGender, BaziPrecision
+from src.bazi import Bazi, BaziGender
 from src.bazi_chart import BaziChart
 from src.transits import TransitMoment, TransitOptions, TransitDatabase
 from src.defines import Tiangan, Dizhi, Ganzhi, TianganRelation, DizhiRelation
@@ -53,7 +53,6 @@ def test_case1() -> None:
   bazi: Bazi = Bazi(
     birth_time=datetime(1984, 4, 1, 11, 8),
     gender=BaziGender.MALE,
-    precision=BaziPrecision.DAY,
   )
   chart: BaziChart = BaziChart(bazi)
   db: TransitDatabase = TransitDatabase(chart)
@@ -138,7 +137,6 @@ def test_case2() -> None:
   bazi: Bazi = Bazi(
     birth_time=datetime(2024, 5, 19, 18, 59),
     gender=BaziGender.FEMALE,
-    precision=BaziPrecision.DAY,
   )
   chart: BaziChart = BaziChart(bazi)
   db: TransitDatabase = TransitDatabase(chart)

--- a/tests/integration/test_relationship_analysis.py
+++ b/tests/integration/test_relationship_analysis.py
@@ -10,7 +10,7 @@ from typing import cast
 
 from src.defines import Tiangan, Dizhi, Ganzhi, TianganRelation, DizhiRelation, Shishen
 from src.utils import tiangan_utils, dizhi_utils, bazi_utils, shensha_utils
-from src.bazi import Bazi, BaziGender, BaziPrecision
+from src.bazi import Bazi, BaziGender
 from src.bazi_chart import BaziChart
 from src.transits import TransitMoment, TransitOptions, TransitDatabase
 from src.analyzer.relationship import RelationshipAnalyzer, ShenshaAnalysis, TransitAnalysis, AtBirthAnalysis
@@ -57,7 +57,6 @@ def test_case1() -> None:
   bazi: Bazi = Bazi(
     birth_time=datetime(1984, 4, 1, 11, 8),
     gender=BaziGender.MALE,
-    precision=BaziPrecision.DAY,
   )
   chart: BaziChart = BaziChart(bazi)
   db: TransitDatabase = TransitDatabase(chart)
@@ -242,7 +241,6 @@ def test_case2() -> None:
   bazi: Bazi = Bazi(
     birth_time=datetime(2020, 7, 2, 19, 8),
     gender=BaziGender.FEMALE,
-    precision=BaziPrecision.DAY,
   )
   chart: BaziChart = BaziChart(bazi)
   birth_gz_year: int = bazi.ganzhi_date.year

--- a/tests/o_smoke.py
+++ b/tests/o_smoke.py
@@ -40,11 +40,11 @@ def main() -> int:
 
   checks: list[tuple[str, type[Exception], Callable[[], object]]] = [
     ('Bazi.create below window (1901-01-01)', ValueError,
-     lambda: Bazi.create(datetime(1901, 1, 1, 12), 'male', 'day')),
+     lambda: Bazi.create(datetime(1901, 1, 1, 12), 'male')),
     ('Bazi.create above window (2100-06-01)', ValueError,
-     lambda: Bazi.create(datetime(2100, 6, 1, 12), 'male', 'day')),
+     lambda: Bazi.create(datetime(2100, 6, 1, 12), 'male')),
     ('Bazi.create tz-aware birth time', ValueError,
-     lambda: Bazi.create(datetime(2000, 1, 1, 7, tzinfo=ZoneInfo('Asia/Shanghai')), 'male', 'day')),
+     lambda: Bazi.create(datetime(2000, 1, 1, 7, tzinfo=ZoneInfo('Asia/Shanghai')), 'male')),
     ('tiangan_utils.he on raw strings', TypeError,
      lambda: tiangan_utils.he('甲', '己')), # type: ignore
     ('DecodedLunarYears.get out of range', ValueError,
@@ -54,7 +54,7 @@ def main() -> int:
     ('TransitMoment mutually exclusive fields', ValueError,
      lambda: TransitMoment(2024, Dizhi.子, date(2024, 6, 1))),
     ('dayun past supported window', ValueError,
-     lambda: next(BaziChart(Bazi.create(datetime(2091, 6, 1, 12), 'male', 'day')).dayun)),
+     lambda: next(BaziChart(Bazi.create(datetime(2091, 6, 1, 12), 'male')).dayun)),
     ('hko get_min_supported_date garbage date_type', ValueError,
      lambda: hko_data_utils.get_min_supported_date(42)),
     ('celestial get_max_supported_date garbage date_type', ValueError,

--- a/tests/test_bazi.py
+++ b/tests/test_bazi.py
@@ -14,7 +14,7 @@ from typing import Final
 from src.calendar import JieqiTime
 from src.defines import Tiangan, Dizhi, Ganzhi, Jieqi
 from src.bazi import BaziGender, BaziPrecision, Bazi, 八字
-from src.school import BaziConfig
+from src.school import DayRollover, BaziSchool, BaziConfig
 from src.calendar import CalendarBackend, calendar_utils_of
 
 
@@ -112,6 +112,50 @@ def test_the_23_oclock_rollover_moves_only_the_day_pillar(moment: str, year: str
   assert str(bazi.year_pillar) == year
   assert str(bazi.month_pillar) == month
   assert str(bazi.day_pillar) == day
+
+
+# 换日点 variants (issue #69): `DayRollover` mounted on `BaziSchool.day_rollover`.
+@pytest.mark.parametrize('rollover, day_pillar, hour_pillar', [
+  (DayRollover.WAN_ZISHI, '己未', '甲子'), # 晚子时 (the default): rolled at 23:00; 己日 -> 甲子时.
+  (DayRollover.ZIZHENG,   '戊午', '壬子'), # 子正: the civil day's pillar; 戊日 -> 壬子时.
+])
+def test_day_rollover_variant_at_23_oclock(rollover: DayRollover, day_pillar: str, hour_pillar: str) -> None:
+  '''
+  A 23:30 birth at DAY precision: WAN_ZISHI (晚子时, the default) moves the day pillar to
+  the next day, ZIZHENG (子正) keeps the civil day's. The hour dizhi is 子 either way, but
+  the hour tiangan follows the day tiangan via 五鼠遁 (己日 -> 甲子, 戊日 -> 壬子), so the
+  full hour pillar splits with the variant too. The year and month pillars do NOT follow
+  this knob -- they are `BaziPrecision`'s attribution (see `DayRollover`'s docstring).
+  '''
+  config: BaziConfig = BaziConfig(school=BaziSchool(day_rollover=rollover))
+  bazi: Bazi = Bazi.create('2000-01-01 23:30', 'male', config)
+  assert str(bazi.year_pillar) == '己卯'
+  assert str(bazi.month_pillar) == '丙子'
+  assert str(bazi.day_pillar) == day_pillar
+  assert str(bazi.hour_pillar) == hour_pillar
+
+  # The default school is WAN_ZISHI -- the long-pinned behavior carries over unchanged.
+  if rollover is DayRollover.WAN_ZISHI:
+    assert Bazi.create('2000-01-01 23:30', 'male').day_pillar == bazi.day_pillar
+
+
+# Brief-v2 P2-5 golden: 换日点 variant inside a jieqi tie window (cross-midnight 子时).
+@pytest.mark.parametrize('rollover, pillars', [
+  (DayRollover.WAN_ZISHI, ('己丑', '丙寅', '庚辰', '丙子')), # 晚子时: day rolled; 庚日 -> 丙子时.
+  (DayRollover.ZIZHENG,   ('己丑', '丙寅', '己卯', '甲子')), # 子正: civil day kept; 己日 -> 甲子时.
+])
+def test_day_rollover_variant_inside_a_jieqi_tie_window(rollover: DayRollover, pillars: tuple[str, str, str, str]) -> None:
+  '''
+  立春 2009 = 02-04 00:49:48, inside the 子时 that began at 02-03 23:00, so a HOUR birth at
+  2009-02-03 23:30 ties and the year/month pillars already read the new side -- under BOTH
+  variants. 换日点 only splits the day pillar (and with it the hour tiangan via 五鼠遁);
+  it never moves the year/month attribution, which is `BaziPrecision`'s own rule. This pins
+  that 子正 does NOT mean "the whole 子时 keeps the old year and month too".
+  '''
+  config: BaziConfig = BaziConfig(precision=BaziPrecision.HOUR, school=BaziSchool(day_rollover=rollover))
+  bazi: Bazi = Bazi.create('2009-02-03 23:30', 'male', config)
+  assert (str(bazi.year_pillar), str(bazi.month_pillar),
+          str(bazi.day_pillar), str(bazi.hour_pillar)) == pillars
 
 
 # HOUR / MINUTE precisions (issue #6): `birth >= jieqi` compared at the known granularity,

--- a/tests/test_bazi.py
+++ b/tests/test_bazi.py
@@ -13,8 +13,8 @@ from typing import Final
 
 from src.calendar import JieqiTime
 from src.defines import Tiangan, Dizhi, Ganzhi, Jieqi
-from src.bazi import BaziGender, BaziPrecision, Bazi, 八字
-from src.school import DayRollover, BaziSchool, BaziConfig
+from src.bazi import BaziGender, Bazi, 八字
+from src.school import BaziPrecision, DayRollover, BaziSchool, BaziConfig
 from src.calendar import CalendarBackend, calendar_utils_of
 
 
@@ -37,14 +37,6 @@ def test_str() -> None:
   assert str(BaziGender.YIN) == 'female'
   assert BaziGender.YANG is BaziGender('男')
   assert BaziGender.YIN is BaziGender('女')
-
-
-def test_bazi_precision_basic() -> None:
-  assert len(BaziPrecision) == 3
-
-  assert str(BaziPrecision.DAY) == 'day'
-  assert str(BaziPrecision.HOUR) == 'hour'
-  assert str(BaziPrecision.MINUTE) == 'minute'
 
 
 @pytest.mark.parametrize('backend', ('hko', 'celestial'))
@@ -139,7 +131,8 @@ def test_day_rollover_variant_at_23_oclock(rollover: DayRollover, day_pillar: st
     assert Bazi.create('2000-01-01 23:30', 'male').day_pillar == bazi.day_pillar
 
 
-# Brief-v2 P2-5 golden: 换日点 variant inside a jieqi tie window (cross-midnight 子时).
+# Golden pair pinned for issue #69: the 换日点 variant inside a jieqi tie window
+# (cross-midnight 子时).
 @pytest.mark.parametrize('rollover, pillars', [
   (DayRollover.WAN_ZISHI, ('己丑', '丙寅', '庚辰', '丙子')), # 晚子时: day rolled; 庚日 -> 丙子时.
   (DayRollover.ZIZHENG,   ('己丑', '丙寅', '己卯', '甲子')), # 子正: civil day kept; 己日 -> 甲子时.

--- a/tests/test_bazi.py
+++ b/tests/test_bazi.py
@@ -14,6 +14,7 @@ from typing import Final
 from src.calendar import JieqiTime
 from src.defines import Tiangan, Dizhi, Ganzhi, Jieqi
 from src.bazi import BaziGender, BaziPrecision, Bazi, 八字
+from src.school import BaziConfig
 from src.calendar import CalendarBackend, calendar_utils_of
 
 
@@ -66,7 +67,7 @@ def test_day_precision_compares_dates_not_moments(backend: str, moment: str, yea
   stayed open long enough to become issue #72. Changing the rule should mean deleting this
   test on purpose.
   '''
-  bazi: Bazi = Bazi.create(moment, 'male', 'day', backend=backend)
+  bazi: Bazi = Bazi.create(moment, 'male', BaziConfig.from_values(backend=backend))
   assert str(bazi.year_pillar) == year_pillar
   assert bazi.month_commander == month_dizhi
 
@@ -81,7 +82,7 @@ def test_day_precision_bracketing_jies_stay_moment_level() -> None:
   `Bazi.bracketing_jies`' docstring points at.
   '''
   # 立春 2000 = 02-04 20:40:23; midnight precedes the true moment by 20h40m...
-  bazi: Bazi = Bazi.create('2000-02-04 00:00', 'male', 'day')
+  bazi: Bazi = Bazi.create('2000-02-04 00:00', 'male')
   # ...yet the pillars already read the new year and month (day-level attribution).
   assert str(bazi.year_pillar) == '庚辰'
   assert str(bazi.month_pillar) == '戊寅'
@@ -107,7 +108,7 @@ def test_the_23_oclock_rollover_moves_only_the_day_pillar(moment: str, year: str
   which answer is today's default, so that making it configurable is a deliberate carry-over
   rather than whatever the code happened to do.
   '''
-  bazi: Bazi = Bazi.create(moment, 'male', 'day')
+  bazi: Bazi = Bazi.create(moment, 'male')
   assert str(bazi.year_pillar) == year
   assert str(bazi.month_pillar) == month
   assert str(bazi.day_pillar) == day
@@ -174,7 +175,7 @@ def test_goldens_from_the_docstring(moment: str, precision: str, year_pillar: st
     attributes a 02-03 23:30 birth to the new year on a day DAY assigns to the old side.
     The granularities are three readings of one rule, not nested refinements.
   '''
-  bazi: Bazi = Bazi.create(moment, 'male', precision)
+  bazi: Bazi = Bazi.create(moment, 'male', BaziConfig.from_values(precision=precision))
   assert str(bazi.year_pillar) == year_pillar
   assert bazi.month_commander == month_dizhi
 
@@ -183,9 +184,9 @@ def test_day_and_hour_pillars_ignore_precision() -> None:
   '''Precision only moves the year/month attribution; the day/hour pillars must not move.'''
   moments: list[str] = ['2009-02-03 23:30', '2017-02-03 23:10', '2000-02-04 20:39', '1984-02-04 12:30']
   for moment in moments:
-    day_bazi: Bazi = Bazi.create(moment, 'female', 'day')
+    day_bazi: Bazi = Bazi.create(moment, 'female')
     for precision in ('hour', 'minute'):
-      bazi: Bazi = Bazi.create(moment, 'female', precision)
+      bazi: Bazi = Bazi.create(moment, 'female', BaziConfig.from_values(precision=precision))
       assert bazi.day_pillar == day_bazi.day_pillar
       assert bazi.hour_pillar == day_bazi.hour_pillar
 
@@ -194,13 +195,13 @@ def test_hko_backend_rejected() -> None:
   '''HOUR / MINUTE need real jieqi moments; the HKO backend's are midnight placeholders.'''
   for precision in (BaziPrecision.HOUR, BaziPrecision.MINUTE):
     with pytest.raises(ValueError):
-      Bazi(datetime(2000, 2, 4, 19, 30), BaziGender.MALE, precision, CalendarBackend.HKO)
-  assert str(Bazi.create('2000-02-04 19:30', 'male', 'day', backend='hko').year_pillar) == '庚辰'
+      Bazi(datetime(2000, 2, 4, 19, 30), BaziGender.MALE, BaziConfig(precision=precision, backend=CalendarBackend.HKO))
+  assert str(Bazi.create('2000-02-04 19:30', 'male', BaziConfig.from_values(backend='hko')).year_pillar) == '庚辰'
 
 
 def test_ganzhi_year_and_bracketing_jies_are_the_attribution() -> None:
   '''`ganzhi_year` / `bracketing_jies` expose exactly what the pillars were derived from.'''
-  bazi: Bazi = Bazi.create('2009-02-04 00:30', 'male', 'hour')
+  bazi: Bazi = Bazi.create('2009-02-04 00:30', 'male', BaziConfig.from_values(precision='hour'))
   assert bazi.ganzhi_year == 2009
   owning, following = bazi.bracketing_jies
   assert owning == JieqiTime(Jieqi.立春, datetime(2009, 2, 4, 0, 49, 48))
@@ -211,7 +212,7 @@ def test_ganzhi_year_and_bracketing_jies_are_the_attribution() -> None:
   # (DAY gives the whole day to the new side), but for the cross-midnight tie birth on the
   # PREVIOUS day they legitimately disagree.
   assert bazi.ganzhi_date.year == 2009
-  advance: Bazi = Bazi.create('2009-02-03 23:30', 'male', 'hour')
+  advance: Bazi = Bazi.create('2009-02-03 23:30', 'male', BaziConfig.from_values(precision='hour'))
   assert advance.ganzhi_year == 2009
   assert advance.ganzhi_date.year == 2008
 
@@ -252,7 +253,7 @@ def test_attribution_matches_scan_oracle() -> None:
   divergent: int = 0
   for _ in range(total):
     birth: datetime = __random_moment()
-    day_bazi: Bazi = Bazi(birth, BaziGender.女, BaziPrecision.DAY)
+    day_bazi: Bazi = Bazi(birth, BaziGender.女)
 
     candidates: list[JieqiTime] = sorted(
       (JieqiTime(jie, utils.jieqi_moment(year, jie))
@@ -261,7 +262,7 @@ def test_attribution_matches_scan_oracle() -> None:
     )
 
     for precision in (BaziPrecision.HOUR, BaziPrecision.MINUTE):
-      bazi: Bazi = Bazi(birth, BaziGender.女, precision)
+      bazi: Bazi = Bazi(birth, BaziGender.女, BaziConfig(precision=precision))
 
       trunc_birth: datetime = _truncated(birth, precision)
       lichun: datetime = utils.jieqi_moment(birth.year, Jieqi.立春)
@@ -310,7 +311,7 @@ def test_minute_vs_moment_level_prev_jie() -> None:
     jie_moment: datetime = utils.jieqi_moment(rng.randint(1902, 2080), rng.choice(all_jies))
     birth: datetime = (jie_moment + timedelta(seconds=rng.randint(-90, 90))).replace(second=0, microsecond=0)
 
-    bazi: Bazi = Bazi(birth, BaziGender.男, BaziPrecision.MINUTE)
+    bazi: Bazi = Bazi(birth, BaziGender.男, BaziConfig(precision=BaziPrecision.MINUTE))
     moment_owning: JieqiTime = utils.prev_jie(birth)
     attribution_owning: JieqiTime = bazi.bracketing_jies[0]
 
@@ -339,14 +340,13 @@ def test_init() -> None:
     bazi: Bazi = Bazi(
       birth_time=random_dt,
       gender=BaziGender.男,
-      precision=BaziPrecision.DAY,
     )
 
     assert bazi.solar_date == date(random_dt.year, random_dt.month, random_dt.day)
     assert bazi.hour == random_dt.hour
     assert bazi.minute == random_dt.minute
     assert bazi.gender == BaziGender.男
-    assert bazi.precision == BaziPrecision.DAY
+    assert bazi.config.precision == BaziPrecision.DAY
 
 
 def test_chinese() -> None:
@@ -365,14 +365,13 @@ def test_chinese() -> None:
     bazi: 八字 = 八字(
       birth_time=random_dt,
       gender=BaziGender.男,
-      precision=BaziPrecision.DAY,
     )
 
     assert bazi.solar_date == date(random_dt.year, random_dt.month, random_dt.day)
     assert bazi.hour == random_dt.hour
     assert bazi.minute == random_dt.minute
     assert bazi.gender == BaziGender.男
-    assert bazi.precision == BaziPrecision.DAY
+    assert bazi.config.precision == BaziPrecision.DAY
 
 
 def test_invalid_arguments() -> None:
@@ -386,17 +385,17 @@ def test_invalid_arguments() -> None:
   )
 
   with pytest.raises(TypeError):
-    Bazi(birth_time=random_dt, gender=BaziGender.男) # type: ignore # Missing `precision`
+    Bazi(birth_time=random_dt, gender=BaziGender.男, config='day') # type: ignore # `__init__` only takes `BaziConfig`, not str.
   with pytest.raises(TypeError):
-    Bazi(birth_time=random_dt, precision=BaziPrecision.DAY) # type: ignore # Missing `gender`
+    Bazi(birth_time=random_dt) # type: ignore # Missing `gender`
   with pytest.raises(TypeError):
-    Bazi(birth_time='2024-03-03', gender=BaziGender.男, precision=BaziPrecision.DAY) # type: ignore # Currently doesn't take string as input
+    Bazi(birth_time='2024-03-03', gender=BaziGender.男) # type: ignore # Currently doesn't take string as input
   with pytest.raises(TypeError):
-    Bazi(birth_time=date(9999, 1, 1), gender=BaziGender.男, precision=BaziPrecision.DAY) # type: ignore
+    Bazi(birth_time=date(9999, 1, 1), gender=BaziGender.男) # type: ignore
   with pytest.raises(TypeError):
-    Bazi(birth_time=random_dt, gender='男', precision=BaziPrecision.DAY) # type: ignore # `__init__` only takes the enum.
+    Bazi(birth_time=random_dt, gender='男') # type: ignore # `__init__` only takes the enum.
   with pytest.raises(TypeError):
-    Bazi(birth_time=random_dt, gender=BaziGender.男, precision='day') # type: ignore # `__init__` only takes the enum.
+    Bazi(birth_time=random_dt, gender=BaziGender.男, config=BaziPrecision.DAY) # type: ignore # `__init__` only takes `BaziConfig`.
   with pytest.raises(ValueError):
     dt: datetime = datetime(
       year=9999, # Out of supported range.
@@ -406,7 +405,7 @@ def test_invalid_arguments() -> None:
       minute=random.randint(0, 59),
       second=random.randint(0, 59)
     )
-    Bazi(birth_time=dt, gender=BaziGender.男, precision=BaziPrecision.DAY)
+    Bazi(birth_time=dt, gender=BaziGender.男)
   with pytest.raises(ValueError):
     Bazi(
       birth_time=datetime(
@@ -419,7 +418,6 @@ def test_invalid_arguments() -> None:
         tzinfo=ZoneInfo('Asia/Shanghai') # Doesn't support timezone.
       ),
       gender=BaziGender.男,
-      precision=BaziPrecision.DAY,
     )
 
 
@@ -427,7 +425,6 @@ def _create_bazi(dt: datetime) -> Bazi:
   return Bazi(
     birth_time=dt,
     gender=BaziGender.男,
-    precision=BaziPrecision.DAY,
   )
 
 
@@ -492,11 +489,11 @@ def test_ganzhi_date() -> None:
   # the 1917/1927 jieqi-shift windows (pinned by the parity whitelist), so an oracle bound
   # to the wrong backend false-reds there -- the #114 CI failure was exactly that.
   bazi: Bazi = _create_bazi(datetime(1984, 4, 2, 4, 2))
-  assert bazi.ganzhi_date == calendar_utils_of(bazi.backend).to_ganzhi(date(1984, 4, 2))
+  assert bazi.ganzhi_date == calendar_utils_of(bazi.config.backend).to_ganzhi(date(1984, 4, 2))
 
   for _ in range(10):
     bazi = Bazi.random()
-    assert bazi.ganzhi_date == calendar_utils_of(bazi.backend).to_ganzhi(bazi.solar_date)
+    assert bazi.ganzhi_date == calendar_utils_of(bazi.config.backend).to_ganzhi(bazi.solar_date)
 
 
 def test_date_time() -> None:
@@ -560,7 +557,6 @@ def test_deepcopy() -> None:
   bazi: Bazi = Bazi(
     birth_time=datetime(1984, 4, 2, 4, 2),
     gender=BaziGender.男,
-    precision=BaziPrecision.DAY,
   )
   bazi2: Bazi = copy.deepcopy(bazi)
 
@@ -578,26 +574,28 @@ def test_deepcopy() -> None:
 
 def test_create() -> None:
   with pytest.raises(ValueError):
-    Bazi.create('WrongDatetimeFormat', BaziGender.FEMALE, BaziPrecision.DAY)
+    Bazi.create('WrongDatetimeFormat', BaziGender.FEMALE)
   with pytest.raises(ValueError):
-    Bazi.create(datetime.now(), 'femal', BaziPrecision.DAY)
+    Bazi.create(datetime.now(), 'femal')
   with pytest.raises(ValueError):
-    Bazi.create(datetime.now(), BaziGender.FEMALE, 'dya')
+    Bazi.create(datetime.now(), BaziGender.FEMALE, BaziConfig.from_values(precision='dya'))
 
   with pytest.raises(TypeError):
-    Bazi.create(19840402, BaziGender.FEMALE, BaziPrecision.DAY) # type: ignore
+    Bazi.create(19840402, BaziGender.FEMALE) # type: ignore
   with pytest.raises(TypeError):
-    Bazi.create(datetime.now(), 1984, BaziPrecision.DAY) # type: ignore
+    Bazi.create(datetime.now(), 1984) # type: ignore
   with pytest.raises(TypeError):
-    Bazi.create(datetime.now(), BaziGender.FEMALE, 1984) # type: ignore
+    Bazi.create(datetime.now(), BaziGender.FEMALE, BaziConfig.from_values(precision=1984)) # type: ignore
+  with pytest.raises(TypeError):
+    Bazi.create(datetime.now(), BaziGender.FEMALE, 'day') # type: ignore # `create` takes `BaziConfig`, not str.
 
   # Create a datetime and set its timezone to Asia/Shanghai.
   _dt: datetime = datetime.now()
   _dt = _dt.replace(tzinfo=ZoneInfo('Asia/Shanghai'))
   with pytest.raises(ValueError):
-    Bazi.create(_dt, BaziGender.FEMALE, BaziPrecision.DAY)
+    Bazi.create(_dt, BaziGender.FEMALE)
   with pytest.raises(ValueError):
-    Bazi.create(_dt.isoformat(), BaziGender.FEMALE, BaziPrecision.DAY)
+    Bazi.create(_dt.isoformat(), BaziGender.FEMALE)
 
   now: datetime = datetime.now()
   dt_options: list[str | datetime] = [now, now.isoformat()]
@@ -605,32 +603,32 @@ def test_create() -> None:
   female_options: list[str | BaziGender] = [BaziGender.YIN, BaziGender.FEMALE, '女', 'FEMALE', 'female']
   day_precision_options: list[str | BaziPrecision] = [BaziPrecision.DAY, 'day', 'DAY', 'Day', '日', '天', 'd', 'D']
 
-  expected_bazi: Bazi = Bazi.create(now, BaziGender.FEMALE, BaziPrecision.DAY)
+  expected_bazi: Bazi = Bazi.create(now, BaziGender.FEMALE)
   for dt, g, p in product(dt_options, female_options, day_precision_options):
-    bazi = Bazi.create(dt, g, p)
+    bazi = Bazi.create(dt, g, BaziConfig.from_values(precision=p))
     assert list(bazi.pillars) == list(expected_bazi.pillars)
     assert bazi.gender == expected_bazi.gender
-    assert bazi.precision == expected_bazi.precision
+    assert bazi.config.precision == expected_bazi.config.precision
     assert bazi.solar_date == expected_bazi.solar_date
     assert bazi.hour == expected_bazi.hour
     assert bazi.minute == expected_bazi.minute
 
-  expected_bazi = Bazi.create(now, BaziGender.MALE, BaziPrecision.DAY)
+  expected_bazi = Bazi.create(now, BaziGender.MALE)
   for dt, g, p in product(dt_options, male_options, day_precision_options):
-    bazi = Bazi.create(dt, g, p)
+    bazi = Bazi.create(dt, g, BaziConfig.from_values(precision=p))
     assert list(bazi.pillars) == list(expected_bazi.pillars)
     assert bazi.gender == expected_bazi.gender
-    assert bazi.precision == expected_bazi.precision
+    assert bazi.config.precision == expected_bazi.config.precision
     assert bazi.solar_date == expected_bazi.solar_date
     assert bazi.hour == expected_bazi.hour
     assert bazi.minute == expected_bazi.minute
 
   finer_precision_options: list = [BaziPrecision.HOUR, BaziPrecision.MINUTE, 'hour', 'minute', 'H', 'm', '时', '小时', '分', '分钟']
   for dt, g, p in product(dt_options, male_options + female_options, finer_precision_options):
-    bazi = Bazi.create(dt, g, p) # Supported since issue #6 -- on the celestial backend only.
-    assert bazi.precision in (BaziPrecision.HOUR, BaziPrecision.MINUTE)
+    bazi = Bazi.create(dt, g, BaziConfig.from_values(precision=p)) # Supported since issue #6 -- on the celestial backend only.
+    assert bazi.config.precision in (BaziPrecision.HOUR, BaziPrecision.MINUTE)
     with pytest.raises(ValueError):
-      Bazi.create(dt, g, p, backend='hko') # HKO has no real jieqi moments.
+      Bazi.create(dt, g, BaziConfig.from_values(precision=p, backend='hko')) # HKO has no real jieqi moments.
 
 
 def test_supported_date_window_edges() -> None:
@@ -640,15 +638,15 @@ def test_supported_date_window_edges() -> None:
   construct. The window itself is the celestial backend's, pinned in its own tests.
   '''
   with pytest.raises(ValueError):
-    Bazi.create(datetime(1901, 2, 18, 12), 'male', 'day')
+    Bazi.create(datetime(1901, 2, 18, 12), 'male')
   with pytest.raises(ValueError):
-    Bazi.create(datetime(2100, 1, 1, 12), 'male', 'day')
-  assert Bazi.create(datetime(1901, 2, 19, 12), 'male', 'day').solar_date == date(1901, 2, 19)
-  assert Bazi.create(datetime(2099, 12, 31, 12), 'male', 'day').solar_date == date(2099, 12, 31)
+    Bazi.create(datetime(2100, 1, 1, 12), 'male')
+  assert Bazi.create(datetime(1901, 2, 19, 12), 'male').solar_date == date(1901, 2, 19)
+  assert Bazi.create(datetime(2099, 12, 31, 12), 'male').solar_date == date(2099, 12, 31)
 
 
 def test_eq_ne() -> None:
-  def __random_info() -> tuple[datetime, BaziGender, BaziPrecision]:
+  def __random_info() -> tuple[datetime, BaziGender]:
     return (datetime(
       year=random.randint(1950, 2000),
       month=random.randint(1, 12),
@@ -656,7 +654,7 @@ def test_eq_ne() -> None:
       hour=random.randint(0, 23),
       minute=random.randint(0, 59),
       second=random.randint(0, 59)
-    ), random.choice(list(BaziGender)), BaziPrecision.DAY)
+    ), random.choice(list(BaziGender)))
 
   def __toggle_gender(g: BaziGender) -> BaziGender:
     return BaziGender.MALE if g is BaziGender.FEMALE else BaziGender.FEMALE
@@ -665,28 +663,28 @@ def test_eq_ne() -> None:
     return dt + timedelta(days=1)
 
   for _ in range(64):
-    dt, gender, precision = __random_info()
+    dt, gender = __random_info()
 
-    bazi: Bazi = Bazi.create(dt, gender, precision)
-    assert bazi == Bazi.create(dt, gender, precision)
-    assert bazi != Bazi.create(dt, __toggle_gender(gender), precision)
-    assert bazi != Bazi.create(__inc_datetime(dt), gender, precision)
+    bazi: Bazi = Bazi.create(dt, gender)
+    assert bazi == Bazi.create(dt, gender)
+    assert bazi != Bazi.create(dt, __toggle_gender(gender))
+    assert bazi != Bazi.create(__inc_datetime(dt), gender)
 
     assert bazi != 0
 
-    bazi_hacked: Bazi = Bazi.create(dt, gender, precision)
-    bazi_hacked._precision = BaziPrecision.HOUR # type: ignore # Intended for testing only.
+    bazi_hacked: Bazi = Bazi.create(dt, gender)
+    bazi_hacked._config = BaziConfig(precision=BaziPrecision.HOUR) # type: ignore # Intended for testing only.
     assert bazi != bazi_hacked
 
 
 def test_hash() -> None:
   dt: datetime = datetime(2000, 2, 4, 22, 1)
-  bazi: Bazi = Bazi.create(dt, BaziGender.MALE, BaziPrecision.DAY)
-  same: Bazi = Bazi.create(dt, BaziGender.MALE, BaziPrecision.DAY)
+  bazi: Bazi = Bazi.create(dt, BaziGender.MALE)
+  same: Bazi = Bazi.create(dt, BaziGender.MALE)
   assert hash(bazi) == hash(same)
   assert len({bazi, same}) == 1 # In sync with `__eq__`: usable for set dedup.
 
-  other: Bazi = Bazi.create(dt, BaziGender.FEMALE, BaziPrecision.DAY)
+  other: Bazi = Bazi.create(dt, BaziGender.FEMALE)
   assert len({bazi, same, other}) == 2
 
 
@@ -694,9 +692,9 @@ def test_sub_minute_truncation() -> None:
   # Two births in the same minute are the same Bazi -- `Bazi.solar_datetime` is the
   # SSOT on why sub-minute parts are dropped.
   dt: datetime = datetime(2000, 2, 4, 22, 1)
-  bazi: Bazi = Bazi.create(dt, BaziGender.MALE, BaziPrecision.DAY)
+  bazi: Bazi = Bazi.create(dt, BaziGender.MALE)
   sub_minute: Bazi = Bazi.create(dt.replace(second=37, microsecond=999999),
-                                 BaziGender.MALE, BaziPrecision.DAY)
+                                 BaziGender.MALE)
   assert sub_minute.solar_datetime == dt
   assert sub_minute.hour == 22
   assert sub_minute.minute == 1

--- a/tests/test_bazi_chart.py
+++ b/tests/test_bazi_chart.py
@@ -12,6 +12,7 @@ from datetime import datetime, date, timedelta
 
 from src.defines import Tiangan, Dizhi, Ganzhi, Wuxing, Yinyang, Shishen, ShierZhangsheng
 from src.bazi import BaziGender, BaziPrecision, Bazi
+from src.school import BaziConfig, BaziSchool, DayRollover, KeyStem
 from src.utils import bazi_utils
 
 from src.data_types import (
@@ -28,7 +29,6 @@ def test_basic() -> None:
   bazi: Bazi = Bazi(
     birth_time=datetime(1984, 4, 2, 4, 2),
     gender=BaziGender.男,
-    precision=BaziPrecision.DAY,
   )
   chart: BaziChart = BaziChart(bazi)
 
@@ -46,7 +46,6 @@ def test_malicious() -> None:
   bazi: Bazi = Bazi(
     birth_time=datetime(1984, 4, 2, 4, 2),
     gender=BaziGender.男,
-    precision=BaziPrecision.DAY,
   )
   chart: BaziChart = BaziChart(bazi)
 
@@ -91,7 +90,6 @@ def test_traits() -> None:
   bazi: Bazi = Bazi(
     birth_time=datetime(1984, 4, 2, 4, 2),
     gender=BaziGender.男,
-    precision=BaziPrecision.DAY,
   )
   chart: BaziChart = BaziChart(bazi)
   traits: BaziData[BaziChart.PillarTraits] = chart.traits
@@ -119,7 +117,6 @@ def test_hidden_tiangans() -> None:
   bazi: Bazi = Bazi(
     birth_time=datetime(1984, 4, 2, 4, 2),
     gender=BaziGender.男,
-    precision=BaziPrecision.DAY,
   )
   chart: BaziChart = BaziChart(bazi)
   hidden_tiangans: BaziData[HiddenTianganDict] = chart.hidden_tiangan
@@ -144,7 +141,6 @@ def test_shishens() -> None:
   chart: BaziChart = BaziChart(Bazi.create(
     birth_time=datetime(1984, 4, 2, 4, 2),
     gender=BaziGender.男,
-    precision=BaziPrecision.DAY,
   ))
   shishens: BaziData[BaziChart.PillarShishens] = chart.shishen
 
@@ -171,7 +167,6 @@ def test_nayin() -> None:
   chart: BaziChart = BaziChart(Bazi.create(
     birth_time=datetime(1984, 4, 2, 4, 2),
     gender=BaziGender.男,
-    precision=BaziPrecision.DAY,
   ))
   nayin: BaziData[str] = chart.nayin
 
@@ -191,7 +186,6 @@ def test_shier_zhangsheng() -> None:
   chart: BaziChart = BaziChart(Bazi.create(
     birth_time=datetime(1984, 4, 2, 4, 2),
     gender=BaziGender.男,
-    precision=BaziPrecision.DAY,
   ))
   zhangshengs: BaziData[ShierZhangsheng] = chart.shier_zhangsheng
 
@@ -292,19 +286,19 @@ def test_dayun_start_moment() -> None:
   # re-bake that moves a jieqi goes red here -- and trips the frozen table hash first.
   delta: timedelta = timedelta(seconds=1)
 
-  bazi1: Bazi = Bazi.create(datetime(2000, 2, 4, 22, 1), BaziGender.MALE, BaziPrecision.DAY)
+  bazi1: Bazi = Bazi.create(datetime(2000, 2, 4, 22, 1), BaziGender.MALE)
   assert BaziChart(bazi1).dayun_start_moment == pytest.approx(
     datetime(2009, 12, 26, 21, 8, 25),
     abs=delta,
   )
 
-  bazi2: Bazi = Bazi.create(datetime(1984, 4, 2, 4, 2), BaziGender.MALE, BaziPrecision.DAY)
+  bazi2: Bazi = Bazi.create(datetime(1984, 4, 2, 4, 2), BaziGender.MALE)
   assert BaziChart(bazi2).dayun_start_moment == pytest.approx(
     datetime(1985, 3, 4, 11, 17, 55),
     abs=delta,
   )
 
-  bazi3: Bazi = Bazi.create(datetime(1984, 4, 2, 4, 2), BaziGender.FEMALE, BaziPrecision.DAY)
+  bazi3: Bazi = Bazi.create(datetime(1984, 4, 2, 4, 2), BaziGender.FEMALE)
   assert BaziChart(bazi3).dayun_start_moment == pytest.approx(
     datetime(1993, 5, 24, 0, 24, 13, 333333),
     abs=delta,
@@ -322,7 +316,7 @@ def test_dayun_start_before_the_true_moment_on_a_jieqi_day() -> None:
   '''
   delta: timedelta = timedelta(seconds=1)
 
-  chart: BaziChart = BaziChart(Bazi.create(datetime(2000, 2, 4, 0, 0), BaziGender.MALE, BaziPrecision.DAY))
+  chart: BaziChart = BaziChart(Bazi.create(datetime(2000, 2, 4, 0, 0), BaziGender.MALE))
   assert chart.dayun_start_moment == pytest.approx(
     datetime(2000, 5, 18, 19, 13, 18, 333333), # Float tail written out; the 1s tolerance is re-bake headroom.
     abs=delta,
@@ -342,10 +336,10 @@ def test_dayun_start_diverges_across_backends_on_the_same_pillars() -> None:
   '''
   delta: timedelta = timedelta(seconds=1)
 
-  cel: BaziChart = BaziChart(Bazi.create(datetime(2000, 2, 4, 10, 0), BaziGender.MALE, BaziPrecision.DAY,
-                                         backend='celestial'))
-  hko: BaziChart = BaziChart(Bazi.create(datetime(2000, 2, 4, 10, 0), BaziGender.MALE, BaziPrecision.DAY,
-                                         backend='hko'))
+  cel: BaziChart = BaziChart(Bazi.create(datetime(2000, 2, 4, 10, 0), BaziGender.MALE,
+                                         BaziConfig.from_values(backend='celestial')))
+  hko: BaziChart = BaziChart(Bazi.create(datetime(2000, 2, 4, 10, 0), BaziGender.MALE,
+                                         BaziConfig.from_values(backend='hko')))
 
   # Same pillars on both backends; only the dayun start (and everything it feeds) diverges.
   assert [str(p) for p in cel.bazi.pillars] == ['庚辰', '戊寅', '壬辰', '乙巳']
@@ -364,19 +358,19 @@ def test_dayun_start_diverges_across_backends_on_the_same_pillars() -> None:
 
 
 def test_dayun_ganzhi() -> None:
-  bazi1: Bazi = Bazi.create(datetime(2000, 2, 4, 22, 1), BaziGender.MALE, BaziPrecision.DAY)
+  bazi1: Bazi = Bazi.create(datetime(2000, 2, 4, 22, 1), BaziGender.MALE)
   bazi1_dayun_gen = BaziChart(bazi1).dayun
   assert next(bazi1_dayun_gen).ganzhi == Ganzhi.from_str('己卯')
   assert next(bazi1_dayun_gen).ganzhi == Ganzhi.from_str('庚辰')
   assert next(bazi1_dayun_gen).ganzhi == Ganzhi.from_str('辛巳')
 
-  bazi2: Bazi = Bazi.create(datetime(1984, 4, 2, 4, 2), BaziGender.MALE, BaziPrecision.DAY)
+  bazi2: Bazi = Bazi.create(datetime(1984, 4, 2, 4, 2), BaziGender.MALE)
   bazi2_dayun_gen = BaziChart(bazi2).dayun
   assert next(bazi2_dayun_gen).ganzhi == Ganzhi.from_str('戊辰')
   assert next(bazi2_dayun_gen).ganzhi == Ganzhi.from_str('己巳')
   assert next(bazi2_dayun_gen).ganzhi == Ganzhi.from_str('庚午')
 
-  bazi3: Bazi = Bazi.create(datetime(1984, 4, 2, 4, 2), BaziGender.FEMALE, BaziPrecision.DAY)
+  bazi3: Bazi = Bazi.create(datetime(1984, 4, 2, 4, 2), BaziGender.FEMALE)
   bazi3_dayun_gen = BaziChart(bazi3).dayun
   assert next(bazi3_dayun_gen).ganzhi == Ganzhi.from_str('丙寅')
   assert next(bazi3_dayun_gen).ganzhi == Ganzhi.from_str('乙丑')
@@ -384,16 +378,16 @@ def test_dayun_ganzhi() -> None:
 
 
 def test_dayun_ganzhi_year() -> None:
-  bazi1: Bazi = Bazi.create(datetime(2000, 2, 4, 22, 1), BaziGender.MALE, BaziPrecision.DAY)
+  bazi1: Bazi = Bazi.create(datetime(2000, 2, 4, 22, 1), BaziGender.MALE)
   first_dayun1: DayunTuple = next(BaziChart(bazi1).dayun)
   assert first_dayun1.ganzhi_year == 2009
 
-  bazi2: Bazi = Bazi.create(datetime(1984, 4, 2, 4, 2), BaziGender.MALE, BaziPrecision.DAY)
+  bazi2: Bazi = Bazi.create(datetime(1984, 4, 2, 4, 2), BaziGender.MALE)
   first_dayun2: DayunTuple = next(BaziChart(bazi2).dayun)
   # celestial start 1985-03-04 is past 立春 1985; lunar_python / china95 / 测测 all agree.
   assert first_dayun2.ganzhi_year == 1985
 
-  bazi3: Bazi = Bazi.create(datetime(1984, 4, 2, 4, 2), BaziGender.FEMALE, BaziPrecision.DAY)
+  bazi3: Bazi = Bazi.create(datetime(1984, 4, 2, 4, 2), BaziGender.FEMALE)
   first_dayun3: DayunTuple = next(BaziChart(bazi3).dayun)
   assert first_dayun3.ganzhi_year == 1993
 
@@ -414,18 +408,18 @@ def test_xiaoyun() -> None:
       assert xiaoyuns[age-1].ganzhi == gz
 
   # Data collected from https://p.china95.net/paipan/bazi/
-  __check(Bazi.create(datetime(2017, 8, 17, 2, 23), BaziGender.MALE, BaziPrecision.DAY),
+  __check(Bazi.create(datetime(2017, 8, 17, 2, 23), BaziGender.MALE),
             '戊子 丁亥 丙戌 乙酉')
-  __check(Bazi.create(datetime(2017, 8, 17, 2, 23), BaziGender.FEMALE, BaziPrecision.DAY),
+  __check(Bazi.create(datetime(2017, 8, 17, 2, 23), BaziGender.FEMALE),
             '庚寅 辛卯 壬辰 癸巳 甲午 乙未 丙申 丁酉')
-  __check(Bazi.create(datetime(2017, 8, 16, 2, 23), BaziGender.MALE, BaziPrecision.DAY),
+  __check(Bazi.create(datetime(2017, 8, 16, 2, 23), BaziGender.MALE),
             '丙子 乙亥 甲戌 癸酉')
-  __check(Bazi.create(datetime(2017, 4, 16, 2, 23), BaziGender.FEMALE, BaziPrecision.DAY),
+  __check(Bazi.create(datetime(2017, 4, 16, 2, 23), BaziGender.FEMALE),
             '甲寅 乙卯 丙辰 丁巳 戊午 己未 庚申')
 
   # Directed: celestial moves this man's dayun start past 立春 1985, so xiaoyun gains a year
   # (HKO gives '辛卯' alone); china95 lists exactly '辛卯 壬辰' for the same birth.
-  __check(Bazi.create(datetime(1984, 4, 2, 4, 2), BaziGender.MALE, BaziPrecision.DAY),
+  __check(Bazi.create(datetime(1984, 4, 2, 4, 2), BaziGender.MALE),
             '辛卯 壬辰')
 
 
@@ -487,7 +481,7 @@ def test_json() -> None:
         minute=random.randint(0, 59),
       ),
       gender=random.choice(list(BaziGender)),
-      precision=precision,
+      config=BaziConfig(precision=precision),
     ))
 
   for _ in range(32):
@@ -510,17 +504,24 @@ def test_json() -> None:
     assert chart.json != __j
 
     assert datetime.fromisoformat(j['birth_time']) == dt
-    assert j['precision'] == str(chart.bazi.precision)
+    assert j['precision'] == str(chart.bazi.config.precision)
 
     j_gender: BaziGender = BaziGender.MALE
     if j['gender'] == 'female':
       j_gender = BaziGender.FEMALE
     assert j_gender == chart.bazi.gender
 
-    # The rebuild parses everything -- precision included -- from the json itself.
+    # The rebuild parses everything -- precision, backend, school included -- from the json itself.
     __chart: BaziChart = BaziChart(
-      Bazi.create(datetime.fromisoformat(j['birth_time']), j_gender, j['precision'],
-                  backend=j['backend'])
+      Bazi.create(datetime.fromisoformat(j['birth_time']), j_gender,
+                  BaziConfig.from_values(
+                    precision=j['precision'],
+                    backend=j['backend'],
+                    school=BaziSchool(
+                      day_rollover=DayRollover[j['school']['day_rollover']],
+                      hongyan_key=KeyStem[j['school']['hongyan_key']],
+                    ),
+                  ))
     )
 
     assert j == __chart.json
@@ -530,7 +531,6 @@ def test_json_correctness() -> None:
   chart: BaziChart = BaziChart(Bazi.create(
     birth_time=datetime(1984, 4, 2, 4, 2),
     gender=BaziGender.男,
-    precision=BaziPrecision.DAY,
   ))
 
   #           Year    Month     Day     Hour
@@ -628,7 +628,7 @@ def test_backward_dayun_counts_from_the_month_owning_jie() -> None:
   zero: the dayun starts at the birth itself. (Moment-level counting would instead walk ~29
   days back to 小寒, starting the dayun ~9.7 years late and contradicting the 寅 month.)
   '''
-  chart: BaziChart = BaziChart(Bazi.create('2009-02-04 00:30', 'male', 'hour'))
+  chart: BaziChart = BaziChart(Bazi.create('2009-02-04 00:30', 'male', BaziConfig.from_values(precision='hour')))
   assert chart.bazi.month_commander == Dizhi.寅
   assert not chart.dayun_order
   assert chart.dayun_start_moment == chart.bazi.solar_datetime
@@ -640,7 +640,7 @@ def test_forward_dayun_skips_the_tie_jie() -> None:
   i.e. 惊蛰 (2009-03-05 18:47:32) -- the owning jie already opened the birth month and does
   not count as next, even though its true moment lies after the birth.
   '''
-  chart: BaziChart = BaziChart(Bazi.create('2009-02-04 00:30', 'female', 'hour'))
+  chart: BaziChart = BaziChart(Bazi.create('2009-02-04 00:30', 'female', BaziConfig.from_values(precision='hour')))
   assert chart.dayun_order
   birth: datetime = chart.bazi.solar_datetime
   gap: timedelta = datetime(2009, 3, 5, 18, 47, 32) - birth
@@ -652,7 +652,7 @@ def test_minute_precision_counts_to_the_true_moment() -> None:
   The same birth at MINUTE precision is NOT a tie (00:30 < 00:49): the year stays 戊子 (阳,
   male -> forward), and the next jie is 立春 itself, 19m48s away.
   '''
-  chart: BaziChart = BaziChart(Bazi.create('2009-02-04 00:30', 'male', 'minute'))
+  chart: BaziChart = BaziChart(Bazi.create('2009-02-04 00:30', 'male', BaziConfig.from_values(precision='minute')))
   assert chart.bazi.month_commander == Dizhi.丑
   assert chart.dayun_order
   birth: datetime = chart.bazi.solar_datetime
@@ -669,8 +669,8 @@ def test_backward_clamp_across_midnight_matches_the_same_shichen() -> None:
   year-level attribution: the xiaoyun stays populated and the first dayun lands in 2009,
   agreeing with the 己丑 year pillar.
   '''
-  across: BaziChart = BaziChart(Bazi.create('2009-02-03 23:30', 'male', 'hour'))
-  same_day: BaziChart = BaziChart(Bazi.create('2009-02-04 00:30', 'male', 'hour'))
+  across: BaziChart = BaziChart(Bazi.create('2009-02-03 23:30', 'male', BaziConfig.from_values(precision='hour')))
+  same_day: BaziChart = BaziChart(Bazi.create('2009-02-04 00:30', 'male', BaziConfig.from_values(precision='hour')))
 
   assert list(across.bazi.pillars) == list(same_day.bazi.pillars)
   assert not across.dayun_order
@@ -694,7 +694,7 @@ def test_liunian_and_xiaoyun_start_from_the_attributed_year(precision: str, firs
   follows the same attributed year (pinned lengths: forward 己丑 chart 10, backward 戊子
   chart 11).
   '''
-  chart: BaziChart = BaziChart(Bazi.create('2009-02-03 23:30', 'female', precision))
+  chart: BaziChart = BaziChart(Bazi.create('2009-02-03 23:30', 'female', BaziConfig.from_values(precision=precision)))
   assert str(chart.bazi.year_pillar) == year_pillar
 
   first_liunian = next(chart.liunian)

--- a/tests/test_bazi_chart.py
+++ b/tests/test_bazi_chart.py
@@ -11,8 +11,8 @@ import pytest
 from datetime import datetime, date, timedelta
 
 from src.defines import Tiangan, Dizhi, Ganzhi, Wuxing, Yinyang, Shishen, ShierZhangsheng
-from src.bazi import BaziGender, BaziPrecision, Bazi
-from src.school import BaziConfig, BaziSchool, DayRollover, KeyStem
+from src.bazi import BaziGender, Bazi
+from src.school import BaziPrecision, BaziConfig, BaziSchool, DayRollover, KeyStem
 from src.utils import bazi_utils
 
 from src.data_types import (

--- a/tests/test_school.py
+++ b/tests/test_school.py
@@ -1,0 +1,201 @@
+# Copyright (C) 2026 Ningqi Wang (0xf3cd) <https://github.com/0xf3cd>
+# test_school.py
+
+import pytest
+
+from dataclasses import FrozenInstanceError
+from datetime import datetime
+
+from src.calendar import CalendarBackend
+from src.bazi import Bazi, BaziGender
+from src.bazi_chart import BaziChart
+from src.school import (
+  BaziPrecision, DayRollover, KeyStem, BaziSchool, BaziConfig,
+  DEFAULT_SCHOOL, DEFAULT_CONFIG,
+)
+
+
+def test_school_enums_basic() -> None:
+  assert len(DayRollover) == 2
+  assert DayRollover.WAN_ZISHI.value == 0 # 晚子时, the default.
+  assert DayRollover.ZIZHENG.value == 1   # 子正.
+
+  assert len(KeyStem) == 2
+  assert KeyStem.DAY_MASTER.value == 0  # 日干, the 《三命通会》 reading, the default.
+  assert KeyStem.YEAR_MASTER.value == 1 # 年干.
+
+
+def test_school_defaults() -> None:
+  assert BaziSchool().day_rollover is DayRollover.WAN_ZISHI
+  assert BaziSchool().hongyan_key is KeyStem.DAY_MASTER
+  assert BaziSchool() == DEFAULT_SCHOOL
+
+
+def test_config_type_gates() -> None:
+  # The constructor takes the strict types only; coercion lives in `from_values`.
+  with pytest.raises(TypeError):
+    BaziConfig(precision='day') # type: ignore
+  with pytest.raises(TypeError):
+    BaziConfig(backend='hko') # type: ignore
+  with pytest.raises(TypeError):
+    BaziConfig(school=DayRollover.ZIZHENG) # type: ignore # An enum is not a `BaziSchool`.
+  with pytest.raises(TypeError):
+    BaziSchool(day_rollover='wan_zishi') # type: ignore
+  with pytest.raises(TypeError):
+    BaziSchool(hongyan_key=0) # type: ignore
+
+
+def test_config_and_school_are_frozen() -> None:
+  config: BaziConfig = BaziConfig()
+  with pytest.raises(FrozenInstanceError):
+    config.precision = BaziPrecision.HOUR # type: ignore
+  with pytest.raises(FrozenInstanceError):
+    config.school = BaziSchool(day_rollover=DayRollover.ZIZHENG) # type: ignore
+  with pytest.raises(FrozenInstanceError):
+    DEFAULT_SCHOOL.hongyan_key = KeyStem.YEAR_MASTER # type: ignore
+
+
+# The same acceptance face `Bazi.create` historically parsed: every alias below must
+# resolve, case insensitively -- written out as data so the test shares no table with src.
+@pytest.mark.parametrize('spelling, expected', [
+  ('分', BaziPrecision.MINUTE), ('分钟', BaziPrecision.MINUTE),
+  ('m', BaziPrecision.MINUTE), ('M', BaziPrecision.MINUTE),
+  ('min', BaziPrecision.MINUTE), ('Min', BaziPrecision.MINUTE),
+  ('minute', BaziPrecision.MINUTE), ('MINUTE', BaziPrecision.MINUTE),
+  ('时', BaziPrecision.HOUR), ('小时', BaziPrecision.HOUR),
+  ('h', BaziPrecision.HOUR), ('H', BaziPrecision.HOUR),
+  ('hour', BaziPrecision.HOUR), ('HOUR', BaziPrecision.HOUR), ('Hour', BaziPrecision.HOUR),
+  ('天', BaziPrecision.DAY), ('日', BaziPrecision.DAY),
+  ('d', BaziPrecision.DAY), ('D', BaziPrecision.DAY),
+  ('day', BaziPrecision.DAY), ('DAY', BaziPrecision.DAY), ('Day', BaziPrecision.DAY),
+])
+def test_from_values_precision_aliases(spelling: str, expected: BaziPrecision) -> None:
+  assert BaziConfig.from_values(precision=spelling).precision is expected
+
+
+# Both the member name and the value resolve, case insensitively (same face as
+# `CalendarBackend.from_str`, which does the actual parsing).
+@pytest.mark.parametrize('spelling, expected', [
+  ('hko', CalendarBackend.HKO), ('HKO', CalendarBackend.HKO), ('Hko', CalendarBackend.HKO),
+  ('celestial', CalendarBackend.CELESTIAL), ('CELESTIAL', CalendarBackend.CELESTIAL),
+  ('Celestial', CalendarBackend.CELESTIAL),
+  ('celestial-algo2', CalendarBackend.CELESTIAL_ALGO2),
+  ('CELESTIAL_ALGO2', CalendarBackend.CELESTIAL_ALGO2),
+  ('celestial_algo2', CalendarBackend.CELESTIAL_ALGO2),
+])
+def test_from_values_backend_spellings(spelling: str, expected: CalendarBackend) -> None:
+  assert BaziConfig.from_values(backend=spelling).backend is expected
+
+
+def test_from_values_enum_passthrough() -> None:
+  config: BaziConfig = BaziConfig.from_values(precision=BaziPrecision.HOUR, backend=CalendarBackend.HKO)
+  assert config.precision is BaziPrecision.HOUR
+  assert config.backend is CalendarBackend.HKO
+
+
+@pytest.mark.parametrize('bad', ['sec', '秒', 'hr', 'days', ''])
+def test_from_values_rejects_bad_precision(bad: str) -> None:
+  with pytest.raises(ValueError):
+    BaziConfig.from_values(precision=bad)
+
+
+def test_from_values_rejection_face() -> None:
+  with pytest.raises(ValueError):
+    BaziConfig.from_values(backend='lunar')
+  with pytest.raises(TypeError):
+    BaziConfig.from_values(precision=1984) # type: ignore
+  with pytest.raises(TypeError):
+    BaziConfig.from_values(backend=42) # type: ignore
+  with pytest.raises(TypeError):
+    BaziConfig.from_values(school='default') # type: ignore # No string spelling for school.
+
+
+def test_from_values_school_passthrough() -> None:
+  school: BaziSchool = BaziSchool(day_rollover=DayRollover.ZIZHENG, hongyan_key=KeyStem.YEAR_MASTER)
+  config: BaziConfig = BaziConfig.from_values(school=school)
+  assert config.school is school
+  assert config.precision is BaziPrecision.DAY # Untouched knobs keep their defaults.
+  assert config.backend is CalendarBackend.CELESTIAL
+
+
+def test_defaults_are_defined_once() -> None:
+  # D-7: the defaults live in the field defaults only; the constants pick them up.
+  assert BaziConfig() == DEFAULT_CONFIG
+  assert BaziConfig() is not DEFAULT_CONFIG
+  assert BaziConfig().school is DEFAULT_SCHOOL
+  assert BaziConfig.from_values() == DEFAULT_CONFIG
+  assert BaziConfig.from_values().school is DEFAULT_SCHOOL
+  assert DEFAULT_CONFIG.school is DEFAULT_SCHOOL
+
+
+def test_bazi_default_config_is_the_shared_default() -> None:
+  # Every construction path picks up `DEFAULT_CONFIG` implicitly (默认零变化).
+  dt: datetime = datetime(1984, 4, 2, 4, 2)
+  assert Bazi.create(dt, BaziGender.男).config is DEFAULT_CONFIG
+  assert Bazi(dt, BaziGender.男).config is DEFAULT_CONFIG
+  assert Bazi.random().config is DEFAULT_CONFIG
+  assert Bazi.create(dt, BaziGender.男) == Bazi(dt, BaziGender.男)
+
+
+def test_eq_hash_include_school() -> None:
+  # Same birth, same gender, different school: not equal, different hash, no set dedup.
+  dt: datetime = datetime(1984, 4, 2, 4, 2)
+  default_bazi: Bazi = Bazi.create(dt, BaziGender.MALE)
+  zi_bazi: Bazi = Bazi.create(dt, BaziGender.MALE,
+                              BaziConfig(school=BaziSchool(day_rollover=DayRollover.ZIZHENG)))
+
+  assert default_bazi != zi_bazi
+  assert hash(default_bazi) != hash(zi_bazi)
+  assert len({default_bazi, zi_bazi}) == 2
+
+  # Same school (by value, not identity): equal, same hash, set dedups.
+  same_school: Bazi = Bazi.create(dt, BaziGender.MALE,
+                                  BaziConfig(school=BaziSchool(day_rollover=DayRollover.ZIZHENG)))
+  assert zi_bazi == same_school
+  assert hash(zi_bazi) == hash(same_school)
+  assert len({zi_bazi, same_school}) == 1
+
+
+def test_json_roundtrip_default_school() -> None:
+  chart: BaziChart = BaziChart(Bazi.create(datetime(1984, 4, 2, 4, 2), BaziGender.MALE))
+  j = chart.json
+  assert j['school'] == { 'day_rollover': 'WAN_ZISHI', 'hongyan_key': 'DAY_MASTER' }
+
+  rebuilt: BaziChart = BaziChart(
+    Bazi.create(datetime.fromisoformat(j['birth_time']), j['gender'],
+                BaziConfig.from_values(
+                  precision=j['precision'],
+                  backend=j['backend'],
+                  school=BaziSchool(
+                    day_rollover=DayRollover[j['school']['day_rollover']],
+                    hongyan_key=KeyStem[j['school']['hongyan_key']],
+                  ),
+                ))
+  )
+  assert rebuilt.json == j
+  assert rebuilt.bazi == chart.bazi
+
+
+def test_json_roundtrip_non_default_school() -> None:
+  # A non-default school must survive the JSON roundtrip losslessly (D-5): rebuilding
+  # from the json alone reproduces the same chart, not a silent default-school one.
+  school: BaziSchool = BaziSchool(day_rollover=DayRollover.ZIZHENG, hongyan_key=KeyStem.YEAR_MASTER)
+  chart: BaziChart = BaziChart(Bazi.create(datetime(1984, 4, 2, 4, 2), BaziGender.MALE,
+                                           BaziConfig(school=school)))
+  j = chart.json
+  assert j['school'] == { 'day_rollover': 'ZIZHENG', 'hongyan_key': 'YEAR_MASTER' }
+
+  rebuilt: BaziChart = BaziChart(
+    Bazi.create(datetime.fromisoformat(j['birth_time']), j['gender'],
+                BaziConfig.from_values(
+                  precision=j['precision'],
+                  backend=j['backend'],
+                  school=BaziSchool(
+                    day_rollover=DayRollover[j['school']['day_rollover']],
+                    hongyan_key=KeyStem[j['school']['hongyan_key']],
+                  ),
+                ))
+  )
+  assert rebuilt.json == j
+  assert rebuilt.bazi == chart.bazi
+  assert rebuilt.bazi.config.school == school

--- a/tests/test_school.py
+++ b/tests/test_school.py
@@ -1,10 +1,10 @@
 # Copyright (C) 2026 Ningqi Wang (0xf3cd) <https://github.com/0xf3cd>
 # test_school.py
 
-import pytest
-
 from dataclasses import FrozenInstanceError
 from datetime import datetime
+
+import pytest
 
 from src.calendar import CalendarBackend
 from src.bazi import Bazi, BaziGender
@@ -149,16 +149,22 @@ def test_eq_hash_include_school() -> None:
   # Same birth, same gender, different school: not equal, different hash, no set dedup.
   dt: datetime = datetime(1984, 4, 2, 4, 2)
   default_bazi: Bazi = Bazi.create(dt, BaziGender.MALE)
-  zi_bazi: Bazi = Bazi.create(dt, BaziGender.MALE,
-                              BaziConfig(school=BaziSchool(day_rollover=DayRollover.ZIZHENG)))
+  zi_bazi: Bazi = Bazi.create(
+    dt,
+    BaziGender.MALE,
+    BaziConfig(school=BaziSchool(day_rollover=DayRollover.ZIZHENG)),
+  )
 
   assert default_bazi != zi_bazi
   assert hash(default_bazi) != hash(zi_bazi)
   assert len({default_bazi, zi_bazi}) == 2
 
   # Same school (by value, not identity): equal, same hash, set dedups.
-  same_school: Bazi = Bazi.create(dt, BaziGender.MALE,
-                                  BaziConfig(school=BaziSchool(day_rollover=DayRollover.ZIZHENG)))
+  same_school: Bazi = Bazi.create(
+    dt,
+    BaziGender.MALE,
+    BaziConfig(school=BaziSchool(day_rollover=DayRollover.ZIZHENG)),
+  )
   assert zi_bazi == same_school
   assert hash(zi_bazi) == hash(same_school)
   assert len({zi_bazi, same_school}) == 1

--- a/tests/test_school.py
+++ b/tests/test_school.py
@@ -15,6 +15,14 @@ from src.school import (
 )
 
 
+def test_bazi_precision_basic() -> None:
+  assert len(BaziPrecision) == 3
+
+  assert str(BaziPrecision.DAY) == 'day'
+  assert str(BaziPrecision.HOUR) == 'hour'
+  assert str(BaziPrecision.MINUTE) == 'minute'
+
+
 def test_school_enums_basic() -> None:
   assert len(DayRollover) == 2
   assert DayRollover.WAN_ZISHI.value == 0 # 晚子时, the default.
@@ -55,8 +63,8 @@ def test_config_and_school_are_frozen() -> None:
     DEFAULT_SCHOOL.hongyan_key = KeyStem.YEAR_MASTER # type: ignore
 
 
-# The same acceptance face `Bazi.create` historically parsed: every alias below must
-# resolve, case insensitively -- written out as data so the test shares no table with src.
+# Every alias below must resolve, case insensitively -- written out as data so the test
+# shares no table with src.
 @pytest.mark.parametrize('spelling, expected', [
   ('分', BaziPrecision.MINUTE), ('分钟', BaziPrecision.MINUTE),
   ('m', BaziPrecision.MINUTE), ('M', BaziPrecision.MINUTE),
@@ -119,7 +127,7 @@ def test_from_values_school_passthrough() -> None:
 
 
 def test_defaults_are_defined_once() -> None:
-  # D-7: the defaults live in the field defaults only; the constants pick them up.
+  # The defaults live in the field defaults only; the constants pick them up.
   assert BaziConfig() == DEFAULT_CONFIG
   assert BaziConfig() is not DEFAULT_CONFIG
   assert BaziConfig().school is DEFAULT_SCHOOL
@@ -177,7 +185,7 @@ def test_json_roundtrip_default_school() -> None:
 
 
 def test_json_roundtrip_non_default_school() -> None:
-  # A non-default school must survive the JSON roundtrip losslessly (D-5): rebuilding
+  # A non-default school must survive the JSON roundtrip losslessly: rebuilding
   # from the json alone reproduces the same chart, not a silent default-school one.
   school: BaziSchool = BaziSchool(day_rollover=DayRollover.ZIZHENG, hongyan_key=KeyStem.YEAR_MASTER)
   chart: BaziChart = BaziChart(Bazi.create(datetime(1984, 4, 2, 4, 2), BaziGender.MALE,

--- a/tests/test_transit_chart.py
+++ b/tests/test_transit_chart.py
@@ -5,7 +5,7 @@ import pytest
 
 from datetime import datetime
 
-from src.bazi import Bazi, BaziGender, BaziPrecision
+from src.bazi import Bazi, BaziGender
 from src.bazi_chart import BaziChart
 from src.defines import Dizhi
 from src.transits import TransitMoment, TransitOptions, TransitDatabase
@@ -32,7 +32,7 @@ def test_basic_negative() -> None:
 
 
 def test_delegation() -> None:
-  bazi: Bazi = Bazi.create(datetime(2000, 2, 4, 22, 1), BaziGender.MALE, BaziPrecision.DAY)
+  bazi: Bazi = Bazi.create(datetime(2000, 2, 4, 22, 1), BaziGender.MALE)
   transits: TransitChart = TransitChart(BaziChart(bazi))
   db: TransitDatabase = TransitDatabase(transits.bazi_chart)
 
@@ -46,7 +46,7 @@ def test_delegation() -> None:
 
 
 def test_delegation_negative() -> None:
-  bazi: Bazi = Bazi.create(datetime(2000, 2, 4, 22, 1), BaziGender.MALE, BaziPrecision.DAY)
+  bazi: Bazi = Bazi.create(datetime(2000, 2, 4, 22, 1), BaziGender.MALE)
   transits: TransitChart = TransitChart(BaziChart(bazi))
 
   with pytest.raises(TypeError):

--- a/tests/test_transits.py
+++ b/tests/test_transits.py
@@ -11,7 +11,8 @@ from src.data_types import DayunTuple
 from src.defines import Ganzhi, Dizhi
 from src.utils import bazi_utils
 
-from src.bazi import Bazi, BaziGender, BaziPrecision
+from src.bazi import Bazi, BaziGender
+from src.school import BaziConfig
 from src.bazi_chart import BaziChart
 from src.calendar import calendar_utils_of
 from src.transits import DayunDatabase, TransitMoment, TransitOptions, TransitDatabase, _ALL_OPTIONS
@@ -22,13 +23,13 @@ def _dayun_start_gz_year(chart: BaziChart) -> int:
   # expression `TransitDatabase` consumes: the day-level label of `dayun_start_moment`
   # through the chart's own backend, floored at `Bazi.ganzhi_year`.
   return max(
-    calendar_utils_of(chart.bazi.backend).to_ganzhi(chart.dayun_start_moment).year,
+    calendar_utils_of(chart.bazi.config.backend).to_ganzhi(chart.dayun_start_moment).year,
     chart.bazi.ganzhi_year,
   )
 
 
 def test_simple() -> None:
-  bazi: Bazi = Bazi.create(datetime(2000, 2, 4, 22, 1), BaziGender.MALE, BaziPrecision.DAY)
+  bazi: Bazi = Bazi.create(datetime(2000, 2, 4, 22, 1), BaziGender.MALE)
   chart: BaziChart = BaziChart(bazi)
   db = DayunDatabase(chart)
 
@@ -252,7 +253,7 @@ def test_birth_year_is_precision_attributed() -> None:
   never produces, and 虚岁 must count from 2009 so that the dayun-start year 2018 supports
   xiaoyun.
   '''
-  chart: BaziChart = BaziChart(Bazi.create('2009-02-03 23:30', 'female', 'hour'))
+  chart: BaziChart = BaziChart(Bazi.create('2009-02-03 23:30', 'female', BaziConfig.from_values(precision='hour')))
   assert chart.bazi.ganzhi_year == 2009
   db: TransitDatabase = TransitDatabase(chart)
 
@@ -269,7 +270,7 @@ def test_birth_year_is_precision_attributed() -> None:
 
 def test_day_precision_unchanged() -> None:
   '''At DAY the two year channels agree.'''
-  chart: BaziChart = BaziChart(Bazi.create('2009-02-03 23:30', 'female', 'day'))
+  chart: BaziChart = BaziChart(Bazi.create('2009-02-03 23:30', 'female'))
   assert chart.bazi.ganzhi_year == chart.bazi.ganzhi_date.year
   db: TransitDatabase = TransitDatabase(chart)
   assert db.support(TransitMoment(2008), TransitOptions.LIUNIAN)  # 戊子 2008 IS this chart's first liunian.
@@ -285,7 +286,7 @@ def test_dayun_year_floored_at_ganzhi_year() -> None:
   dayun, and every later year would resolve one dayun step off (2018: 甲子 instead of
   乙丑).
   '''
-  chart: BaziChart = BaziChart(Bazi.create('2009-02-03 23:30', 'male', 'hour'))
+  chart: BaziChart = BaziChart(Bazi.create('2009-02-03 23:30', 'male', BaziConfig.from_values(precision='hour')))
   assert chart.dayun_start_moment == chart.bazi.solar_datetime # The clamp: the start IS the birth.
   assert chart.bazi.ganzhi_date.year == 2008 # The bare day-level label of the clamped start.
   assert chart.bazi.ganzhi_year == 2009


### PR DESCRIPTION
#69 第一弹:Chart 级配置机制 + 首个流派 variant 挂载。机制与八项范围裁决见 #69 评论(2026-08-04 拍板)。

## 内容

**c1 机制(bf20a99)**:
- 新模块 `src/school.py`:`BaziConfig`(precision/backend/school 三旋钮聚合,frozen)+ `BaziSchool`(流派档案)+ `DayRollover`/`KeyStem` 分歧枚举 + `DEFAULT_SCHOOL`/`DEFAULT_CONFIG` 单点默认(构造即默认,无双写)+ `from_values` 字符串解析(与 `Bazi.create` 既有别名面同一张表)。`BaziPrecision` 迁入本模块(叶模块,破双向模块期依赖),`src.bazi` 保留 re-export 兼容。
- **签名级切换**:`Bazi.create(birth_time, gender, config=DEFAULT_CONFIG)`,`Bazi()` 构造同步;公开读面只留 `bazi.config`(`precision`/`backend` 属性删除,读点随迁)。仓内 86 处 create + 30 处直接构造 + 全部读点机械迁移(六种形态,开工前冻结形态表,表外零意外)。
- `__eq__`/`__hash__`/JSON 纳入 school(与 backend 先例对齐:凡影响盘面的旋钮进序列化与相等性);非默认 school 的 JSON roundtrip 保真。

**c2 首个挂载(6b68aab)**:`DayRollover` 进 `bazi.py` 换日点——`WAN_ZISHI`(晚子时,默认=现状多数派)/ `ZIZHENG`(子正换日)。年/月柱不随此旋钮(与 `BaziPrecision` 归属是两条独立机制);时干经五鼠遁自动跟随。新增钉:DAY 两 variant 全柱、23:xx 时柱天干 golden(补缺口)、HOUR×节气子时 tie 全柱金样(2009-02-03 23:30,防「子正=年月也不翻」误读)。

**修复批(d5f614c)**:R1 四席后的 14 项——`src.school` 注册公开面(opus P2)、DayRollover 派发加穷尽性接缝(opus P2,照 `calendar_utils_of` 先例)、AGENTS.md 示例迁签名、tz 双闸去重、注释/措辞/import 统一等。

## 默认零变化(本批最强断言)

- 与 parent 默认盘面黑盒对拍 **5652 例零差异**(300 随机 + 14 边界 × 性别 × 3 精度 × 3 后端,含完整 JSON 与异常面)。
- str coercion 新旧解析面 67 例逐项相同(含边角拒绝面)。
- 全量门禁 456 passed、coverage 100%、o_smoke 11/11。

## 审阅史

计划审 grok(GO-WITH-CHANGES:JSON/eq 对称 P1、迁移形态穷尽、frozen coercion 先例、红艳 registry 触点、HOUR tie 金样——全部前置消化)→ R1 四席:**grok 清单 NO FINDINGS**(检出率四刀全实证)、**opus 盲审 2×P2+2×P3**(公开面注册、穷尽接缝;金样经外部锚点独立复算)、**kimi 风格 2×P2+5×P3**(评审工件引用住代码、import 分裂)、**kimi 减法 2×P3**(宪章示例、tz 双闸;hongyan_key 惰性论证后保留)。修复批 14 项,用户拍板免 R2(打磨件无结构级),bot 循环兜底。

## 纪律说明

- `hongyan_key` 在本 PR 是惰性旋钮(查法消费在 PR-2 落地,docstring 已注明时点);**PR-1 与 PR-2 合入之间不发版、不打 tag**。
- 下一弹 PR-2:红艳查法挂载(D-8)+ 《三命通会》出处标注 + XingDef/dayun_order 措辞。
