### PR TITLE
feat: #69 红艳查法挂载(KeyStem 评估期覆盖)+ 出处/措辞三件(PR-2)

### DIFF
--- a/src/analyzer/relationship.py
+++ b/src/analyzer/relationship.py
@@ -42,7 +42,7 @@ class _KeySource(Enum):
   '''The key(s) that a Shensha is looked up by (查询神煞时所用的 key).'''
   YEAR_DIZHI        = auto() # By the year pillar's Dizhi only (只看年支).
   YEAR_OR_DAY_DIZHI = auto() # By the year or day pillar's Dizhi (看年支或日支).
-  DAY_MASTER        = auto() # By a key Tiangan (查法锚干): day master by default, year tiangan per school. Sole consumer today: 红艳 (see `_hongyan_anchor`).
+  KEY_TIANGAN       = auto() # By a key Tiangan (查法锚干): day master by default, year tiangan per school. Sole consumer today: 红艳 (see `_hongyan_anchor`).
 
 
 @dataclass(frozen=True)
@@ -51,7 +51,7 @@ class _ShenshaSpec:
   The spec of a Shensha: the predicate and the key source (神煞的规格：判断函数和查询 key).
 
   Note: the predicate's first-parameter type must match `key` (e.g. a `Tiangan`-keyed predicate
