### PR TITLE
feat: #69 收尾单——AnheDef/XingDef 穿透 BaziSchool(机制面全落地)

### DIFF
--- a/src/analyzer/relationship.py
+++ b/src/analyzer/relationship.py
@@ -6,12 +6,12 @@ from dataclasses import dataclass
 from enum import Enum, IntFlag, auto, unique
 from itertools import product
 from typing import Final, TypedDict
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Sequence
 
 from ..common import frozendict
 from ..data_types import GanzhiData
 from ..defines import Tiangan, Dizhi, Shishen, DizhiRelation
-from ..school import KeyStem
+from ..school import KeyStem, BaziSchool
 from ..bazi import Bazi
 from ..bazi_chart import BaziChart
 from ..transits import TransitMoment, TransitOptions
@@ -124,6 +124,26 @@ def _eval_transits(spec: _ShenshaSpec, bazi: Bazi, transit_dizhis: Iterable[Dizh
   return frozenset(find_shensha(spec.predicate, (first_args, transit_dizhis)))
 
 
+# The ONLY place this file reads the school profile for Dizhi relation discovery:
+# every `dizhi_utils.search` / `discover` / `discover_mutual` call below goes through one
+# of these three wrappers, so "no bare calls in this file" is a grep-checkable invariant --
+# a forgotten `anhe_def=` / `xing_def=` at some call site would silently fall back to the
+# hardcoded defaults (issue #69).
+# 本文件唯一为地支关系查法读流派档案的地方：下面的 `dizhi_utils.search` / `discover` /
+# `discover_mutual` 调用一律走这三个薄包装——「本文件无裸调」是一条 grep 可验的不变量，
+# 某个调用点忘传参会静默回落到硬编码默认（issue #69）。
+def _dz_search(school: BaziSchool, dizhis: Sequence[Dizhi], relation: DizhiRelation) -> dizhi_utils.DizhiRelationCombos:
+  return dizhi_utils.search(dizhis, relation, anhe_def=school.anhe_def, xing_def=school.xing_def)
+
+
+def _dz_discover(school: BaziSchool, dizhis: Sequence[Dizhi]) -> dizhi_utils.DizhiRelationDiscovery:
+  return dizhi_utils.discover(dizhis, anhe_def=school.anhe_def, xing_def=school.xing_def)
+
+
+def _dz_discover_mutual(school: BaziSchool, dizhis1: Sequence[Dizhi], dizhis2: Sequence[Dizhi]) -> dizhi_utils.DizhiRelationDiscovery:
+  return dizhi_utils.discover_mutual(dizhis1, dizhis2, anhe_def=school.anhe_def, xing_def=school.xing_def)
+
+
 
 class ShenshaAnalysis(TypedDict):
   # The Taohua Dizhis   (桃花星所在地支)
@@ -167,7 +187,7 @@ class AtBirthAnalysis:
     #
     # With that being said, for AtBirth analysis, this problem doesn't exist.
     # Still use `discover` with `filter` though - it is expected to be equivalent to `discover_mutual([d_dz], [*other_three_dz])`
-    return dizhi_utils.discover(self._chart.bazi.four_dizhis).filter(
+    return _dz_discover(self._chart.bazi.config.school, self._chart.bazi.four_dizhis).filter(
       lambda _, combo : self._chart.house_of_relationship in combo
     )
   
@@ -177,7 +197,7 @@ class AtBirthAnalysis:
     stars = self._chart.relationship_stars
 
     tg = tiangan_utils.discover(self._chart.bazi.four_tiangans).filter(lambda _, combo : stars.tiangan in combo)
-    dz = dizhi_utils.discover(self._chart.bazi.four_dizhis).filter(lambda _, combo : any(dz in combo for dz in stars.dizhi))
+    dz = _dz_discover(self._chart.bazi.config.school, self._chart.bazi.four_dizhis).filter(lambda _, combo : any(dz in combo for dz in stars.dizhi))
     return GanzhiData(tg, dz)
 
 
@@ -263,7 +283,7 @@ class TransitAnalysis:
     house = self._chart.house_of_relationship
     bazi = self._chart.bazi
 
-    result = dizhi_utils.discover_mutual([house], transit_dizhis)
+    result = _dz_discover_mutual(bazi.config.school, [house], transit_dizhis)
 
     # Unlike Tiangan relations, Dizhi relation combos can contain up to 3 Dizhis.
     # So `discover_mutual([house], transit_dizhis)` may contain incomplete results.
@@ -280,8 +300,13 @@ class TransitAnalysis:
               return True
         return False
 
+      # The school params pass through for consistency, though `xing_def` is inert here:
+      # `__filter` keeps only 3-Dizhi combos, and STRICT vs LOOSE differ only in 2-Dizhi
+      # combos -- the two definitions coincide on `len == 3` results (issue #69).
+      # 流派参数照传以保持一致；`xing_def` 在此其实是惰性参数——`__filter` 只留三组合，
+      # 而 STRICT 与 LOOSE 之差全在二组合上，`len == 3` 的结果两定义等价（issue #69）。
       return dizhi_utils.DizhiRelationDiscovery({
-        rel : dizhi_utils.search(list(bazi.four_dizhis) + transit_dizhis, rel)
+        rel : _dz_search(bazi.config.school, list(bazi.four_dizhis) + transit_dizhis, rel)
       }).filter(__filter)
 
     result = result.merge(__discover(DizhiRelation.三合))
@@ -335,15 +360,16 @@ class TransitAnalysis:
 
     at_birth_tg = self._chart.bazi.four_tiangans
     at_birth_dz = self._chart.bazi.four_dizhis
+    school: Final[BaziSchool] = self._chart.bazi.config.school
 
     tg = tiangan_utils.TianganRelationDiscovery({})
     dz = dizhi_utils.DizhiRelationDiscovery({})
     if level & TransitAnalysis.Level.TRANSITS_ONLY:
       tg = tg.merge(tiangan_utils.discover(transit_tg))
-      dz = dz.merge(dizhi_utils.discover(transit_dz))
+      dz = dz.merge(_dz_discover(school, transit_dz))
     if level & TransitAnalysis.Level.MUTUAL:
       tg = tg.merge(tiangan_utils.discover_mutual(at_birth_tg, transit_tg))
-      dz = dz.merge(dizhi_utils.discover_mutual(at_birth_dz, transit_dz))
+      dz = dz.merge(_dz_discover_mutual(school, at_birth_dz, transit_dz))
 
     stars = self._chart.relationship_stars
     return GanzhiData(

--- a/src/analyzer/relationship.py
+++ b/src/analyzer/relationship.py
@@ -133,16 +133,18 @@ def _eval_transits(spec: _ShenshaSpec, bazi: Bazi, transit_dizhis: Iterable[Dizh
 # `discover_mutual` 调用一律走这三个薄包装——「本文件无裸调」是一条 grep 可验的不变量，
 # 某个调用点忘传参会静默回落到硬编码默认（issue #69）。
 def _dz_search(school: BaziSchool, dizhis: Sequence[Dizhi], relation: DizhiRelation) -> dizhi_utils.DizhiRelationCombos:
+  '''`dizhi_utils.search` under the chart's school profile / 按盘的流派档案查地支关系组合。'''
   return dizhi_utils.search(dizhis, relation, anhe_def=school.anhe_def, xing_def=school.xing_def)
 
 
 def _dz_discover(school: BaziSchool, dizhis: Sequence[Dizhi]) -> dizhi_utils.DizhiRelationDiscovery:
+  '''`dizhi_utils.discover` under the chart's school profile / 按盘的流派档案发现地支关系。'''
   return dizhi_utils.discover(dizhis, anhe_def=school.anhe_def, xing_def=school.xing_def)
 
 
 def _dz_discover_mutual(school: BaziSchool, dizhis1: Sequence[Dizhi], dizhis2: Sequence[Dizhi]) -> dizhi_utils.DizhiRelationDiscovery:
+  '''`dizhi_utils.discover_mutual` under the chart's school profile / 按盘的流派档案发现两组地支间的关系。'''
   return dizhi_utils.discover_mutual(dizhis1, dizhis2, anhe_def=school.anhe_def, xing_def=school.xing_def)
-
 
 
 class ShenshaAnalysis(TypedDict):
@@ -282,8 +284,9 @@ class TransitAnalysis:
 
     house = self._chart.house_of_relationship
     bazi = self._chart.bazi
+    school: Final[BaziSchool] = bazi.config.school
 
-    result = _dz_discover_mutual(bazi.config.school, [house], transit_dizhis)
+    result = _dz_discover_mutual(school, [house], transit_dizhis)
 
     # Unlike Tiangan relations, Dizhi relation combos can contain up to 3 Dizhis.
     # So `discover_mutual([house], transit_dizhis)` may contain incomplete results.
@@ -306,7 +309,7 @@ class TransitAnalysis:
       # 流派参数照传以保持一致；`xing_def` 在此其实是惰性参数——`__filter` 只留三组合，
       # 而 STRICT 与 LOOSE 之差全在二组合上，`len == 3` 的结果两定义等价（issue #69）。
       return dizhi_utils.DizhiRelationDiscovery({
-        rel : _dz_search(bazi.config.school, list(bazi.four_dizhis) + transit_dizhis, rel)
+        rel : _dz_search(school, list(bazi.four_dizhis) + transit_dizhis, rel)
       }).filter(__filter)
 
     result = result.merge(__discover(DizhiRelation.三合))

--- a/src/bazi_chart.py
+++ b/src/bazi_chart.py
@@ -68,7 +68,7 @@ class BaziJson:
 
   class School(TypedDict):
     '''Not expected to be accessed directly. Used in `BaziChartJsonDict`. The school
-    profile (流派档案), serialized as the member name of each variant knob.
+    profile (流派档案), serialized as the member name of each school reading.
     流派档案：每项流派看法各存其枚举成员名。'''
     day_rollover: str
     hongyan_key: str

--- a/src/bazi_chart.py
+++ b/src/bazi_chart.py
@@ -69,9 +69,11 @@ class BaziJson:
   class School(TypedDict):
     '''Not expected to be accessed directly. Used in `BaziChartJsonDict`. The school
     profile (流派档案), serialized as the member name of each variant knob.
-    流派档案：每个分歧旋钮各存其枚举成员名。'''
+    流派档案：每项流派看法各存其枚举成员名。'''
     day_rollover: str
     hongyan_key: str
+    anhe_def: str
+    xing_def: str
 
   class BaziChartJsonDict(TypedDict):
     birth_time: str
@@ -457,6 +459,8 @@ class BaziChart:
       'school': {
         'day_rollover': self._bazi.config.school.day_rollover.name,
         'hongyan_key': self._bazi.config.school.hongyan_key.name,
+        'anhe_def': self._bazi.config.school.anhe_def.name,
+        'xing_def': self._bazi.config.school.xing_def.name,
       },
       'pillars': f([str(p) for p in self._bazi.pillars]),
       'nayin': f([str(ny) for ny in self.nayin]),

--- a/src/rules.py
+++ b/src/rules.py
@@ -290,14 +290,14 @@ class DizhiRules:
     This knob is declared per chart via `BaziSchool.anhe_def` and read at evaluation time
     by relation discovery (`analyzer/relationship.py`); member names are serialized into JSON.
     本旋钮由 `BaziSchool.anhe_def` 按盘声明，关系查法在评估期读取；成员名进 JSON。
+
+    No change should be made to the existing definitions. Only add new definitions.
     '''
     NORMAL           = 0 # 卯申、巳酉、亥午、子巳、寅午 - 这也是所谓的“通禄合”/“通禄暗合”，与天干五合一一对应。
                          # 选 NORMAL 时 `DIZHI_ANHE[NORMAL]` 与 `DIZHI_TONGLUHE` 逐项相同——discovery 会在
                          # 暗合与通禄合两个键下给出相同组合，那是同一证据，不是两条独立证据。
     NORMAL_EXTENDED  = 1 # 卯申、巳酉、亥午、子巳、寅午 + 寅丑。这六组的藏干没有明显的冲突，而且有藏干相合的关系。
     MANGPAI          = 2 # 卯申、寅丑、午亥。盲派最认可这三对暗合。
-    # No change should be made to the existing definitions.
-    # Only add new definitions.
 
   # The tables are used to query the ANHE (暗合) relation across all Dizhis.
   # ANHE relation is a non-directional/mutual relation.

--- a/src/rules.py
+++ b/src/rules.py
@@ -382,12 +382,10 @@ class DizhiRules:
     - Definition layer (holds at every query entry): STRICT requires all three Dizhis of
       丑未戌 / 寅巳申 to appear; LOOSE requires any two of the three.
       定义层（各查法入口共有）：STRICT 要求丑未戌 / 寅巳申三支齐现；LOOSE 三取二即成立。
-    - Entry layer: direction (谁刑谁, following the cycles 丑->戌->未->丑 / 寅->巳->申->寅)
-      is only observable in order-exact lookups like `dizhi_utils.xing`; the batch entries
-      `search` / `discover` compare as multisets, where direction is unobservable and LOOSE
-      means exactly "any two of the three".
-      入口层：方向（谁刑谁）只在 `dizhi_utils.xing` 这类按序精确匹配的查法里可观测；
-      批量入口 `search` / `discover` 按多重集比对，方向不可观测，LOOSE 在那里就等于「三取二」。
+    - Entry layer: only order-exact lookups (`dizhi_utils.xing`) see the direction (谁刑谁);
+      the batch entries `search` / `discover` compare as multisets and cannot.
+      入口层：方向（谁刑谁）只有按序查法（`dizhi_utils.xing`）可见；
+      批量入口（`search` / `discover`）按多重集比对，看不出方向。
 
     This knob is declared per chart via `BaziSchool.xing_def` and read at evaluation time
     by relation discovery (`analyzer/relationship.py`); member names are serialized into JSON.

--- a/src/rules.py
+++ b/src/rules.py
@@ -281,8 +281,19 @@ class DizhiRules:
     '''
     The definitions of ANHE relation. Different definitions mean different query tables.
     不同的地支暗合关系看法。
+
+    ANHE is non-directional, so every query entry (`anhe` / `search` / `discover`) sees the
+    same table per definition -- there is no entry-layer divergence like `XingDef`'s.
+    暗合无方向，各查法入口（`anhe` / `search` / `discover`）看到的表一致——无 `XingDef`
+    那种入口层分歧。
+
+    This knob is declared per chart via `BaziSchool.anhe_def` and read at evaluation time
+    by relation discovery (`analyzer/relationship.py`); member names are serialized into JSON.
+    本旋钮由 `BaziSchool.anhe_def` 按盘声明，关系查法在评估期读取；成员名进 JSON。
     '''
     NORMAL           = 0 # 卯申、巳酉、亥午、子巳、寅午 - 这也是所谓的“通禄合”/“通禄暗合”，与天干五合一一对应。
+                         # 选 NORMAL 时 `DIZHI_ANHE[NORMAL]` 与 `DIZHI_TONGLUHE` 逐项相同——discovery 会在
+                         # 暗合与通禄合两个键下给出相同组合，那是同一证据，不是两条独立证据。
     NORMAL_EXTENDED  = 1 # 卯申、巳酉、亥午、子巳、寅午 + 寅丑。这六组的藏干没有明显的冲突，而且有藏干相合的关系。
     MANGPAI          = 2 # 卯申、寅丑、午亥。盲派最认可这三对暗合。
     # No change should be made to the existing definitions.
@@ -367,11 +378,28 @@ class DizhiRules:
     '''
     The definitions of XING relation. This makes a difference on two combos - 丑未戌、寅巳申。
     不同的地支相刑的看法。主要区别在于丑未戌、寅巳申之间相刑的定义。
+
+    - Definition layer (holds at every query entry): STRICT requires all three Dizhis of
+      丑未戌 / 寅巳申 to appear; LOOSE requires any two of the three.
+      定义层（各查法入口共有）：STRICT 要求丑未戌 / 寅巳申三支齐现；LOOSE 三取二即成立。
+    - Entry layer: direction (谁刑谁, following the cycles 丑->戌->未->丑 / 寅->巳->申->寅)
+      is only observable in order-exact lookups like `dizhi_utils.xing`; the batch entries
+      `search` / `discover` compare as multisets, where direction is unobservable and LOOSE
+      means exactly "any two of the three".
+      入口层：方向（谁刑谁）只在 `dizhi_utils.xing` 这类按序精确匹配的查法里可观测；
+      批量入口 `search` / `discover` 按多重集比对，方向不可观测，LOOSE 在那里就等于「三取二」。
+
+    This knob is declared per chart via `BaziSchool.xing_def` and read at evaluation time
+    by relation discovery (`analyzer/relationship.py`); member names are serialized into JSON.
+    本旋钮由 `BaziSchool.xing_def` 按盘声明，关系查法在评估期读取；成员名进 JSON。
+
+    No change should be made to the existing definitions. Only add new definitions.
     '''
     STRICT = 0 # For 丑未戌 and 寅巳申, a XING relation is formed only when all three Dizhis appear.
-    LOOSE  = 1 # For 丑未戌 and 寅巳申, a XING relation is formed if any two of the three Dizhis appear --
-               # directionally, following the cycle 丑->戌->未->丑 / 寅->巳->申->寅: (丑,戌) forms XING
-               # while (戌,丑) does not. The direction is locked in by the implementation and `test_dizhi_utils`.
+    LOOSE  = 1 # For 丑未戌 and 寅巳申, any two of the three suffice. In order-exact lookups
+               # (`dizhi_utils.xing`) the pair must also follow the cycle direction
+               # 丑->戌->未->丑 / 寅->巳->申->寅: (丑,戌) forms XING while (戌,丑) does not.
+               # The direction is locked in by the implementation and `test_dizhi_utils`.
 
   class XingSubType(Enum):
     SANXING   = 0 # 丑未戌、寅巳申三刑

--- a/src/school.py
+++ b/src/school.py
@@ -1,7 +1,8 @@
 # Copyright (C) 2026 Ningqi Wang (0xf3cd) <https://github.com/0xf3cd>
 
-'''The home of the chart-level configuration: `BaziConfig` (every knob steering chart
-computation), the school-divergence knobs (`BaziSchool` / `DayRollover` / `KeyStem`), and `BaziPrecision`.'''
+'''The home of the chart-level configuration: `BaziConfig` (computation knobs plus the
+school profile), the school-divergence declarations (`BaziSchool` / `DayRollover` / `KeyStem`),
+and `BaziPrecision`.'''
 
 from enum import Enum
 from dataclasses import dataclass
@@ -127,16 +128,16 @@ class BaziSchool:
   '''
   The school (流派) profile of a chart: the value each variant knob takes where schools
   disagree. The profile only declares -- it computes nothing. Whoever needs a knob reads
-  it at its own time: `day_rollover` steers the day pillar when the chart is computed,
+  it at its own stage: `day_rollover` steers the day pillar when the chart is computed,
   the rest are read at evaluation time (神煞 lookups, relation discovery). Every field
   feeds `__eq__` / `__hash__` / JSON, so two charts differing only in a knob are two charts.
-  命盘的流派档案：本盘在各流派分歧处所取的看法。档案只声明、不演算——谁要哪个口径，谁在自己的时机
+  命盘的流派档案：本盘在各流派分歧处所取的看法。档案只声明、不演算——谁要哪个口径，谁在自己的阶段
   读它：`day_rollover` 在排盘期决定日柱，其余在评估期读（神煞查法、关系查法）。每个字段
   都进相等性 / 哈希 / JSON，只差一个旋钮的两张盘就是两张盘。
 
-  Out of scope: `precision` / `backend` (chart computation knobs, not school divergences)
+  Not here: `precision` / `backend` (chart computation knobs, not school divergences)
   and gender -- see `BaziConfig`.
-  不管的：`precision` / `backend`（算路，不是流派）与性别——见 `BaziConfig`。
+  不在此：`precision` / `backend`（算路，不是流派）与性别——见 `BaziConfig`。
 
   Fields must stay immutable types (enums / frozen value types) -- no `dict` / `list`
   defaults, so a shared default instance can never be mutated through.

--- a/src/school.py
+++ b/src/school.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from typing import Final
 
 from .calendar import CalendarBackend
+from .rules import DizhiRules
 
 
 class BaziPrecision(Enum):
@@ -124,9 +125,18 @@ class KeyStem(Enum):
 @dataclass(frozen=True)
 class BaziSchool:
   '''
-  The school (流派) profile of a chart: the variant knobs where schools disagree.
-  Immutable; a chart carries one profile end to end.
-  命盘的流派档案：各流派分歧旋钮的取值。不可变；一张盘从头到尾持有一份。
+  The school (流派) profile of a chart: the value each variant knob takes where schools
+  disagree. The profile only declares -- it computes nothing. Whoever needs a knob reads
+  it at its own time: `day_rollover` steers the day pillar when the chart is computed,
+  the rest are read at evaluation time (神煞 lookups, relation discovery). Every field
+  feeds `__eq__` / `__hash__` / JSON, so two charts differing only in a knob are two charts.
+  命盘的流派档案：本盘在各流派分歧处所取的看法。档案只声明、不演算——谁要哪个口径，谁在自己的时机
+  读它：`day_rollover` 在排盘期决定日柱，其余在评估期读（神煞查法、关系查法）。每个字段
+  都进相等性 / 哈希 / JSON，只差一个旋钮的两张盘就是两张盘。
+
+  Out of scope: `precision` / `backend` (chart computation knobs, not school divergences)
+  and gender -- see `BaziConfig`.
+  不管的：`precision` / `backend`（算路，不是流派）与性别——见 `BaziConfig`。
 
   Fields must stay immutable types (enums / frozen value types) -- no `dict` / `list`
   defaults, so a shared default instance can never be mutated through.
@@ -136,12 +146,13 @@ class BaziSchool:
   `DEFAULT_SCHOOL` picks them up, and `BaziConfig.school` points at that same instance --
   the defaults are written down exactly once.
   默认流派只在字段默认值处定义一次；`DEFAULT_SCHOOL` 构造即默认，`BaziConfig.school` 指向同一实例。
-
-  `hongyan_key` steers the 红艳 lookup in relationship analysis (read at evaluation time);
-  it does not move the four pillars. `hongyan_key` 决定红艳查法的锚干（评估期读取）；四柱不随它动。
   '''
   day_rollover: DayRollover = DayRollover.WAN_ZISHI
   hongyan_key:  KeyStem     = KeyStem.DAY_MASTER
+  # The 暗合/刑 definition enums live with their tables in `DizhiRules`; only referenced here.
+  # 暗合/刑的定义枚举与它们的表同住 `DizhiRules`，这里只引用。
+  anhe_def:     DizhiRules.AnheDef = DizhiRules.AnheDef.NORMAL_EXTENDED
+  xing_def:     DizhiRules.XingDef = DizhiRules.XingDef.LOOSE
 
   def __post_init__(self) -> None:
     # Type check at runtime (same shape as `CalendarDate`).
@@ -149,20 +160,26 @@ class BaziSchool:
       raise TypeError(f'Expected DayRollover, got {type(self.day_rollover)}')
     if not isinstance(self.hongyan_key, KeyStem):
       raise TypeError(f'Expected KeyStem, got {type(self.hongyan_key)}')
+    if not isinstance(self.anhe_def, DizhiRules.AnheDef):
+      raise TypeError(f'Expected AnheDef, got {type(self.anhe_def)}')
+    if not isinstance(self.xing_def, DizhiRules.XingDef):
+      raise TypeError(f'Expected XingDef, got {type(self.xing_def)}')
 
 
-'''The default school profile: 晚子时换日 + 红艳以日干为锚 (《三命通会》). / 默认流派档案：晚子时换日、红艳查日干。'''
+'''The default school profile: 晚子时换日 + 红艳以日干为锚 (《三命通会》) + 暗合 NORMAL_EXTENDED
++ 刑 LOOSE (现状多数派口径). / 默认流派档案：晚子时换日、红艳查日干、暗合最宽表、刑三取二。'''
 DEFAULT_SCHOOL: Final[BaziSchool] = BaziSchool()
 
 
 @dataclass(frozen=True)
 class BaziConfig:
   '''
-  The chart-level configuration of a `Bazi`: every knob that affects what the chart
-  computes, carried as one immutable value. A `Bazi` stores its `BaziConfig`, and the
+  The chart-level configuration of a `Bazi`: the knobs steering chart computation
+  (`precision` / `backend`) plus the school profile (流派档案, which evaluation-time
+  lookups read), carried as one immutable value. A `Bazi` stores its `BaziConfig`, and the
   config feeds `__eq__` / `__hash__` / JSON as a unit (same precedent as `backend`).
-  命盘级配置：凡影响盘面演算的旋钮聚合为一个不可变值。`Bazi` 持有它，
-  相等性 / 哈希 / JSON 都以它为单位进出（同 `backend` 先例）。
+  命盘级配置：排盘算路旋钮（`precision` / `backend`）加流派档案（评估期查法读取），
+  聚合为一个不可变值。`Bazi` 持有它，相等性 / 哈希 / JSON 都以它为单位进出（同 `backend` 先例）。
 
   - precision: (BaziPrecision) The precision of the birth time / 出生时间精度。
   - backend: (CalendarBackend) The calendar backend for all calendar conversions / 历法后端。

--- a/src/utils/dizhi_utils.py
+++ b/src/utils/dizhi_utils.py
@@ -442,7 +442,7 @@ def search(dizhis: Sequence[Dizhi], relation: DizhiRelation, *,
   - For XING relation, it's a bit more complicated.
     - Some definitions require all the Dizhis to appear in order to qualify the SANXING (三刑) relation (a subset of XING).
     - Some definitions consider only two Dizhis appearing a valid XING relation (e.g. only 丑 and 未 can form a XING relation).
-    - In this method, for 丑未戌 and 寅巳申 SANXING, it is required that any two of the three to present in order to qualify the XING relation.
+    - Which definition applies is chosen by `xing_def`; under the default `XingDef.LOOSE`, any two of 丑未戌 / 寅巳申 suffice (see the `xing_def` Note below).
     - Use `xing` to do more fine-grained checking.
   - 返回的 combos 中没有体现关系作用的方向。
   - 比如说，如果检查输入地支的相生关系并返回 ({午, 寅})，那么不能从返回结果中看出是寅生午还是午生寅。
@@ -452,7 +452,7 @@ def search(dizhis: Sequence[Dizhi], relation: DizhiRelation, *,
     - 对于辰午酉亥自刑，只需要同时出现两次就满足相刑关系。
     - 对于子卯相刑，只需要子、卯都出现就满足相刑关系。
     - 对于丑未戌、寅巳申三刑，有的看法认为需要三个地支同时出现才算刑，有的看法认为只需要出现两个也算相刑。
-    - 本方法的实现中，对于丑未戌、寅巳申三刑，只需要同时出现两个地支就算相刑。
+    - 用哪个定义由 `xing_def` 决定；默认 `XingDef.LOOSE` 下，丑未戌、寅巳申三取二即算（见下方 `xing_def` 注）。
     - 请使用 `xing` 来进行更细粒度的检查。
 
   Note:
@@ -487,7 +487,7 @@ def search(dizhis: Sequence[Dizhi], relation: DizhiRelation, *,
     - return: ({Dizhi.寅, Dizhi.卯, Dizhi.辰})
   - search([Dizhi.寅, Dizhi.卯, Dizhi.丑, Dizhi.午, Dizhi.申], DizhiRelation.暗合)
     - return: ({ Dizhi.卯, Dizhi.申}, { Dizhi.寅, Dizhi.午}, { Dizhi.寅, Dizhi.丑})
-    - `DizhiRules.AnheDef.NORMAL_EXTENDED` is used.
+    - The default `DizhiRules.AnheDef.NORMAL_EXTENDED` is used.
   - search([Dizhi.寅,Dizhi.巳, Dizhi.申, Dizhi.辰], DizhiRelation.刑)
     - return: ({ Dizhi.寅, Dizhi.巳, Dizhi.申 }, { Dizhi.寅, Dizhi.巳 }, { Dizhi.巳, Dizhi.申 }, { Dizhi.寅, Dizhi.申 })
     - Only one 辰 appears in the input - not forming a XING relation.
@@ -496,7 +496,7 @@ def search(dizhis: Sequence[Dizhi], relation: DizhiRelation, *,
     - 辰 appear twice in the input - forming a XING relation.
   - search([Dizhi.卯, Dizhi.子, Dizhi.寅, Dizhi.巳], DizhiRelation.刑)
     - return: ({ Dizhi.子, Dizhi.卯}, { Dizhi.寅, Dizhi.巳 })
-    - `DizhiRules.XingDef.LOOSE` is used.
+    - The default `DizhiRules.XingDef.LOOSE` is used.
   '''
 
   if not isinstance(relation, DizhiRelation):
@@ -555,13 +555,9 @@ def discover(dizhis: Sequence[Dizhi], *,
   - 返回的字典的键中可能不包含所有的 `DizhiRelation`。
 
   Note:
-  - For XING relation, the `xing_def` parameter picks the table (default `XingDef.LOOSE`);
-    for ANHE relation, the `anhe_def` parameter (default `AnheDef.NORMAL_EXTENDED`).
-    Charts declare these school readings via `BaziSchool` -- see `search` for what the
-    parameters mean at this batch entry (direction is unobservable here).
-  - 刑表由 `xing_def` 选择（默认 `XingDef.LOOSE`），暗合表由 `anhe_def` 选择
-    （默认 `AnheDef.NORMAL_EXTENDED`）。盘级流派口径经 `BaziSchool` 声明；
-    参数在批量入口下的含义见 `search`（方向在此不可观测）。
+  - `anhe_def` / `xing_def` are forwarded to `search` -- defaults, table picking, and
+    batch-entry semantics (direction unobservable): see `search`.
+  - 参数原样转给 `search`——默认值、选表、批量入口语义（方向不可观测）：见 `search`。
 
   Args:
   - dizhis: (Sequence[Dizhi]) The Dizhis to check.
@@ -600,13 +596,9 @@ def discover_mutual(dizhis1: Sequence[Dizhi], dizhis2: Sequence[Dizhi], *,
   - 返回的字典的键中可能不包含所有的 `DizhiRelation`。
 
   Note:
-  - For XING relation, the `xing_def` parameter picks the table (default `XingDef.LOOSE`);
-    for ANHE relation, the `anhe_def` parameter (default `AnheDef.NORMAL_EXTENDED`).
-    Charts declare these school readings via `BaziSchool` -- see `search` for what the
-    parameters mean at this batch entry (direction is unobservable here).
-  - 刑表由 `xing_def` 选择（默认 `XingDef.LOOSE`），暗合表由 `anhe_def` 选择
-    （默认 `AnheDef.NORMAL_EXTENDED`）。盘级流派口径经 `BaziSchool` 声明；
-    参数在批量入口下的含义见 `search`（方向在此不可观测）。
+  - `anhe_def` / `xing_def` are forwarded to `search` -- defaults, table picking, and
+    batch-entry semantics (direction unobservable): see `search`.
+  - 参数原样转给 `search`——默认值、选表、批量入口语义（方向不可观测）：见 `search`。
 
   Args:
   - dizhis1: (Sequence[Dizhi]) The first set of Dizhis to check.

--- a/src/utils/dizhi_utils.py
+++ b/src/utils/dizhi_utils.py
@@ -408,16 +408,15 @@ def ke(dz1: Dizhi, dz2: Dizhi) -> bool:
   return (dz1, dz2) in DizhiRules.DIZHI_KE
 
 
-# The subset-style relations `search` supports, mapped to their combo tables (暗合
-# pre-resolves the widest `AnheDef.NORMAL_EXTENDED` definition at build time). Tables are
+# The subset-style relations `search` supports, mapped to their combo tables. 暗合 is NOT
+# here: its table is picked by the `anhe_def` parameter at query time. Tables are
 # stored as-is -- wrapping the mapping tables in `frozenset` would trade their stable
 # definition-order iteration for per-process hash order.
-# `search` 支持的子集型关系与其组合表（暗合建表时预解最宽的 `NORMAL_EXTENDED` 定义）。
+# `search` 支持的子集型关系与其组合表（暗合不在此列——它的表在查询期按 `anhe_def` 参数选择）。
 # 表原样存放——若包一层 `frozenset`，映射表稳定的定义序迭代会退化成逐进程哈希序。
 _SUBSET_SEARCH_COMBOS: Final[frozendict[DizhiRelation, Collection[DizhiCombo]]] = frozendict({
   DizhiRelation.三会:  DizhiRules.DIZHI_SANHUI,
   DizhiRelation.六合:  DizhiRules.DIZHI_LIUHE,
-  DizhiRelation.暗合:  DizhiRules.DIZHI_ANHE[DizhiRules.AnheDef.NORMAL_EXTENDED],
   DizhiRelation.通合:  DizhiRules.DIZHI_TONGHE,
   DizhiRelation.通禄合: DizhiRules.DIZHI_TONGLUHE,
   DizhiRelation.三合:  DizhiRules.DIZHI_SANHE,
@@ -428,7 +427,9 @@ _SUBSET_SEARCH_COMBOS: Final[frozendict[DizhiRelation, Collection[DizhiCombo]]] 
 })
 
 
-def search(dizhis: Sequence[Dizhi], relation: DizhiRelation) -> DizhiRelationCombos:
+def search(dizhis: Sequence[Dizhi], relation: DizhiRelation, *,
+           anhe_def: DizhiRules.AnheDef = DizhiRules.AnheDef.NORMAL_EXTENDED,
+           xing_def: DizhiRules.XingDef = DizhiRules.XingDef.LOOSE) -> DizhiRelationCombos:
   '''
   Find all possible Dizhi combos in the given `dizhis` that satisfy the `relation`.
   返回`dizhis`中所有满足该关系的组合。
@@ -455,19 +456,29 @@ def search(dizhis: Sequence[Dizhi], relation: DizhiRelation) -> DizhiRelationCom
     - 请使用 `xing` 来进行更细粒度的检查。
 
   Note:
-  - For ANHE relation, the `DizhiRules.AnheDef.NORMAL_EXTENDED` definition is used, as it is the widest definition.
-  - 对于暗合关系的查询，默认使用 `DizhiRules.AnheDef.NORMAL_EXTENDED` 定义，因为它包含最多的暗合地支组合。
+  - For ANHE relation, the `anhe_def` parameter picks the table; it defaults to
+    `DizhiRules.AnheDef.NORMAL_EXTENDED`, the widest definition. Charts declare this
+    school reading via `BaziSchool.anhe_def`.
+  - 暗合查询的表由 `anhe_def` 参数选择，默认 `DizhiRules.AnheDef.NORMAL_EXTENDED`（最宽定义）。
+    盘级流派口径经 `BaziSchool.anhe_def` 声明。
 
   Note:
-  - For XING relation, `DizhiRules.XingDef.LOOSE` definition is used.
+  - For XING relation, the `xing_def` parameter picks the table; it defaults to
+    `DizhiRules.XingDef.LOOSE`. This is a batch entry: combos are compared as multisets,
+    so direction (谁刑谁) is unobservable here -- `LOOSE` at this entry means exactly
+    "any two of the three". Use `xing` for direction-aware checks (see `XingDef`'s docstring).
   - e.g., if only 丑 and 未 appear in the input, the XING relation is considered satisfied (戌 missing, but `LOOSE` definition only requires any two of the three).
-  - 对于刑关系，默认使用 `DizhiRules.XingDef.LOOSE` 定义。
+  - 刑查询的表由 `xing_def` 参数选择，默认 `DizhiRules.XingDef.LOOSE`。本入口是批量查法：
+    组合按多重集比对，方向（谁刑谁）不可观测——`LOOSE` 在此就等于「三取二」。
+    要看方向请用 `xing`（见 `XingDef` 的 docstring）。
   - 举例来说，即使输入中只有丑、未，也符合相刑关系（缺少戌，但 `LOOSE` 定义只要求三个地支中出现两个）。
 
   Args:
   - dizhis: (Sequence[Dizhi]) The Dizhis to check. A sequence rather than a set --
     the frequency of Dizhis matters.
   - relation: (DizhiRelation) The relation to check.
+  - anhe_def: (DizhiRules.AnheDef) The ANHE definition; only consulted for 暗合 queries.
+  - xing_def: (DizhiRules.XingDef) The XING definition; only consulted for 刑 queries.
 
   Return: (DizhiRelationCombos) The result containing all matching Dizhi combos.
 
@@ -494,6 +505,10 @@ def search(dizhis: Sequence[Dizhi], relation: DizhiRelation) -> DizhiRelationCom
     raise TypeError(f'Expected a Sequence, got {type(dizhis)}')
   if not all(isinstance(dz, Dizhi) for dz in dizhis):
     raise TypeError(f'Expected all Dizhi, got {[type(dz) for dz in dizhis]}')
+  if not isinstance(anhe_def, DizhiRules.AnheDef):
+    raise TypeError(f'Expected AnheDef, got {type(anhe_def)}')
+  if not isinstance(xing_def, DizhiRules.XingDef):
+    raise TypeError(f'Expected XingDef, got {type(xing_def)}')
 
   if relation is DizhiRelation.刑:
     # Multiset-sensitive, so plain subset tests don't apply: 自刑 needs the same Dizhi twice.
@@ -501,7 +516,7 @@ def search(dizhis: Sequence[Dizhi], relation: DizhiRelation) -> DizhiRelationCom
     dz_counter: Counter[Dizhi] = Counter(dizhis)
 
     ret: set[DizhiCombo] = set()
-    for xing_tuple in DizhiRules.DIZHI_XING[DizhiRules.XingDef.LOOSE]:
+    for xing_tuple in DizhiRules.DIZHI_XING[xing_def]:
       xing_dz_counter: Counter[Dizhi] = Counter(xing_tuple)
       if dz_counter & xing_dz_counter == xing_dz_counter:
         ret.add(DizhiCombo(xing_tuple))
@@ -517,11 +532,17 @@ def search(dizhis: Sequence[Dizhi], relation: DizhiRelation) -> DizhiRelationCom
     return DizhiRelationCombos(combo for combo in pair_combos if combo.issubset(dz_set))
 
   # Every other relation shares one shape: keep the table combos fully present in the input.
-  # 其余关系同构：保留完整出现在输入中的组合。
-  return DizhiRelationCombos(combo for combo in _SUBSET_SEARCH_COMBOS[relation] if combo.issubset(dizhis))
+  # 暗合's table is picked by `anhe_def` at query time; the rest resolve statically.
+  # 其余关系同构：保留完整出现在输入中的组合。暗合的表在查询期按 `anhe_def` 选，其余静态解析。
+  combos: Collection[DizhiCombo] = (
+    DizhiRules.DIZHI_ANHE[anhe_def] if relation is DizhiRelation.暗合 else _SUBSET_SEARCH_COMBOS[relation]
+  )
+  return DizhiRelationCombos(combo for combo in combos if combo.issubset(dizhis))
 
 
-def discover(dizhis: Sequence[Dizhi]) -> DizhiRelationDiscovery:
+def discover(dizhis: Sequence[Dizhi], *,
+             anhe_def: DizhiRules.AnheDef = DizhiRules.AnheDef.NORMAL_EXTENDED,
+             xing_def: DizhiRules.XingDef = DizhiRules.XingDef.LOOSE) -> DizhiRelationDiscovery:
   '''
   Discover all possible Dizhi combos of all `DizhiRelation`s (SANHUI, LIUHE, XING...) in the given `dizhis`.
   This method further invokes `search`.
@@ -534,25 +555,38 @@ def discover(dizhis: Sequence[Dizhi]) -> DizhiRelationDiscovery:
   - 返回的字典的键中可能不包含所有的 `DizhiRelation`。
 
   Note:
-  - For XING relation, `XingDef.LOOSE` is used; For ANHE relation, `AnheDef.NORMAL_EXTENDED` is used.
-  - 对于相刑的关系，使用 `XingDef.LOOSE` 模式。对于暗合的关系，使用 `AnheDef.NORMAL_EXTENDED` 模式。
+  - For XING relation, the `xing_def` parameter picks the table (default `XingDef.LOOSE`);
+    for ANHE relation, the `anhe_def` parameter (default `AnheDef.NORMAL_EXTENDED`).
+    Charts declare these school readings via `BaziSchool` -- see `search` for what the
+    parameters mean at this batch entry (direction is unobservable here).
+  - 刑表由 `xing_def` 选择（默认 `XingDef.LOOSE`），暗合表由 `anhe_def` 选择
+    （默认 `AnheDef.NORMAL_EXTENDED`）。盘级流派口径经 `BaziSchool` 声明；
+    参数在批量入口下的含义见 `search`（方向在此不可观测）。
 
   Args:
   - dizhis: (Sequence[Dizhi]) The Dizhis to check.
+  - anhe_def: (DizhiRules.AnheDef) The ANHE definition, forwarded to `search`.
+  - xing_def: (DizhiRules.XingDef) The XING definition, forwarded to `search`.
 
   Return: (DizhiRelationDiscovery) The result containing all matching Dizhi combos. Note that returned combos don't reveal the directions.
   '''
 
   if not all(isinstance(dz, Dizhi) for dz in dizhis):
     raise TypeError(f'Expected all Dizhi, got {[type(dz) for dz in dizhis]}')
+  if not isinstance(anhe_def, DizhiRules.AnheDef):
+    raise TypeError(f'Expected AnheDef, got {type(anhe_def)}')
+  if not isinstance(xing_def, DizhiRules.XingDef):
+    raise TypeError(f'Expected XingDef, got {type(xing_def)}')
   return DizhiRelationDiscovery({
     rel : result
     for rel in DizhiRelation
-    if len(result := search(dizhis, rel)) > 0
+    if len(result := search(dizhis, rel, anhe_def=anhe_def, xing_def=xing_def)) > 0
   })
 
 
-def discover_mutual(dizhis1: Sequence[Dizhi], dizhis2: Sequence[Dizhi]) -> DizhiRelationDiscovery:
+def discover_mutual(dizhis1: Sequence[Dizhi], dizhis2: Sequence[Dizhi], *,
+                    anhe_def: DizhiRules.AnheDef = DizhiRules.AnheDef.NORMAL_EXTENDED,
+                    xing_def: DizhiRules.XingDef = DizhiRules.XingDef.LOOSE) -> DizhiRelationDiscovery:
   '''
   Discover all possible Dizhi combos of all `DizhiRelation`s (SANHUI, LIUHE, XING...) among the given `dizhis1` and `dizhis2`.
   Note that it is required that the Dizhis in a returned combo come from both `dizhis1` and `dizhis2`, which means
@@ -566,12 +600,19 @@ def discover_mutual(dizhis1: Sequence[Dizhi], dizhis2: Sequence[Dizhi]) -> Dizhi
   - 返回的字典的键中可能不包含所有的 `DizhiRelation`。
 
   Note:
-  - For XING relation, `XingDef.LOOSE` is used; For ANHE relation, `AnheDef.NORMAL_EXTENDED` is used.
-  - 对于相刑的关系，使用 `XingDef.LOOSE` 模式。对于暗合的关系，使用 `AnheDef.NORMAL_EXTENDED` 模式。
+  - For XING relation, the `xing_def` parameter picks the table (default `XingDef.LOOSE`);
+    for ANHE relation, the `anhe_def` parameter (default `AnheDef.NORMAL_EXTENDED`).
+    Charts declare these school readings via `BaziSchool` -- see `search` for what the
+    parameters mean at this batch entry (direction is unobservable here).
+  - 刑表由 `xing_def` 选择（默认 `XingDef.LOOSE`），暗合表由 `anhe_def` 选择
+    （默认 `AnheDef.NORMAL_EXTENDED`）。盘级流派口径经 `BaziSchool` 声明；
+    参数在批量入口下的含义见 `search`（方向在此不可观测）。
 
   Args:
   - dizhis1: (Sequence[Dizhi]) The first set of Dizhis to check.
   - dizhis2: (Sequence[Dizhi]) The second set of Dizhis to check.
+  - anhe_def: (DizhiRules.AnheDef) The ANHE definition, forwarded to `search`.
+  - xing_def: (DizhiRules.XingDef) The XING definition, forwarded to `search`.
 
   Return: (DizhiRelationDiscovery) The result containing all matching Dizhi combos. Note that returned combos don't reveal the directions.
   
@@ -589,10 +630,14 @@ def discover_mutual(dizhis1: Sequence[Dizhi], dizhis2: Sequence[Dizhi]) -> Dizhi
     raise TypeError(f'Expected all Dizhi, got {[type(dz) for dz in dizhis1]}')
   if not all(isinstance(dz, Dizhi) for dz in dizhis2):
     raise TypeError(f'Expected all Dizhi, got {[type(dz) for dz in dizhis2]}')
+  if not isinstance(anhe_def, DizhiRules.AnheDef):
+    raise TypeError(f'Expected AnheDef, got {type(anhe_def)}')
+  if not isinstance(xing_def, DizhiRules.XingDef):
+    raise TypeError(f'Expected XingDef, got {type(xing_def)}')
 
   # 自刑 depends on multiplicity (the same Dizhi appearing once on each side forms 自刑),
   # so the two sides CONCATENATE -- a set union would silently break it. Deliberately
   # different from `tiangan_utils.discover_mutual`.
   # 自刑依赖重数（同一地支两侧各现一次也构成自刑），故两侧拼接——集合并会静默破坏
   # 自刑。与天干侧的集合并是刻意分歧。
-  return discover(list(dizhis1) + list(dizhis2)).mutual_only(set(dizhis1), set(dizhis2))
+  return discover(list(dizhis1) + list(dizhis2), anhe_def=anhe_def, xing_def=xing_def).mutual_only(set(dizhis1), set(dizhis2))

--- a/src/utils/relation_discovery.py
+++ b/src/utils/relation_discovery.py
@@ -45,7 +45,13 @@ class RelationDiscovery(
 
   def mutual_only(self, items1: AbstractSet[RelationItemType], items2: AbstractSet[RelationItemType]) -> Self:
     '''Keep only the combos that draw from both sides (a combo disjoint from either side
-    comes from one side only). 只保留同时取材于两侧的组合（与任一侧不相交即单侧组合）。'''
+    comes from one side only). 只保留同时取材于两侧的组合（与任一侧不相交即单侧组合）。
+
+    Note: the test is by VALUE, not by provenance -- combos don't track which copy of an
+    item was used. If the two sides share a value, a combo whose members all come from
+    one side can still touch both value-sets and be kept.
+    按值判定，非按出处——组合不追踪用的是哪一份。两侧有共同值时，成员全来自单侧的
+    组合也可能因触及两侧值集而被保留。'''
     if not isinstance(items1, AbstractSet):
       raise TypeError(f'Expected AbstractSet, got {type(items1)}')
     if not isinstance(items2, AbstractSet):

--- a/src/utils/relation_discovery.py
+++ b/src/utils/relation_discovery.py
@@ -47,11 +47,12 @@ class RelationDiscovery(
     '''Keep only the combos that draw from both sides (a combo disjoint from either side
     comes from one side only). 只保留同时取材于两侧的组合（与任一侧不相交即单侧组合）。
 
-    Note: the test is by VALUE, not by provenance -- combos don't track which copy of an
-    item was used. If the two sides share a value, a combo whose members all come from
-    one side can still touch both value-sets and be kept.
-    按值判定，非按出处——组合不追踪用的是哪一份。两侧有共同值时，成员全来自单侧的
-    组合也可能因触及两侧值集而被保留。'''
+    Note: the test is by VALUE, not by provenance -- a combo built entirely from one side
+    can still be kept if the other side happens to share the value:
+    `discover_mutual([子, 丑], [子])` keeps 六合{子,丑} (子 appears in both value-sets,
+    though side 1 alone completes the combo).
+    按值判定，非按出处：组合全由单侧凑成，只要另一侧碰巧也有这个值，就会被保留——
+    `discover_mutual([子, 丑], [子])` 仍保留六合{子,丑}（子出现在两侧值集里，尽管一侧就够凑）。'''
     if not isinstance(items1, AbstractSet):
       raise TypeError(f'Expected AbstractSet, got {type(items1)}')
     if not isinstance(items2, AbstractSet):

--- a/tests/analyzer/test_relationship_analyzer.py
+++ b/tests/analyzer/test_relationship_analyzer.py
@@ -102,11 +102,18 @@ def test_at_birth_house_relations() -> None:
     y, m, d, h = chart.bazi.four_dizhis
     at_birth = analyzer.at_birth
 
+    # The oracle mirrors the analyzer by reading the chart's school profile (issue #69).
+    school: BaziSchool = chart.bazi.config.school
+
     # For AtBirth analysis, the following two algorithms are equivalent.
-    assert at_birth.house_relations == dizhi_utils.discover([y, m, d, h]).filter(
+    assert at_birth.house_relations == dizhi_utils.discover(
+      [y, m, d, h], anhe_def=school.anhe_def, xing_def=school.xing_def,
+    ).filter(
       lambda _, combo : d in combo
     )
-    assert at_birth.house_relations == dizhi_utils.discover_mutual([y, m, h], [d])
+    assert at_birth.house_relations == dizhi_utils.discover_mutual(
+      [y, m, h], [d], anhe_def=school.anhe_def, xing_def=school.xing_def,
+    )
 
     assert at_birth.house_relations == at_birth.house_relations # Repeated lookup must answer the same.
 
@@ -148,7 +155,11 @@ def test_filtered() -> None:
         for tg_combo in tg_combos:
           assert (stars.tiangan in tg_combo) == (tg_combo in at_birth.star_relations.tiangan[tg_rel])
 
-    for dz_rel, dz_combos in dizhi_utils.discover(chart.bazi.four_dizhis).items():
+    for dz_rel, dz_combos in dizhi_utils.discover(
+      chart.bazi.four_dizhis,
+      anhe_def=chart.bazi.config.school.anhe_def, # The oracle mirrors the chart's school (issue #69).
+      xing_def=chart.bazi.config.school.xing_def,
+    ).items():
       if dz_rel not in at_birth.star_relations.dizhi:
         assert all(dz not in dz_combo for dz_combo in dz_combos for dz in stars.dizhi)
       else:
@@ -323,7 +334,11 @@ def test_transit_house_relations() -> None:
 
         return not (combo - {house}).isdisjoint(transit_dz)
 
-      expected = dizhi_utils.discover_mutual(bazi.four_dizhis, transit_dz).filter(__expected_filter)
+      expected = dizhi_utils.discover_mutual(
+        bazi.four_dizhis, transit_dz,
+        anhe_def=bazi.config.school.anhe_def, # The oracle mirrors the chart's school (issue #69).
+        xing_def=bazi.config.school.xing_def,
+      ).filter(__expected_filter)
 
       assert _equal(expected, actual)
 
@@ -354,12 +369,14 @@ def test_transit_star_relations() -> None:
 
       tg_discovery = tiangan_utils.TianganRelationDiscovery({})
       dz_discovery = dizhi_utils.DizhiRelationDiscovery({})
+      # The oracle mirrors the analyzer by reading the chart's school profile (issue #69).
+      school: BaziSchool = chart.bazi.config.school
       if random_level in [TransitAnalysis.Level.TRANSITS_ONLY, TransitAnalysis.Level.ALL]:
         tg_discovery = tg_discovery.merge(tiangan_utils.discover(transit_tg))
-        dz_discovery = dz_discovery.merge(dizhi_utils.discover(transit_dz))
+        dz_discovery = dz_discovery.merge(dizhi_utils.discover(transit_dz, anhe_def=school.anhe_def, xing_def=school.xing_def))
       if random_level in [TransitAnalysis.Level.MUTUAL, TransitAnalysis.Level.ALL]:
         tg_discovery = tg_discovery.merge(tiangan_utils.discover_mutual(chart.bazi.four_tiangans, transit_tg))
-        dz_discovery = dz_discovery.merge(dizhi_utils.discover_mutual(chart.bazi.four_dizhis, transit_dz))
+        dz_discovery = dz_discovery.merge(dizhi_utils.discover_mutual(chart.bazi.four_dizhis, transit_dz, anhe_def=school.anhe_def, xing_def=school.xing_def))
 
       actual = transits_analysis.star_relations(randon_year, random_options, level=random_level)
 

--- a/tests/analyzer/test_relationship_analyzer.py
+++ b/tests/analyzer/test_relationship_analyzer.py
@@ -3,6 +3,8 @@
 
 import pytest
 
+import ast
+import inspect
 import random
 import itertools
 
@@ -12,6 +14,7 @@ from src.bazi import Bazi
 from src.bazi_chart import BaziChart
 from src.school import BaziConfig, BaziSchool, KeyStem
 from src.transits import TransitMoment, TransitOptions, TransitDatabase
+from src.analyzer import relationship as relationship_module
 from src.analyzer.relationship import RelationshipAnalyzer, TransitAnalysis, ShenshaAnalysis, _REGISTRY
 
 
@@ -493,3 +496,36 @@ def test_transit_analysis_negative() -> None:
 def test_registry_matches_shensha_analysis_keys() -> None:
   '''The Shensha registry and `ShenshaAnalysis` must stay in sync / 神煞注册表和 ShenshaAnalysis 的键必须保持同步。'''
   assert set(_REGISTRY.keys()) == set(ShenshaAnalysis.__required_keys__ | ShenshaAnalysis.__optional_keys__)
+
+
+def test_no_bare_dizhi_discovery_calls() -> None:
+  # The "no bare calls" invariant declared by the `_dz_*` wrappers in relationship.py needs
+  # an executor: every `dizhi_utils.search` / `discover` / `discover_mutual` call in that
+  # file must sit inside one of the three wrappers -- a call anywhere else silently falls
+  # back to the hardcoded defaults (issue #69).
+  # 「无裸调」不变量得有执行者：relationship.py 里的三入口调用必须都在三薄包装体内——
+  # 别处的调用会静默回落到硬编码默认（issue #69）。
+  wrappers = {'_dz_search', '_dz_discover', '_dz_discover_mutual'}
+  gated = {'search', 'discover', 'discover_mutual'}
+
+  bare: list[int] = []
+
+  class _Visitor(ast.NodeVisitor):
+    def __init__(self) -> None:
+      self._scope: list[str] = []
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+      self._scope.append(node.name)
+      self.generic_visit(node)
+      self._scope.pop()
+
+    def visit_Call(self, node: ast.Call) -> None:
+      f = node.func
+      if (isinstance(f, ast.Attribute) and f.attr in gated
+          and isinstance(f.value, ast.Name) and f.value.id == 'dizhi_utils'
+          and (not self._scope or self._scope[-1] not in wrappers)):
+        bare.append(node.lineno)
+      self.generic_visit(node)
+
+  _Visitor().visit(ast.parse(inspect.getsource(relationship_module)))
+  assert bare == []

--- a/tests/integration/test_relationship_analysis.py
+++ b/tests/integration/test_relationship_analysis.py
@@ -685,9 +685,9 @@ def test_school_variants_reach_relationship_analysis() -> None:
   # 端到端钉住流派档案确实驱动关系查法（issue #69）。断言钉精确集合而非「有差异」——
   # MANGPAI/STRICT 都是默认定义的子集，「变少」在错传空表/错表时同样成立。
 
-  # Chart A: 戊寅 day with 午 in the month pillar -- 寅午 forms ANHE only under
-  # NORMAL_EXTENDED (MANGPAI drops it). Covers the AtBirth `discover` path.
-  # 盘 A：戊寅日、月支午——寅午暗合仅 NORMAL_EXTENDED 有（MANGPAI 无）。覆盖 AtBirth `discover` 路径。
+  # Chart A: 戊寅 day with 午 in the month pillar -- 寅午 forms ANHE under NORMAL /
+  # NORMAL_EXTENDED but not MANGPAI. Covers the AtBirth `discover` path.
+  # 盘 A：戊寅日、月支午——寅午暗合 NORMAL / NORMAL_EXTENDED 皆有、MANGPAI 无。覆盖 AtBirth `discover` 路径。
   dt_a: datetime = datetime(1984, 6, 13) # 甲子 / 庚午 / 戊寅 / 壬子
   anhe_default: AtBirthAnalysis = RelationshipAnalyzer(BaziChart(Bazi.create(dt_a, BaziGender.MALE))).at_birth
   anhe_mangpai: AtBirthAnalysis = RelationshipAnalyzer(BaziChart(Bazi.create(
@@ -732,3 +732,37 @@ def test_school_variants_reach_relationship_analysis() -> None:
   assert set(map(frozenset, default_rels_c[DizhiRelation.刑])) == {frozenset((Dizhi.丑, Dizhi.未))}
   assert DizhiRelation.刑 not in strict_rels_c
   assert {r: c for r, c in default_rels_c.items() if r is not DizhiRelation.刑} == dict(strict_rels_c.items())
+
+  # Chart D: 辛巳 day with 寅 in the month pillar -- the relationship star is 寅 (辛's
+  # 正财甲 lives in 寅), and 寅巳 forms XING only under LOOSE. Covers the AtBirth
+  # `star_relations` path.
+  # 盘 D：辛巳日、月支寅——配偶星为寅（辛之正财甲藏于寅），寅巳刑仅 LOOSE 成立。
+  # 覆盖 AtBirth `star_relations` 路径。
+  dt_d: datetime = datetime(1984, 2, 17) # 甲子 / 丙寅 / 辛巳 / 戊子
+  star_default_d = RelationshipAnalyzer(BaziChart(Bazi.create(dt_d, BaziGender.MALE))).at_birth.star_relations.dizhi
+  star_strict_d = RelationshipAnalyzer(BaziChart(Bazi.create(
+    dt_d, BaziGender.MALE, BaziConfig(school=BaziSchool(xing_def=DizhiRules.XingDef.STRICT)),
+  ))).at_birth.star_relations.dizhi
+
+  assert set(map(frozenset, star_default_d[DizhiRelation.刑])) == {frozenset((Dizhi.寅, Dizhi.巳))}
+  assert DizhiRelation.刑 not in star_strict_d
+  assert {r: c for r, c in star_default_d.items() if r is not DizhiRelation.刑} == dict(star_strict_d.items())
+
+  # Chart E: 辛未 day, the star 寅 present (month), no 巳/申 at birth; the 1992 壬申 流年
+  # brings 申 -- 寅申 forms XING only under LOOSE. Covers the transit-side `star_relations`
+  # MUTUAL path (the TRANSITS_ONLY path shares `_dz_discover` with the AtBirth cases above).
+  # 盘 E：辛未日、月支寅（配偶星）、原局无巳申；1992 壬申流年带来申——寅申刑仅 LOOSE 成立。
+  # 覆盖流运侧 `star_relations` MUTUAL 路径（TRANSITS_ONLY 路径与上面 AtBirth 案例共用 `_dz_discover`）。
+  dt_e: datetime = datetime(1984, 2, 7) # 甲子 / 丙寅 / 辛未 / 戊子
+  transit_default_e: TransitAnalysis = RelationshipAnalyzer(BaziChart(Bazi.create(dt_e, BaziGender.MALE))).transits
+  transit_strict_e: TransitAnalysis = RelationshipAnalyzer(BaziChart(Bazi.create(
+    dt_e, BaziGender.MALE, BaziConfig(school=BaziSchool(xing_def=DizhiRules.XingDef.STRICT)),
+  ))).transits
+
+  assert transit_default_e.support(1992, TransitOptions.LIUNIAN)
+  assert transit_strict_e.support(1992, TransitOptions.LIUNIAN)
+  default_star_e = transit_default_e.star_relations(1992, TransitOptions.LIUNIAN, level=TransitAnalysis.Level.MUTUAL).dizhi
+  strict_star_e = transit_strict_e.star_relations(1992, TransitOptions.LIUNIAN, level=TransitAnalysis.Level.MUTUAL).dizhi
+  assert set(map(frozenset, default_star_e[DizhiRelation.刑])) == {frozenset((Dizhi.寅, Dizhi.申))}
+  assert DizhiRelation.刑 not in strict_star_e
+  assert {r: c for r, c in default_star_e.items() if r is not DizhiRelation.刑} == dict(strict_star_e.items())

--- a/tests/integration/test_relationship_analysis.py
+++ b/tests/integration/test_relationship_analysis.py
@@ -12,7 +12,7 @@ from src.defines import Tiangan, Dizhi, Ganzhi, TianganRelation, DizhiRelation, 
 from src.utils import tiangan_utils, dizhi_utils, bazi_utils, shensha_utils
 from src.bazi import Bazi, BaziGender
 from src.bazi_chart import BaziChart
-from src.school import KeyStem
+from src.school import KeyStem, BaziSchool, BaziConfig
 from src.transits import TransitMoment, TransitOptions, TransitDatabase
 from src.analyzer.relationship import RelationshipAnalyzer, ShenshaAnalysis, TransitAnalysis, AtBirthAnalysis
 from src.rules import DizhiRules
@@ -396,6 +396,9 @@ def test_case2() -> None:
   assert chart.relationship_stars.tiangan == Tiangan.癸
   assert set(chart.relationship_stars.dizhi) == {Dizhi.子}
 
+  # The oracle mirrors the analyzer by reading the chart's school profile (issue #69).
+  school: BaziSchool = chart.bazi.config.school
+
   db = TransitDatabase(chart)
   for year in random.sample(range(birth_gz_year, birth_gz_year + 600), 100):
     for option in TransitOptions:
@@ -411,7 +414,9 @@ def test_case2() -> None:
       expected_transits_only_tg_star_relations = tiangan_utils.discover(list(transits_tg)).filter(
         lambda _, combo : Tiangan.癸 in combo
       )
-      expected_transits_only_dz_star_relations = dizhi_utils.discover(list(transits_dz)).filter(
+      expected_transits_only_dz_star_relations = dizhi_utils.discover(
+        list(transits_dz), anhe_def=school.anhe_def, xing_def=school.xing_def,
+      ).filter(
         lambda _, combo : Dizhi.子 in combo
       )
 
@@ -423,7 +428,9 @@ def test_case2() -> None:
       expected_mutual_tg_star_relations = tiangan_utils.discover_mutual(chart.bazi.four_tiangans, list(transits_tg)).filter(
         lambda _, combo : Tiangan.癸 in combo
       )
-      expected_mutual_dz_star_relations = dizhi_utils.discover_mutual(chart.bazi.four_dizhis, list(transits_dz)).filter(
+      expected_mutual_dz_star_relations = dizhi_utils.discover_mutual(
+        chart.bazi.four_dizhis, list(transits_dz), anhe_def=school.anhe_def, xing_def=school.xing_def,
+      ).filter(
         lambda _, combo : Dizhi.子 in combo
       )
 
@@ -441,7 +448,9 @@ def test_case2() -> None:
       assert _equal(all_star_relations.tiangan, tiangan_utils.discover(list(transits_tg) + list(bazi.four_tiangans)).filter(
         lambda _, combo : Tiangan.癸 in combo and not combo.isdisjoint(transits_tg)
       ))
-      assert _equal(all_star_relations.dizhi, dizhi_utils.discover(list(transits_dz) + list(bazi.four_dizhis)).filter(
+      assert _equal(all_star_relations.dizhi, dizhi_utils.discover(
+        list(transits_dz) + list(bazi.four_dizhis), anhe_def=school.anhe_def, xing_def=school.xing_def,
+      ).filter(
         lambda _, combo : Dizhi.子 in combo and not combo.isdisjoint(transits_dz)
       ))
 
@@ -493,6 +502,11 @@ def test_random_cases(bazi: Bazi) -> None:
   # The 红艳 anchor stem follows the chart's school (查法锚干, issue #69) -- don't assume the day master.
   hongyan_anchor: Tiangan = dm if bazi.config.school.hongyan_key is KeyStem.DAY_MASTER else bazi.year_pillar.tiangan
 
+  # The Dizhi-relation oracles below mirror the analyzer by reading the same school profile
+  # (issue #69) -- they don't assume the default 暗合/刑 definitions either.
+  # 地支关系 oracle 同样从流派档案读暗合/刑口径，不假设默认定义（issue #69）。
+  school: BaziSchool = bazi.config.school
+
   assert star is bazi_utils.shishen(dm, chart.relationship_stars.tiangan)
   for star_dz in chart.relationship_stars.dizhi:
     assert star is bazi_utils.shishen(dm, star_dz)
@@ -536,8 +550,12 @@ def test_random_cases(bazi: Bazi) -> None:
       transits_dz_set = {gz.dizhi for gz in transits_gz}
 
       expected_tg_relations = tiangan_utils.discover_mutual([chart.bazi.day_master], list(transits_tg_set))
-      expected_dz_relations = dizhi_utils.discover_mutual([house], list(transits_dz_set)).merge(
-        dizhi_utils.discover_mutual([house], list(transits_dz_set) + [y_dz, m_dz, h_dz]).filter(
+      expected_dz_relations = dizhi_utils.discover_mutual(
+        [house], list(transits_dz_set), anhe_def=school.anhe_def, xing_def=school.xing_def,
+      ).merge(
+        dizhi_utils.discover_mutual(
+          [house], list(transits_dz_set) + [y_dz, m_dz, h_dz], anhe_def=school.anhe_def, xing_def=school.xing_def,
+        ).filter(
           lambda _, combo : len(combo) == 3
         ).filter(
           lambda _, combo : not combo.isdisjoint(filter(lambda dz : dz is not house, transits_dz_set))
@@ -553,7 +571,7 @@ def test_random_cases(bazi: Bazi) -> None:
       if house in [Dizhi.午, Dizhi.亥, Dizhi.辰] and house in transits_dz_set: # 自刑 cases
         assert frozenset({house}) in dz_relations[DizhiRelation.刑]
 
-      for dz_tuple in DizhiRules.DIZHI_XING[DizhiRules.XingDef.LOOSE]: # 三刑 cases
+      for dz_tuple in DizhiRules.DIZHI_XING[school.xing_def]: # 三刑 cases (len-3 combos coincide across defs / 三组合在各定义下相同)
         if len(dz_tuple) == 3 and house in dz_tuple:
           other_dz = frozenset(dz_tuple) - {house}
           assert len(other_dz) == 2
@@ -595,7 +613,9 @@ def test_random_cases(bazi: Bazi) -> None:
         tg_list.remove(stars.tiangan)
         expected_transits_only_tg = tiangan_utils.discover_mutual([stars.tiangan], tg_list)
 
-      expected_transits_only_dz = dizhi_utils.discover(transits_dz_list).filter(
+      expected_transits_only_dz = dizhi_utils.discover(
+        transits_dz_list, anhe_def=school.anhe_def, xing_def=school.xing_def,
+      ).filter(
         lambda _, combo : not combo.isdisjoint(stars.dizhi)
       )
 
@@ -609,7 +629,9 @@ def test_random_cases(bazi: Bazi) -> None:
         lambda _, combo : stars.tiangan in combo
       )
 
-      expected_mutual_dz = dizhi_utils.discover_mutual(bazi.four_dizhis, transits_dz_list).filter(
+      expected_mutual_dz = dizhi_utils.discover_mutual(
+        bazi.four_dizhis, transits_dz_list, anhe_def=school.anhe_def, xing_def=school.xing_def,
+      ).filter(
         lambda _, combo : len(combo & set(stars.dizhi)) > 0
       )
 
@@ -628,7 +650,9 @@ def test_random_cases(bazi: Bazi) -> None:
         lambda _, combo : not combo.isdisjoint(transits_tg_list)
       ))
 
-      assert _equal(all_star_relations.dizhi, dizhi_utils.discover(transits_dz_list + list(bazi.four_dizhis)).filter(
+      assert _equal(all_star_relations.dizhi, dizhi_utils.discover(
+        transits_dz_list + list(bazi.four_dizhis), anhe_def=school.anhe_def, xing_def=school.xing_def,
+      ).filter(
         lambda _, combo : len(combo & set(stars.dizhi)) > 0
       ).filter(
         lambda _, combo : not combo.isdisjoint(transits_dz_list)
@@ -652,3 +676,59 @@ def test_random_cases(bazi: Bazi) -> None:
       star_results = transits.star(year, option)
       assert star_results.tiangan == (stars.tiangan in transits_tg_set)
       assert star_results.dizhi != set(transits_dz_set).isdisjoint(stars.dizhi)
+
+
+def test_school_variants_reach_relationship_analysis() -> None:
+  # End-to-end pins that the chart's school steers relation discovery (issue #69). Assertions
+  # pin exact combo sets, not "fewer results" -- MANGPAI ⊂ NORMAL_EXTENDED and STRICT ⊂ LOOSE,
+  # so a "differs" assertion would also pass on a wrong or empty table.
+  # 端到端钉住流派档案确实驱动关系查法（issue #69）。断言钉精确集合而非「有差异」——
+  # MANGPAI/STRICT 都是默认定义的子集，「变少」在错传空表/错表时同样成立。
+
+  # Chart A: 戊寅 day with 午 in the month pillar -- 寅午 forms ANHE only under
+  # NORMAL_EXTENDED (MANGPAI drops it). Covers the AtBirth `discover` path.
+  # 盘 A：戊寅日、月支午——寅午暗合仅 NORMAL_EXTENDED 有（MANGPAI 无）。覆盖 AtBirth `discover` 路径。
+  dt_a: datetime = datetime(1984, 6, 13) # 甲子 / 庚午 / 戊寅 / 壬子
+  anhe_default: AtBirthAnalysis = RelationshipAnalyzer(BaziChart(Bazi.create(dt_a, BaziGender.MALE))).at_birth
+  anhe_mangpai: AtBirthAnalysis = RelationshipAnalyzer(BaziChart(Bazi.create(
+    dt_a, BaziGender.MALE, BaziConfig(school=BaziSchool(anhe_def=DizhiRules.AnheDef.MANGPAI)),
+  ))).at_birth
+
+  default_rels_a = anhe_default.house_relations
+  mangpai_rels_a = anhe_mangpai.house_relations
+  assert set(map(frozenset, default_rels_a[DizhiRelation.暗合])) == {frozenset((Dizhi.寅, Dizhi.午))}
+  assert DizhiRelation.暗合 not in mangpai_rels_a
+  # Only the 暗合 key may differ between the two charts (其余关系两盘一致).
+  assert {r: c for r, c in default_rels_a.items() if r is not DizhiRelation.暗合} == dict(mangpai_rels_a.items())
+
+  # Chart B: 癸丑 day with 未 in the month pillar -- 丑未 forms XING only under LOOSE
+  # (STRICT requires all three of 丑未戌). Same path, the other knob.
+  # 盘 B：癸丑日、月支未——丑未刑仅 LOOSE 成立（STRICT 要求三支齐现）。同路径，另一个旋钮。
+  dt_b: datetime = datetime(1984, 7, 18) # 甲子 / 辛未 / 癸丑 / 壬子
+  xing_default: AtBirthAnalysis = RelationshipAnalyzer(BaziChart(Bazi.create(dt_b, BaziGender.MALE))).at_birth
+  xing_strict: AtBirthAnalysis = RelationshipAnalyzer(BaziChart(Bazi.create(
+    dt_b, BaziGender.MALE, BaziConfig(school=BaziSchool(xing_def=DizhiRules.XingDef.STRICT)),
+  ))).at_birth
+
+  default_rels_b = xing_default.house_relations
+  strict_rels_b = xing_strict.house_relations
+  assert set(map(frozenset, default_rels_b[DizhiRelation.刑])) == {frozenset((Dizhi.丑, Dizhi.未))}
+  assert DizhiRelation.刑 not in strict_rels_b
+  assert {r: c for r, c in default_rels_b.items() if r is not DizhiRelation.刑} == dict(strict_rels_b.items())
+
+  # Chart C: 辛丑 day with no 未 at birth; the 1991 辛未 流年 brings 未 -- covers the
+  # transit-side `discover_mutual` path in `TransitAnalysis.house_relations`.
+  # 盘 C：辛丑日、原局无未；1991 辛未流年带来未——覆盖流运侧 `discover_mutual` 路径。
+  dt_c: datetime = datetime(1984, 1, 8) # 癸亥 / 乙丑 / 辛丑 / 戊子
+  transit_default: TransitAnalysis = RelationshipAnalyzer(BaziChart(Bazi.create(dt_c, BaziGender.MALE))).transits
+  transit_strict: TransitAnalysis = RelationshipAnalyzer(BaziChart(Bazi.create(
+    dt_c, BaziGender.MALE, BaziConfig(school=BaziSchool(xing_def=DizhiRules.XingDef.STRICT)),
+  ))).transits
+
+  assert transit_default.support(1991, TransitOptions.LIUNIAN)
+  assert transit_strict.support(1991, TransitOptions.LIUNIAN)
+  default_rels_c = transit_default.house_relations(1991, TransitOptions.LIUNIAN)
+  strict_rels_c = transit_strict.house_relations(1991, TransitOptions.LIUNIAN)
+  assert set(map(frozenset, default_rels_c[DizhiRelation.刑])) == {frozenset((Dizhi.丑, Dizhi.未))}
+  assert DizhiRelation.刑 not in strict_rels_c
+  assert {r: c for r, c in default_rels_c.items() if r is not DizhiRelation.刑} == dict(strict_rels_c.items())

--- a/tests/test_bazi_chart.py
+++ b/tests/test_bazi_chart.py
@@ -13,6 +13,7 @@ from datetime import datetime, date, timedelta
 from src.defines import Tiangan, Dizhi, Ganzhi, Wuxing, Yinyang, Shishen, ShierZhangsheng
 from src.bazi import BaziGender, Bazi
 from src.school import BaziPrecision, BaziConfig, BaziSchool, DayRollover, KeyStem
+from src.rules import DizhiRules
 from src.utils import bazi_utils
 
 from src.data_types import (
@@ -520,6 +521,8 @@ def test_json() -> None:
                     school=BaziSchool(
                       day_rollover=DayRollover[j['school']['day_rollover']],
                       hongyan_key=KeyStem[j['school']['hongyan_key']],
+                      anhe_def=DizhiRules.AnheDef[j['school']['anhe_def']],
+                      xing_def=DizhiRules.XingDef[j['school']['xing_def']],
                     ),
                   ))
     )

--- a/tests/test_school.py
+++ b/tests/test_school.py
@@ -53,16 +53,12 @@ def test_config_type_gates() -> None:
     BaziConfig(backend='hko') # type: ignore
   with pytest.raises(TypeError):
     BaziConfig(school=DayRollover.ZIZHENG) # type: ignore # An enum is not a `BaziSchool`.
-  with pytest.raises(TypeError):
-    BaziSchool(day_rollover='wan_zishi') # type: ignore
-  with pytest.raises(TypeError):
-    BaziSchool(hongyan_key=0) # type: ignore
 
 
 def test_every_school_field_has_a_type_gate() -> None:
   # Mechanical binding: every `BaziSchool` field must reject a wrong type at construction --
   # adding a knob without a gate fails here, no per-field test needed (issue #69).
-  # 机械绑定:每个字段都要有构造期类型闸,加字段不加闸会在这里响。
+  # 机械绑定：每个字段都要有构造期类型闸，加字段不加闸会在这里响。
   for f in dataclasses.fields(BaziSchool):
     with pytest.raises(TypeError):
       BaziSchool(**{f.name: object()}) # type: ignore
@@ -71,7 +67,7 @@ def test_every_school_field_has_a_type_gate() -> None:
 def test_every_school_field_reaches_json() -> None:
   # Mechanical binding: every `BaziSchool` field must land in JSON under its own name --
   # adding a knob without serializing it fails here (issue #69).
-  # 机械绑定:每个字段都要以同名键进 JSON,加字段不序列化会在这里响。
+  # 机械绑定：每个字段都要以同名键进 JSON，加字段不序列化会在这里响。
   chart: BaziChart = BaziChart(Bazi.create(datetime(1984, 4, 2, 4, 2), BaziGender.MALE))
   assert {f.name for f in dataclasses.fields(BaziSchool)} == set(chart.json['school'])
 

--- a/tests/test_school.py
+++ b/tests/test_school.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2026 Ningqi Wang (0xf3cd) <https://github.com/0xf3cd>
 # test_school.py
 
+import dataclasses
 from dataclasses import FrozenInstanceError
 from datetime import datetime
 
@@ -9,6 +10,7 @@ import pytest
 from src.calendar import CalendarBackend
 from src.bazi import Bazi, BaziGender
 from src.bazi_chart import BaziChart
+from src.rules import DizhiRules
 from src.school import (
   BaziPrecision, DayRollover, KeyStem, BaziSchool, BaziConfig,
   DEFAULT_SCHOOL, DEFAULT_CONFIG,
@@ -36,6 +38,8 @@ def test_school_enums_basic() -> None:
 def test_school_defaults() -> None:
   assert BaziSchool().day_rollover is DayRollover.WAN_ZISHI
   assert BaziSchool().hongyan_key is KeyStem.DAY_MASTER
+  assert BaziSchool().anhe_def is DizhiRules.AnheDef.NORMAL_EXTENDED
+  assert BaziSchool().xing_def is DizhiRules.XingDef.LOOSE
   assert BaziSchool() == DEFAULT_SCHOOL
 
 
@@ -51,6 +55,23 @@ def test_config_type_gates() -> None:
     BaziSchool(day_rollover='wan_zishi') # type: ignore
   with pytest.raises(TypeError):
     BaziSchool(hongyan_key=0) # type: ignore
+
+
+def test_every_school_field_has_a_type_gate() -> None:
+  # Mechanical binding: every `BaziSchool` field must reject a wrong type at construction --
+  # adding a knob without a gate fails here, no per-field test needed (issue #69).
+  # 机械绑定:每个字段都要有构造期类型闸,加字段不加闸会在这里响。
+  for f in dataclasses.fields(BaziSchool):
+    with pytest.raises(TypeError):
+      BaziSchool(**{f.name: object()}) # type: ignore
+
+
+def test_every_school_field_reaches_json() -> None:
+  # Mechanical binding: every `BaziSchool` field must land in JSON under its own name --
+  # adding a knob without serializing it fails here (issue #69).
+  # 机械绑定:每个字段都要以同名键进 JSON,加字段不序列化会在这里响。
+  chart: BaziChart = BaziChart(Bazi.create(datetime(1984, 4, 2, 4, 2), BaziGender.MALE))
+  assert {f.name for f in dataclasses.fields(BaziSchool)} == set(chart.json['school'])
 
 
 def test_config_and_school_are_frozen() -> None:
@@ -169,11 +190,25 @@ def test_eq_hash_include_school() -> None:
   assert hash(zi_bazi) == hash(same_school)
   assert len({zi_bazi, same_school}) == 1
 
+  # The evaluation-time knobs distinguish charts the same way (评估期旋钮同样区分两盘).
+  for variant_school in (
+    BaziSchool(hongyan_key=KeyStem.YEAR_MASTER),
+    BaziSchool(anhe_def=DizhiRules.AnheDef.MANGPAI),
+    BaziSchool(xing_def=DizhiRules.XingDef.STRICT),
+  ):
+    variant_bazi: Bazi = Bazi.create(dt, BaziGender.MALE, BaziConfig(school=variant_school))
+    assert default_bazi != variant_bazi
+    assert hash(default_bazi) != hash(variant_bazi)
+    assert len({default_bazi, variant_bazi}) == 2
+
 
 def test_json_roundtrip_default_school() -> None:
   chart: BaziChart = BaziChart(Bazi.create(datetime(1984, 4, 2, 4, 2), BaziGender.MALE))
   j = chart.json
-  assert j['school'] == { 'day_rollover': 'WAN_ZISHI', 'hongyan_key': 'DAY_MASTER' }
+  assert j['school'] == {
+    'day_rollover': 'WAN_ZISHI', 'hongyan_key': 'DAY_MASTER',
+    'anhe_def': 'NORMAL_EXTENDED', 'xing_def': 'LOOSE',
+  }
 
   rebuilt: BaziChart = BaziChart(
     Bazi.create(datetime.fromisoformat(j['birth_time']), j['gender'],
@@ -183,6 +218,8 @@ def test_json_roundtrip_default_school() -> None:
                   school=BaziSchool(
                     day_rollover=DayRollover[j['school']['day_rollover']],
                     hongyan_key=KeyStem[j['school']['hongyan_key']],
+                    anhe_def=DizhiRules.AnheDef[j['school']['anhe_def']],
+                    xing_def=DizhiRules.XingDef[j['school']['xing_def']],
                   ),
                 ))
   )
@@ -193,11 +230,21 @@ def test_json_roundtrip_default_school() -> None:
 def test_json_roundtrip_non_default_school() -> None:
   # A non-default school must survive the JSON roundtrip losslessly: rebuilding
   # from the json alone reproduces the same chart, not a silent default-school one.
-  school: BaziSchool = BaziSchool(day_rollover=DayRollover.ZIZHENG, hongyan_key=KeyStem.YEAR_MASTER)
+  # All four knobs flipped, so each field proves it roundtrips (issue #69).
+  # 四旋钮全部取非默认值——每个字段各自证明它能往返。
+  school: BaziSchool = BaziSchool(
+    day_rollover=DayRollover.ZIZHENG,
+    hongyan_key=KeyStem.YEAR_MASTER,
+    anhe_def=DizhiRules.AnheDef.MANGPAI,
+    xing_def=DizhiRules.XingDef.STRICT,
+  )
   chart: BaziChart = BaziChart(Bazi.create(datetime(1984, 4, 2, 4, 2), BaziGender.MALE,
                                            BaziConfig(school=school)))
   j = chart.json
-  assert j['school'] == { 'day_rollover': 'ZIZHENG', 'hongyan_key': 'YEAR_MASTER' }
+  assert j['school'] == {
+    'day_rollover': 'ZIZHENG', 'hongyan_key': 'YEAR_MASTER',
+    'anhe_def': 'MANGPAI', 'xing_def': 'STRICT',
+  }
 
   rebuilt: BaziChart = BaziChart(
     Bazi.create(datetime.fromisoformat(j['birth_time']), j['gender'],
@@ -207,6 +254,8 @@ def test_json_roundtrip_non_default_school() -> None:
                   school=BaziSchool(
                     day_rollover=DayRollover[j['school']['day_rollover']],
                     hongyan_key=KeyStem[j['school']['hongyan_key']],
+                    anhe_def=DizhiRules.AnheDef[j['school']['anhe_def']],
+                    xing_def=DizhiRules.XingDef[j['school']['xing_def']],
                   ),
                 ))
   )

--- a/tests/test_school.py
+++ b/tests/test_school.py
@@ -2,6 +2,7 @@
 # test_school.py
 
 import dataclasses
+import inspect
 from dataclasses import FrozenInstanceError
 from datetime import datetime
 
@@ -11,6 +12,7 @@ from src.calendar import CalendarBackend
 from src.bazi import Bazi, BaziGender
 from src.bazi_chart import BaziChart
 from src.rules import DizhiRules
+from src.utils import dizhi_utils
 from src.school import (
   BaziPrecision, DayRollover, KeyStem, BaziSchool, BaziConfig,
   DEFAULT_SCHOOL, DEFAULT_CONFIG,
@@ -155,6 +157,19 @@ def test_defaults_are_defined_once() -> None:
   assert BaziConfig.from_values() == DEFAULT_CONFIG
   assert BaziConfig.from_values().school is DEFAULT_SCHOOL
   assert DEFAULT_CONFIG.school is DEFAULT_SCHOOL
+
+
+def test_school_defaults_match_utils_signature_defaults() -> None:
+  # The majority reading is spelled twice by design -- the school field defaults (chart
+  # level) and the utils signature defaults (per-query override, same shape as
+  # `anhe` / `xing`). Pin the two spellings identical so they can't drift apart;
+  # do NOT "fix" this by making utils import school (issue #69).
+  # 「多数派口径」刻意两写——school 字段默认（盘级）与 utils 签名默认（单次覆盖，同
+  # `anhe` / `xing` 先例）；钉住两处等价防漂移，但别让 utils 反过来 import school（issue #69）。
+  for fn in (dizhi_utils.search, dizhi_utils.discover, dizhi_utils.discover_mutual):
+    params = inspect.signature(fn).parameters
+    assert BaziSchool().anhe_def is params['anhe_def'].default
+    assert BaziSchool().xing_def is params['xing_def'].default
 
 
 def test_bazi_default_config_is_the_shared_default() -> None:

--- a/tests/utils/test_dizhi_utils.py
+++ b/tests/utils/test_dizhi_utils.py
@@ -551,7 +551,8 @@ def test_search_def_type_gates() -> None:
 
 def test_discover_def_passthrough() -> None:
   # The def params reach `search` through both batch entries (参数经两个批量入口透传到 search)。
-  # 寅午 forms ANHE only under EXTENDED (MANGPAI drops it); 寅巳 forms XING only under LOOSE.
+  # 寅午 forms ANHE under NORMAL / NORMAL_EXTENDED but not MANGPAI; 寅巳 forms XING only under LOOSE.
+  # 寅午暗合 NORMAL / NORMAL_EXTENDED 皆有、MANGPAI 无；寅巳刑仅 LOOSE 成立。
   dizhis: list[Dizhi] = [Dizhi.寅, Dizhi.午, Dizhi.巳, Dizhi.子]
 
   default_d: DizhiRelationDiscovery = dizhi_utils.discover(dizhis)

--- a/tests/utils/test_dizhi_utils.py
+++ b/tests/utils/test_dizhi_utils.py
@@ -156,27 +156,46 @@ def test_liuhe() -> None:
 
 
 def test_search_anhe() -> None:
-  anhe_combos: list[DizhiCombo] = [ # 天干五合对应的地支暗合，5组。
+  normal_combos: list[DizhiCombo] = [ # 天干五合对应的地支暗合，5组。
     DizhiCombo((bazi_utils.lu(tg1), bazi_utils.lu(tg2)))
     for tg1, tg2 in itertools.combinations(Tiangan, 2) if tiangan_utils.he(tg1, tg2) is not None
-  ] + [ # `NORMAL_EXTENDED` 中额外的1组。
-    DizhiCombo((Dizhi.寅, Dizhi.丑)),
   ]
 
-  assert _dz_equal(
-    dizhi_utils.search([], DizhiRelation.暗合),
-    [],
-  )
+  expected: dict[DizhiRules.AnheDef, list[DizhiCombo]] = {
+    DizhiRules.AnheDef.NORMAL: normal_combos,
+    DizhiRules.AnheDef.NORMAL_EXTENDED: normal_combos + [ # `NORMAL_EXTENDED` 中额外的1组。
+      DizhiCombo((Dizhi.寅, Dizhi.丑)),
+    ],
+    DizhiRules.AnheDef.MANGPAI: [ # 盲派三对。
+      DizhiCombo((Dizhi.寅, Dizhi.丑)),
+      DizhiCombo((Dizhi.午, Dizhi.亥)),
+      DizhiCombo((Dizhi.卯, Dizhi.申)),
+    ],
+  }
+
+  for anhe_def in DizhiRules.AnheDef:
+    anhe_combos: list[DizhiCombo] = expected[anhe_def]
+
+    assert _dz_equal(
+      dizhi_utils.search([], DizhiRelation.暗合, anhe_def=anhe_def),
+      [],
+    )
+    assert _dz_equal(
+      dizhi_utils.search(list(Dizhi), DizhiRelation.暗合, anhe_def=anhe_def),
+      anhe_combos,
+    )
+
+    for _ in range(200):
+      dizhis: list[Dizhi] = random.sample(Dizhi.as_list(), random.randint(0, len(Dizhi)))
+      result: DizhiRelationCombos = dizhi_utils.search(dizhis, DizhiRelation.暗合, anhe_def=anhe_def)
+      expected_result: list[set[Dizhi]] = [set(c) for c in anhe_combos if c.issubset(dizhis)]
+      assert _dz_equal(result, expected_result)
+
+  # The default stays `NORMAL_EXTENDED` (默认仍是最宽定义).
   assert _dz_equal(
     dizhi_utils.search(list(Dizhi), DizhiRelation.暗合),
-    anhe_combos,
+    expected[DizhiRules.AnheDef.NORMAL_EXTENDED],
   )
-
-  for _ in range(500):
-    dizhis: list[Dizhi] = random.sample(Dizhi.as_list(), random.randint(0, len(Dizhi)))
-    result: DizhiRelationCombos = dizhi_utils.search(dizhis, DizhiRelation.暗合)
-    expected_result: list[set[Dizhi]] = [set(c) for c in anhe_combos if c.issubset(dizhis)]
-    assert _dz_equal(result, expected_result)
 
 
 def test_anhe() -> None:
@@ -223,7 +242,7 @@ def test_anhe() -> None:
       assert dizhi_utils.anhe(dz1, dz2, definition=anhe_def) == (DizhiCombo((dz1, dz2)) in expected[anhe_def])
       assert dizhi_utils.anhe(dz1, dz2, definition=anhe_def) == dizhi_utils.anhe(dz2, dz1, definition=anhe_def)
 
-  # Ensure the default definition is `NORMAL`.
+  # Ensure the default definition is `NORMAL_EXTENDED`.
   for dz1, dz2 in itertools.product(Dizhi, Dizhi):
     assert dizhi_utils.anhe(dz1, dz2) == (DizhiCombo((dz1, dz2)) in normal_extended_combos)
     assert dizhi_utils.anhe(dz1, dz2) == dizhi_utils.anhe(dz2, dz1)
@@ -440,15 +459,16 @@ def test_banhe() -> None:
 
 
 def test_search_xing() -> None:
-  xing_expected: list[dict[Dizhi, int]] = [ # 辰午酉亥自刑
+  base_expected: list[dict[Dizhi, int]] = [ # 辰午酉亥自刑
     {
       dz : 2,
     } for dz in [Dizhi.辰, Dizhi.午, Dizhi.酉, Dizhi.亥]
-  ] + [ # 其他相刑
+  ] + [ # 其他相刑（两定义共有 / shared by both definitions）。
     { Dizhi.子 : 1, Dizhi.卯 : 1, },
     { Dizhi.寅 : 1, Dizhi.巳 : 1, Dizhi.申 : 1, },
     { Dizhi.丑 : 1, Dizhi.未 : 1, Dizhi.戌 : 1, },
-  ] + [ # LOOSE def.
+  ]
+  loose_only: list[dict[Dizhi, int]] = [ # LOOSE only: any two of the three suffice / 仅 LOOSE：三取二。
     { Dizhi.寅 : 1, Dizhi.巳 : 1, },
     { Dizhi.巳 : 1, Dizhi.申 : 1, },
     { Dizhi.寅 : 1, Dizhi.申 : 1, },
@@ -456,8 +476,12 @@ def test_search_xing() -> None:
     { Dizhi.未 : 1, Dizhi.戌 : 1, },
     { Dizhi.丑 : 1, Dizhi.戌 : 1, },
   ]
+  expected_by_def: dict[DizhiRules.XingDef, list[dict[Dizhi, int]]] = {
+    DizhiRules.XingDef.STRICT: base_expected,
+    DizhiRules.XingDef.LOOSE:  base_expected + loose_only,
+  }
 
-  def __find_qualified(dizhis: list[Dizhi]) -> list[set[Dizhi]]:
+  def __find_qualified(xing_expected: list[dict[Dizhi, int]], dizhis: list[Dizhi]) -> list[set[Dizhi]]:
     ret: list[set[Dizhi]] = []
     for required in xing_expected:
       if all(
@@ -467,6 +491,7 @@ def test_search_xing() -> None:
         ret.append(set(required.keys()))
     return ret
 
+  # The fixed pins below run on the default definition (`LOOSE`).
   assert _dz_equal(
     dizhi_utils.search([], DizhiRelation.刑),
     [],
@@ -487,16 +512,67 @@ def test_search_xing() -> None:
   )
   assert _dz_equal(
     dizhi_utils.search(list(Dizhi) + [Dizhi.辰, Dizhi.午, Dizhi.酉, Dizhi.亥], DizhiRelation.刑),
-    [set(d.keys()) for d in xing_expected]
+    [set(d.keys()) for d in expected_by_def[DizhiRules.XingDef.LOOSE]]
   )
 
-  for _ in range(500):
-    dizhis: list[Dizhi] = []
-    for _ in range(random.randint(1, 4)):
-      dizhis += random.sample(list(Dizhi), random.randint(0, len(Dizhi)))
-    result: DizhiRelationCombos = dizhi_utils.search(dizhis, DizhiRelation.刑)
-    expected_result: list[set[Dizhi]] = __find_qualified(dizhis)
-    assert _dz_equal(result, expected_result)
+  # Every definition gets the full-combo and random-subset treatment (每个定义都过一遍全组合与随机子集).
+  for xing_def in DizhiRules.XingDef:
+    xing_expected: list[dict[Dizhi, int]] = expected_by_def[xing_def]
+
+    assert _dz_equal(
+      dizhi_utils.search(list(Dizhi), DizhiRelation.刑, xing_def=xing_def),
+      __find_qualified(xing_expected, list(Dizhi)),
+    )
+
+    for _ in range(200):
+      dizhis: list[Dizhi] = []
+      for _ in range(random.randint(1, 4)):
+        dizhis += random.sample(list(Dizhi), random.randint(0, len(Dizhi)))
+      result: DizhiRelationCombos = dizhi_utils.search(dizhis, DizhiRelation.刑, xing_def=xing_def)
+      expected_result: list[set[Dizhi]] = __find_qualified(xing_expected, dizhis)
+      assert _dz_equal(result, expected_result)
+
+
+def test_search_def_type_gates() -> None:
+  # Every batch entry gates both def params at runtime (每个批量入口都查两个定义参数的类型).
+  with pytest.raises(TypeError):
+    dizhi_utils.search([Dizhi.子], DizhiRelation.暗合, anhe_def='NORMAL_EXTENDED') # type: ignore
+  with pytest.raises(TypeError):
+    dizhi_utils.search([Dizhi.子], DizhiRelation.刑, xing_def='LOOSE') # type: ignore
+  with pytest.raises(TypeError):
+    dizhi_utils.discover([Dizhi.子], anhe_def=0) # type: ignore
+  with pytest.raises(TypeError):
+    dizhi_utils.discover([Dizhi.子], xing_def=DizhiRules.AnheDef.NORMAL) # type: ignore
+  with pytest.raises(TypeError):
+    dizhi_utils.discover_mutual([Dizhi.子], [Dizhi.丑], anhe_def='NORMAL') # type: ignore
+  with pytest.raises(TypeError):
+    dizhi_utils.discover_mutual([Dizhi.子], [Dizhi.丑], xing_def=1) # type: ignore
+
+
+def test_discover_def_passthrough() -> None:
+  # The def params reach `search` through both batch entries (参数经两个批量入口透传到 search)。
+  # 寅午 forms ANHE only under EXTENDED (MANGPAI drops it); 寅巳 forms XING only under LOOSE.
+  dizhis: list[Dizhi] = [Dizhi.寅, Dizhi.午, Dizhi.巳, Dizhi.子]
+
+  default_d: DizhiRelationDiscovery = dizhi_utils.discover(dizhis)
+  mangpai_d: DizhiRelationDiscovery = dizhi_utils.discover(dizhis, anhe_def=DizhiRules.AnheDef.MANGPAI)
+  strict_d: DizhiRelationDiscovery = dizhi_utils.discover(dizhis, xing_def=DizhiRules.XingDef.STRICT)
+
+  # Pin the exact combos, not just "fewer results" (钉精确集合,不钉「变少」).
+  assert _dz_equal(default_d[DizhiRelation.暗合], [{Dizhi.寅, Dizhi.午}, {Dizhi.子, Dizhi.巳}])
+  assert DizhiRelation.暗合 not in mangpai_d
+  assert _dz_equal(default_d[DizhiRelation.刑], [{Dizhi.寅, Dizhi.巳}])
+  assert DizhiRelation.刑 not in strict_d
+
+  mutual_default: DizhiRelationDiscovery = dizhi_utils.discover_mutual([Dizhi.寅], [Dizhi.午])
+  mutual_mangpai: DizhiRelationDiscovery = dizhi_utils.discover_mutual([Dizhi.寅], [Dizhi.午], anhe_def=DizhiRules.AnheDef.MANGPAI)
+  assert _dz_equal(mutual_default[DizhiRelation.暗合], [{Dizhi.寅, Dizhi.午}])
+  assert DizhiRelation.暗合 not in mutual_mangpai
+
+  mutual_loose: DizhiRelationDiscovery = dizhi_utils.discover_mutual([Dizhi.寅], [Dizhi.巳])
+  mutual_strict: DizhiRelationDiscovery = dizhi_utils.discover_mutual([Dizhi.寅], [Dizhi.巳], xing_def=DizhiRules.XingDef.STRICT)
+  assert _dz_equal(mutual_loose[DizhiRelation.刑], [{Dizhi.寅, Dizhi.巳}])
+  assert DizhiRelation.刑 not in mutual_strict
 
 
 def test_xing_negative() -> None:


### PR DESCRIPTION
# 什么

`BaziSchool` 挂上最后两个流派看法:暗合(`anhe_def`)和刑(`xing_def`)。一张盘现在可以声明自己按哪套定义查暗合/刑,亲密关系分析( marriage/house/star 分析)在评估期读盘的声明,不再用库级硬编码默认。

```python
# 盲派口径的盘:暗合只认三对,刑要三支齐现
school = BaziSchool(anhe_def=AnheDef.MANGPAI, xing_def=XingDef.STRICT)
bazi = Bazi.create(dt, gender, BaziConfig(school=school))
```

默认盘行为零变化(多数派口径 NORMAL_EXTENDED / LOOSE 即原硬编码值)。#69 的 variants 机制面到此全部落地,issue 保持 open 作追踪。

# 为什么

暗合和刑是命理里有名流派分歧(暗合三表:通禄五对 / +寅丑 / 盲派三对;刑:丑未戌寅巳申三支齐现 vs 三取二)。机制批(PR #119/#120)立了 `BaziSchool` 档案和首批挂载(换日点、红艳查法),刻意留下这两个旋钮——它们的消费面不在排盘而在关系查法,需要 utils 三入口先参数化。本单把这条链走完。

# 怎么做

**双轨**:school 供盘级默认;`search` / `discover` / `discover_mutual` 保留关键字参数做单次覆盖(签名默认 = 多数派,同既有 `anhe()` / `xing()` 先例)。utils 不 import school,依赖单向。

**穿透**:analyzer 的地支调用收敛进三个薄包装(`_dz_search` / `_dz_discover` / `_dz_discover_mutual`)——这是该文件唯一读 school 的地方,「无裸调」由一条 AST 机械测试执行,漏传参会静默回落默认的通道就此关死。

**知识层如实化**:`XingDef` docstring 分定义层/入口层——方向(谁刑谁)只在 `xing()` 这类按序查法可观测,批量入口按多重集比对,LOOSE 在那里就等于「三取二」;`AnheDef` 注明选 NORMAL 时暗合表与通禄合表逐项相同(discovery 两键下是同一证据,不是两条)。

# 没做什么(及为什么)

- **utils 签名不砍覆盖参数**:school 是盘级默认,不是唯一真相来源——单点查询的灵活性是既有公开 API 的语义,砍了是 breaking。
- **`anhe()` / `xing()` 不动**:早已参数化,与本批同构。
- **`:284`(Transit house 补全支路)只做惰性传参**:该支路只留三组合,而 STRICT/LOOSE 之差全在二组合上(全 4 支/6 支多重集实证零差异)——传参为一致性,注释说明,不假装这里有行为差异。
- **枚举不迁移出 `DizhiRules`**:定义与表同处,school 只引用。

# 验证

- variant e2e 五盘钉精确集合(非「变少」——MANGPAI/STRICT 都是默认定义的子集,「变少」检不出错传空表):1984-06-13 戊寅日(寅午暗合,MANGPAI 无)/ 1984-07-18 癸丑日(丑未刑,STRICT 无)/ 1984-01-08 + 1991 辛未流年(流运 mutual 路径)/ 1984-02-17 辛巳日(AtBirth star 路径)/ 1984-02-07 + 1992 壬申流年(star MUTUAL 路径)。
- oracle 纪律:集成/单测 14 处地支 oracle 改从 chart 的 school 读,不假设默认(照红艳先例)。
- 机械绑定:字段↔JSON 键、字段↔类型闸、school 默认↔utils 签名默认等价——将来加第 5 个旋钮,漏一处就响。
- 检出率:五组注入全必红(包装不传参 / school 默认翻转 / mutual 不转发 / star 裸调双红)。
- 门禁全绿:coverage 100%,mypy / ruff / o_smoke 通过。

审阅:计划审双席 + R1 四席 + R2 验证,全程零结构性 P1;R1 四席独立撞中同一处文档自相矛盾(`search` 总述的 LOOSE 旧句),盲审另抓一条命理口径失实(寅午暗合「仅 EXTENDED 有」→ 实为 NORMAL 亦有、MANGPAI 无),均已修复(C3)。