-  pairs with `DAY_MASTER`). This contract is guarded by the runtime asserts in `shensha_utils`
+  pairs with `KEY_TIANGAN`). This contract is guarded by the runtime asserts in `shensha_utils`
   and the registry tests, not by the type system.
   '''
   predicate: Callable[..., bool]
@@ -61,7 +61,7 @@ class _ShenshaSpec:
 '''The registry of the Shenshas that relationship analysis currently supports (亲密关系分析目前支持的神煞注册表).'''
 _REGISTRY: Final[frozendict[str, _ShenshaSpec]] = frozendict({
   'taohua'  : _ShenshaSpec(shensha_utils.taohua,   _KeySource.YEAR_OR_DAY_DIZHI),
-  'hongyan' : _ShenshaSpec(shensha_utils.hongyan,  _KeySource.DAY_MASTER),
+  'hongyan' : _ShenshaSpec(shensha_utils.hongyan,  _KeySource.KEY_TIANGAN),
   'hongluan': _ShenshaSpec(shensha_utils.hongluan, _KeySource.YEAR_DIZHI),
   'tianxi'  : _ShenshaSpec(shensha_utils.tianxi,   _KeySource.YEAR_DIZHI),
   'yima'    : _ShenshaSpec(shensha_utils.yima,     _KeySource.YEAR_OR_DAY_DIZHI),
@@ -70,7 +70,7 @@ _REGISTRY: Final[frozendict[str, _ShenshaSpec]] = frozendict({
 
 def _hongyan_anchor(bazi: Bazi) -> Tiangan:
   '''The anchor Tiangan a HONGYAN (红艳) lookup keys on (查法锚干, issue #69): the registry
-  records the static default (`_KeySource.DAY_MASTER`, the 《三命通会》 reading), and the
+  records the static default (`_KeySource.KEY_TIANGAN`, the 《三命通会》 reading), and the
   chart's school profile overrides it at evaluation time -- `KeyStem.YEAR_MASTER` keys on
   the year tiangan instead. 红艳查法的锚干：注册表记静态默认（查日干），评估期由盘的
   `BaziSchool.hongyan_key` 覆盖（可查年干）。'''
@@ -95,7 +95,7 @@ def _eval_at_birth(spec: _ShenshaSpec, bazi: Bazi) -> frozenset[Dizhi]:
     args = (([y_dz], [m_dz, d_dz, h_dz]),)
   elif spec.key is _KeySource.YEAR_OR_DAY_DIZHI:
     args = (([y_dz], [m_dz, d_dz, h_dz]), ([d_dz], [y_dz, m_dz, h_dz]))
-  elif spec.key is _KeySource.DAY_MASTER:
+  elif spec.key is _KeySource.KEY_TIANGAN:
     args = (([_hongyan_anchor(bazi)], [y_dz, m_dz, d_dz, h_dz]),)
   else:
     # Invariant: every `_KeySource` member must be wired up above. Reaching here means we
@@ -113,7 +113,7 @@ def _eval_transits(spec: _ShenshaSpec, bazi: Bazi, transit_dizhis: Iterable[Dizh
     first_args = [bazi.year_pillar.dizhi]
   elif spec.key is _KeySource.YEAR_OR_DAY_DIZHI:
     first_args = [bazi.year_pillar.dizhi, bazi.day_pillar.dizhi]
-  elif spec.key is _KeySource.DAY_MASTER:
+  elif spec.key is _KeySource.KEY_TIANGAN:
     first_args = [_hongyan_anchor(bazi)]
   else:
     # Invariant: every `_KeySource` member must be wired up above. Reaching here means we

--- a/src/analyzer/relationship.py
+++ b/src/analyzer/relationship.py
@@ -11,6 +11,7 @@ from collections.abc import Callable, Iterable
 from ..common import frozendict
 from ..data_types import GanzhiData
 from ..defines import Tiangan, Dizhi, Shishen, DizhiRelation
+from ..school import KeyStem
 from ..bazi import Bazi
 from ..bazi_chart import BaziChart
 from ..transits import TransitMoment, TransitOptions
@@ -41,7 +42,7 @@ class _KeySource(Enum):
   '''The key(s) that a Shensha is looked up by (查询神煞时所用的 key).'''
   YEAR_DIZHI        = auto() # By the year pillar's Dizhi only (只看年支).
   YEAR_OR_DAY_DIZHI = auto() # By the year or day pillar's Dizhi (看年支或日支).
-  DAY_MASTER        = auto() # By the day master (看日主).
+  DAY_MASTER        = auto() # By a key Tiangan (查法锚干): the day master by default, or the year tiangan when the school says so (see `_hongyan_anchor`).
 
 
 @dataclass(frozen=True)
@@ -67,9 +68,26 @@ _REGISTRY: Final[frozendict[str, _ShenshaSpec]] = frozendict({
 })
 
 
+def _hongyan_anchor(bazi: Bazi) -> Tiangan:
+  '''The anchor Tiangan a HONGYAN (红艳) lookup keys on (查法锚干, issue #69): the registry
+  records the static default (`_KeySource.DAY_MASTER`, the 《三命通会》 reading), and the
+  chart's school profile overrides it at evaluation time -- `KeyStem.YEAR_MASTER` keys on
+  the year tiangan instead. 红艳查法的锚干：注册表记静态默认（查日干），评估期由盘的
+  `BaziSchool.hongyan_key` 覆盖（可查年干）。'''
+  key_stem: Final[KeyStem] = bazi.config.school.hongyan_key
+  if key_stem is KeyStem.DAY_MASTER:
+    return bazi.day_master
+  elif key_stem is KeyStem.YEAR_MASTER:
+    return bazi.year_pillar.tiangan
+  else:
+    # Invariant: every `KeyStem` member must be wired up above. Reaching here means we
+    # added a member but forgot to wire it -- not something users can trigger.
+    # `raise` instead of `assert` so the guard survives `python -O`.
+    raise AssertionError(f'`KeyStem` not wired up in `_hongyan_anchor`: {key_stem}') # pragma: no cover # Unreachable invariant guard.
+
+
 def _eval_at_birth(spec: _ShenshaSpec, bazi: Bazi) -> frozenset[Dizhi]:
   '''Evaluate a Shensha against the at-birth Bazi / 在原局上评估某个神煞。'''
-  dm = bazi.day_master
   y_dz, m_dz, d_dz, h_dz = bazi.four_dizhis
 
   args: tuple[_ArgsType, ...]
@@ -78,7 +96,7 @@ def _eval_at_birth(spec: _ShenshaSpec, bazi: Bazi) -> frozenset[Dizhi]:
   elif spec.key is _KeySource.YEAR_OR_DAY_DIZHI:
     args = (([y_dz], [m_dz, d_dz, h_dz]), ([d_dz], [y_dz, m_dz, h_dz]))
   elif spec.key is _KeySource.DAY_MASTER:
-    args = (([dm], [y_dz, m_dz, d_dz, h_dz]),)
+    args = (([_hongyan_anchor(bazi)], [y_dz, m_dz, d_dz, h_dz]),)
   else:
     # Invariant: every `_KeySource` member must be wired up above. Reaching here means we
     # added a member but forgot to update this evaluator -- not something users can trigger.
@@ -96,7 +114,7 @@ def _eval_transits(spec: _ShenshaSpec, bazi: Bazi, transit_dizhis: Iterable[Dizh
   elif spec.key is _KeySource.YEAR_OR_DAY_DIZHI:
     first_args = [bazi.year_pillar.dizhi, bazi.day_pillar.dizhi]
   elif spec.key is _KeySource.DAY_MASTER:
-    first_args = [bazi.day_master]
+    first_args = [_hongyan_anchor(bazi)]
   else:
     # Invariant: every `_KeySource` member must be wired up above. Reaching here means we
     # added a member but forgot to update this evaluator -- not something users can trigger.

--- a/src/analyzer/relationship.py
+++ b/src/analyzer/relationship.py
@@ -42,7 +42,7 @@ class _KeySource(Enum):
   '''The key(s) that a Shensha is looked up by (查询神煞时所用的 key).'''
   YEAR_DIZHI        = auto() # By the year pillar's Dizhi only (只看年支).
   YEAR_OR_DAY_DIZHI = auto() # By the year or day pillar's Dizhi (看年支或日支).
-  DAY_MASTER        = auto() # By a key Tiangan (查法锚干): the day master by default, or the year tiangan when the school says so (see `_hongyan_anchor`).
+  DAY_MASTER        = auto() # By a key Tiangan (查法锚干): day master by default, year tiangan per school. Sole consumer today: 红艳 (see `_hongyan_anchor`).
 
 
 @dataclass(frozen=True)

--- a/src/bazi_chart.py
+++ b/src/bazi_chart.py
@@ -301,6 +301,12 @@ class BaziChart:
     `False` if the Ganzhis of Dayuns are in a backward order.
 
     `True` 代表大运是顺排的，`False` 代表大运是逆排的。
+
+    Note: the traditional phrasing keys on the year Tiangan's yinyang (阳男阴女顺排，阴男阳女逆排);
+    this implementation reads the year Dizhi's yinyang instead -- mathematically identical, since
+    within the 60 Jiazi a Ganzhi's Tiangan and Dizhi always share the same yinyang.
+    传统表述以年干阴阳论「阳男阴女顺、阴男阳女逆」；本实现读年支阴阳，二者数学恒等价——
+    六十甲子内干支的阴阳恒一致。
     '''
     is_male: bool = (self._bazi.gender is BaziGender.男)
     is_year_dz_yang: bool = (traits(self._bazi.year_pillar.dizhi).yinyang is Yinyang.阳)

--- a/src/rules.py
+++ b/src/rules.py
@@ -458,6 +458,9 @@ class ShenshaRules:
   # The table is used to find out HONGYAN (红艳). From 《三命通会》: "甲乙逢午、丙寅、丁未、
   # 戊辰、己辰、庚戌、辛酉、壬子、癸申，为红艳煞".
   # 该表格用于查询红艳星。出自《三命通会》。
+  # One cell diverges across text lineages: the prose above reads 乙→午 (问真八字 follows it), while
+  # this table takes the verse lineage 「甲乙午申庚见戌」 → 乙→申 (both pinned in #69's research).
+  # 乙 一格两谱系分叉:散文本作乙午(问真等从之),本表从歌诀本作乙申。
   # A variant table reading 庚申/癸戌 (instead of 庚戌/癸申) also circulates, but it is
   # attested only in a single aggregator-site text lineage, so it is not adopted here
   # (research of 2026-08-04, see issue #69).

--- a/src/rules.py
+++ b/src/rules.py
@@ -369,7 +369,9 @@ class DizhiRules:
     不同的地支相刑的看法。主要区别在于丑未戌、寅巳申之间相刑的定义。
     '''
     STRICT = 0 # For 丑未戌 and 寅巳申, a XING relation is formed only when all three Dizhis appear.
-    LOOSE  = 1 # For 丑未戌 and 寅巳申, a XING relation is formed if any two of the three Dizhis appear.
+    LOOSE  = 1 # For 丑未戌 and 寅巳申, a XING relation is formed if any two of the three Dizhis appear --
+               # directionally, following the cycle 丑->戌->未->丑 / 寅->巳->申->寅: (丑,戌) forms XING
+               # while (戌,丑) does not. The direction is locked in by the implementation and `test_dizhi_utils`.
 
   class XingSubType(Enum):
     SANXING   = 0 # 丑未戌、寅巳申三刑
@@ -453,8 +455,13 @@ class ShenshaRules:
     for k_str in k_strs
   })
 
-  # The table is used to find out HONGYAN (红艳).
-  # 该表格用于查询红艳星。
+  # The table is used to find out HONGYAN (红艳). From 《三命通会》: "甲乙逢午、丙寅、丁未、
+  # 戊辰、己辰、庚戌、辛酉、壬子、癸申，为红艳煞".
+  # 该表格用于查询红艳星。出自《三命通会》。
+  # A variant table reading 庚申/癸戌 (instead of 庚戌/癸申) also circulates, but it is
+  # attested only in a single aggregator-site text lineage, so it is not adopted here
+  # (research of 2026-08-04, see issue #69).
+  # 另有庚申/癸戌异表流传，但仅见聚合站单一文本谱系，未采（2026-08-04 考证，详见 #69）。
   HONGYAN: Final[frozendict[Tiangan, Dizhi]] = frozendict({
     Tiangan.甲 : Dizhi.午,
     Tiangan.乙 : Dizhi.申,

--- a/src/school.py
+++ b/src/school.py
@@ -110,8 +110,10 @@ class KeyStem(Enum):
   - YEAR_MASTER: key on the Year Tiangan (年干).
     以年干为锚。
 
-  Note: the 查法 consumption lands in #69 PR-2 -- until then this knob feeds eq / JSON
-  only, not the computed chart. 查法消费在 #69 PR-2 落地；此前本旋钮只影响相等性 / JSON，不影响盘面。
+  Note: this knob is consumed at evaluation time by the 红艳 lookup in relationship analysis
+  (`analyzer/relationship.py`); the four pillars never follow it. It also feeds eq / JSON as
+  part of `BaziSchool`. 本旋钮由红艳查法在评估期消费；四柱不随它动。它也随 `BaziSchool`
+  进相等性 / JSON。
 
   No change should be made to the existing definitions. Only add new definitions.
   '''
@@ -135,8 +137,8 @@ class BaziSchool:
   the defaults are written down exactly once.
   默认流派只在字段默认值处定义一次；`DEFAULT_SCHOOL` 构造即默认，`BaziConfig.school` 指向同一实例。
 
-  `hongyan_key` does not steer the chart yet -- its 查法 consumption lands in #69 PR-2;
-  until then it feeds eq / JSON only. `hongyan_key` 的查法消费在 #69 PR-2 落地，此前不进盘面。
+  `hongyan_key` steers the 红艳 lookup in relationship analysis (read at evaluation time);
+  it does not move the four pillars. `hongyan_key` 决定红艳查法的锚干（评估期读取）；四柱不随它动。
   '''
   day_rollover: DayRollover = DayRollover.WAN_ZISHI
   hongyan_key:  KeyStem     = KeyStem.DAY_MASTER

--- a/src/utils/shensha_utils.py
+++ b/src/utils/shensha_utils.py
@@ -42,7 +42,7 @@ def hongyan(key_tiangan: Tiangan, dizhi: Dizhi) -> bool:
 
   Args:
   - key_tiangan: (Tiangan) The anchor Tiangan the lookup keys on (查法锚干) -- the day master under
-    the 《三命通会》 reading, or the year tiangan; the caller decides (see `BaziSchool.hongyan_key`, issue #69).
+    the 《三命通会》 reading, or the year tiangan; the caller decides which.
     查法所锚的天干——《三命通会》口径查日干，也可查年干；锚哪个干由调用方决定。
   - dizhi: (Dizhi) The Dizhi.
 

--- a/src/utils/shensha_utils.py
+++ b/src/utils/shensha_utils.py
@@ -6,7 +6,7 @@ from ..rules import ShenshaRules
 
 '''
 Predicates for Shensha (神煞) detection: 桃花 / 红艳 / 红鸾 / 天喜 / 驿马.
-Each function checks whether a Dizhi forms the Shensha against its anchor (the year/day Dizhi, or the Day Master).
+Each function checks whether a Dizhi forms the Shensha against its anchor (the year/day Dizhi, or a key Tiangan).
 '''
 
 
@@ -35,16 +35,18 @@ def taohua(year_or_day_dizhi: Dizhi, other_dizhi: Dizhi) -> bool:
   return ShenshaRules.TAOHUA[year_or_day_dizhi] is other_dizhi
 
 
-def hongyan(day_master: Tiangan, dizhi: Dizhi) -> bool:
+def hongyan(key_tiangan: Tiangan, dizhi: Dizhi) -> bool:
   '''
-  Check if the input `dizhi` is the HONGYAN (红艳) of `day_master`. If so, return `True`. If not, return `False`.
-  检查输入的地支是否是日主的红艳星。如果是，返回 `True`。如果不是，返回 `False`。
+  Check if the input `dizhi` is the HONGYAN (红艳) of `key_tiangan`. If so, return `True`. If not, return `False`.
+  检查输入的地支是否是 `key_tiangan` 的红艳星。如果是，返回 `True`。如果不是，返回 `False`。
 
   Args:
-  - day_master: (Tiangan) The Tiangan of day pillar.
+  - key_tiangan: (Tiangan) The anchor Tiangan the lookup keys on (查法锚干) -- the day master under
+    the 《三命通会》 reading, or the year tiangan; the caller decides (see `BaziSchool.hongyan_key`, issue #69).
+    查法所锚的天干——《三命通会》口径查日干，也可查年干；锚哪个干由调用方决定。
   - dizhi: (Dizhi) The Dizhi.
 
-  Returns: (bool) Whether the `dizhi` is the HONGYAN (红艳) of `day_master`.
+  Returns: (bool) Whether the `dizhi` is the HONGYAN (红艳) of `key_tiangan`.
 
   Examples:
   - hongyan(Tiangan.癸, Dizhi.申)
@@ -53,11 +55,11 @@ def hongyan(day_master: Tiangan, dizhi: Dizhi) -> bool:
     - return: False
   '''
 
-  if not isinstance(day_master, Tiangan):
-    raise TypeError(f'Expected Tiangan, got {type(day_master)}')
+  if not isinstance(key_tiangan, Tiangan):
+    raise TypeError(f'Expected Tiangan, got {type(key_tiangan)}')
   if not isinstance(dizhi, Dizhi):
     raise TypeError(f'Expected Dizhi, got {type(dizhi)}')
-  return ShenshaRules.HONGYAN[day_master] is dizhi
+  return ShenshaRules.HONGYAN[key_tiangan] is dizhi
 
 
 def hongluan(year_dizhi: Dizhi, other_dizhi: Dizhi) -> bool:

--- a/tests/analyzer/test_relationship_analyzer.py
+++ b/tests/analyzer/test_relationship_analyzer.py
@@ -8,7 +8,9 @@ import itertools
 
 from src.defines import Tiangan, Dizhi, Shishen, DizhiRelation
 from src.utils import shensha_utils, tiangan_utils, dizhi_utils, bazi_utils
+from src.bazi import Bazi
 from src.bazi_chart import BaziChart
+from src.school import BaziConfig, BaziSchool, KeyStem
 from src.transits import TransitMoment, TransitOptions, TransitDatabase
 from src.analyzer.relationship import RelationshipAnalyzer, TransitAnalysis, ShenshaAnalysis, _REGISTRY
 
@@ -21,6 +23,9 @@ def test_at_birth_shensha() -> None:
 
     dm: Tiangan = chart.bazi.day_master
     y, m, d, h = chart.bazi.four_dizhis
+
+    # The 红艳 anchor stem follows the chart's school (查法锚干, issue #69) -- don't assume the day master.
+    anchor: Tiangan = dm if chart.bazi.config.school.hongyan_key is KeyStem.DAY_MASTER else chart.bazi.year_pillar.tiangan
 
     at_birth = analyzer.at_birth
 
@@ -37,7 +42,7 @@ def test_at_birth_shensha() -> None:
 
     # Hongyan / 红艳
     expected_hongyan: list[Dizhi] = []
-    for tg, dz in itertools.product([dm], [y, m, d, h]):
+    for tg, dz in itertools.product([anchor], [y, m, d, h]):
       if shensha_utils.hongyan(tg, dz):
         expected_hongyan.append(dz)
     assert at_birth.shensha['hongyan'] == set(expected_hongyan)
@@ -170,9 +175,12 @@ def test_transit_shensha() -> None:
     chart = BaziChart.random()
     db = TransitDatabase(chart)
 
-    dm = chart.bazi.day_master
     y_dz = chart.bazi.year_pillar.dizhi
     d_dz = chart.bazi.day_pillar.dizhi
+
+    # The 红艳 anchor stem follows the chart's school (查法锚干, issue #69) -- don't assume the day master.
+    anchor: Tiangan = (chart.bazi.day_master if chart.bazi.config.school.hongyan_key is KeyStem.DAY_MASTER
+                       else chart.bazi.year_pillar.tiangan)
 
     analyzer = RelationshipAnalyzer(chart)
     transits_analysis = analyzer.transits
@@ -198,7 +206,7 @@ def test_transit_shensha() -> None:
       # Hongyan / 红艳
       expected = []
       for dz in transit_dz:
-        if shensha_utils.hongyan(dm, dz):
+        if shensha_utils.hongyan(anchor, dz):
           expected.append(dz)
       assert actual['hongyan'] == set(expected)
 
@@ -224,6 +232,38 @@ def test_transit_shensha() -> None:
         if shensha_utils.yima(d_dz, dz):
           expected.append(dz)
       assert actual['yima'] == set(expected)
+
+
+# 红艳查法 variants (issue #69): `KeyStem` mounted on `BaziSchool.hongyan_key`; the analyzer
+# re-reads the anchor stem from the chart's school profile at evaluation time. The chart below
+# is the golden chart of `test_relationship_analysis.test_case1` (1984-04-01 11:08, male:
+# 甲子/丁卯/乙丑/壬午) -- the day master 乙 keys on 申 (absent from the chart), while the year
+# tiangan 甲 keys on 午 (the hour Dizhi), so the two 查法 answer differently on this chart.
+@pytest.mark.parametrize('key_stem, expected', [
+  (KeyStem.DAY_MASTER,  frozenset()),           # 日干乙 -> 申 (《三命通会》, the default): 申 not in 子卯丑午.
+  (KeyStem.YEAR_MASTER, frozenset({Dizhi.午})), # 年干甲 -> 午: the hour Dizhi matches.
+])
+def test_hongyan_key_variant_at_birth(key_stem: KeyStem, expected: frozenset[Dizhi]) -> None:
+  config: BaziConfig = BaziConfig(school=BaziSchool(hongyan_key=key_stem))
+  chart: BaziChart = BaziChart(Bazi.create('1984-04-01 11:08', 'male', config))
+  assert RelationshipAnalyzer(chart).at_birth.shensha['hongyan'] == expected
+
+  # The default school is DAY_MASTER -- the long-pinned behavior carries over unchanged.
+  if key_stem is KeyStem.DAY_MASTER:
+    default_chart: BaziChart = BaziChart(Bazi.create('1984-04-01 11:08', 'male'))
+    assert RelationshipAnalyzer(default_chart).at_birth.shensha['hongyan'] == expected
+
+
+@pytest.mark.parametrize('key_stem, expected', [
+  (KeyStem.DAY_MASTER,  frozenset()),           # 日干乙 -> 申: not among the 1990 transit Dizhis 辰/午.
+  (KeyStem.YEAR_MASTER, frozenset({Dizhi.午})), # 年干甲 -> 午: the 1990 流年 is 庚午.
+])
+def test_hongyan_key_variant_at_transits(key_stem: KeyStem, expected: frozenset[Dizhi]) -> None:
+  '''Same chart; the 1990 transits under DAYUN_LIUNIAN are 戊辰/庚午 (pinned in `test_case1`).'''
+  config: BaziConfig = BaziConfig(school=BaziSchool(hongyan_key=key_stem))
+  chart: BaziChart = BaziChart(Bazi.create('1984-04-01 11:08', 'male', config))
+  transits: TransitAnalysis = RelationshipAnalyzer(chart).transits
+  assert transits.shensha(1990, TransitOptions.DAYUN_LIUNIAN)['hongyan'] == expected
 
 
 @pytest.mark.slow

--- a/tests/integration/test_relationship_analysis.py
+++ b/tests/integration/test_relationship_analysis.py
@@ -12,6 +12,7 @@ from src.defines import Tiangan, Dizhi, Ganzhi, TianganRelation, DizhiRelation, 
 from src.utils import tiangan_utils, dizhi_utils, bazi_utils, shensha_utils
 from src.bazi import Bazi, BaziGender
 from src.bazi_chart import BaziChart
+from src.school import KeyStem
 from src.transits import TransitMoment, TransitOptions, TransitDatabase
 from src.analyzer.relationship import RelationshipAnalyzer, ShenshaAnalysis, TransitAnalysis, AtBirthAnalysis
 from src.rules import DizhiRules
@@ -489,6 +490,9 @@ def test_random_cases(bazi: Bazi) -> None:
   dm: Tiangan = bazi.day_master
   star: Shishen = Shishen.正财 if bazi.gender is BaziGender.MALE else Shishen.正官
 
+  # The 红艳 anchor stem follows the chart's school (查法锚干, issue #69) -- don't assume the day master.
+  hongyan_anchor: Tiangan = dm if bazi.config.school.hongyan_key is KeyStem.DAY_MASTER else bazi.year_pillar.tiangan
+
   assert star is bazi_utils.shishen(dm, chart.relationship_stars.tiangan)
   for star_dz in chart.relationship_stars.dizhi:
     assert star is bazi_utils.shishen(dm, star_dz)
@@ -509,7 +513,7 @@ def test_random_cases(bazi: Bazi) -> None:
         return shensha_utils.yima(y_dz, dz) or shensha_utils.yima(d_dz, dz)
 
       expected_taohua:   set[Dizhi] = set(filter(__taohua, transits_dz_set))
-      expected_hongyan:  set[Dizhi] = set(filter(lambda dz : shensha_utils.hongyan(dm, dz), transits_dz_set))
+      expected_hongyan:  set[Dizhi] = set(filter(lambda dz : shensha_utils.hongyan(hongyan_anchor, dz), transits_dz_set))
       expected_hongluan: set[Dizhi] = set(filter(lambda dz : shensha_utils.hongluan(y_dz, dz), transits_dz_set))
       expected_tianxi:   set[Dizhi] = set(filter(lambda dz : shensha_utils.tianxi(y_dz, dz), transits_dz_set))
       expected_yima:     set[Dizhi] = set(filter(__yima, transits_dz_set))


### PR DESCRIPTION
#69 第二弹(随 PR #119 的机制):红艳查法挂载 + 出处/措辞三件。随本 PR 合入,#69 的机制件与首批挂载全部落地;PR-1/PR-2 之间未发版(惰性旋钮纪律)。

## 内容

**c1 红艳查法挂载(9cf84f2,D-8)**:`_KeySource` registry 保留 DAY_MASTER 静态默认;评估期由 `_hongyan_anchor` 按 `bazi.config.school.hongyan_key` 覆盖(穷尽 switch + invariant guard,复刻 DayRollover 挂载形态;frozendict 常量不动)。`shensha_utils.hongyan` 签名泛化为 `key_tiangan`(锚干由调用方决定)。默认 DAY_MASTER 零变化。金样盘 1984-04-01 11:08 男(甲子/丁卯/乙丑/壬午):DAY_MASTER 红艳 ∅ / YEAR_MASTER 红艳 {午}(甲→午恰是时支),本命与流运两面都钉;slow/integration oracle 改从 school 推导锚干,不再无脑日干。

**c2 措辞三件(eb901b2)**:HONGYAN 标《三命通会》出处 + 异表(庚申/癸戌)未采理由;XingDef.LOOSE 补方向性(丑→戌→未→丑,实现与测试已锁);dayun_order 补传统年干表述与年支实现的数学恒等价注。命理措辞已经用户逐字过目。

**修复批(f392f0d)**:R1 两席独立撞中同一条——散文引文「甲乙逢午」自然读法 = 乙午,与表的歌诀谱系乙申分叉(问真八字即散文读法,integration 早有分歧钉)。用户拍板:引文保留 + 点明双谱系分叉(「散文本作乙午,此表从歌诀本乙申」),落实宪章「保留对立观点」。另:DAY_MASTER 枚举注记唯一消费者(防未来神煞误吃 hongyan 旋钮)、摘 utils 层向上指针。

## 审阅

grok 清单席:行为面未推翻(默认等价 41 盘对拍、金样独立复算、检出率注入双侧必红、transits 侧取出生盘 school 判正确),唯一实质发现即引文对读;kimi 风格席:同发现 + helper 收特例形态认可(对照 DayRollover 先例)+ 保留反例四件认证。

门禁 460 passed、coverage 100%、o_smoke 11/11。
